### PR TITLE
Batch SyncOp's to limit Version size.

### DIFF
--- a/taskchampion/src/server/test.rs
+++ b/taskchampion/src/server/test.rs
@@ -58,6 +58,11 @@ impl TestServer {
         let mut inner = self.0.lock().unwrap();
         inner.versions.remove(&parent_version_id);
     }
+
+    pub(crate) fn versions_len(&self) -> usize {
+        let inner = self.0.lock().unwrap();
+        inner.versions.len()
+    }
 }
 
 impl Server for TestServer {


### PR DESCRIPTION
This will effectively limit the size of http requests. Resolve https://github.com/GothenburgBitFactory/taskwarrior/issues/3331.

I hope this is what you had in mind. As always, please review with a heavy dose of skepticism.