### PR TITLE
Allow to access sync server with full URL instead of origin only

### DIFF
--- a/docs/src/http.md
+++ b/docs/src/http.md
@@ -1,7 +1,7 @@
 # HTTP Representation
 
-The transactions in the sync protocol are realized for an HTTP server at `<origin>` using the HTTP requests and responses described here.
-The `origin` *should* be an HTTPS endpoint on general principle, but nothing in the functonality or security of the protocol depends on connection encryption.
+The transactions in the sync protocol are realized for an HTTP server at `<base_url>` using the HTTP requests and responses described here.
+The `base_url` *should* be an HTTPS endpoint on general principle, but nothing in the functonality or security of the protocol depends on connection encryption.
 
 The replica identifies itself to the server using a `client_id` in the form of a UUID.
 This value is passed with every request in the `X-Client-Id` header, in its dashed-hex format.
@@ -10,7 +10,7 @@ The salt used in key derivation is the 16-byte client ID.
 
 ## AddVersion
 
-The request is a `POST` to `<origin>/v1/client/add-version/<parentVersionId>`.
+The request is a `POST` to `<base_url>/v1/client/add-version/<parentVersionId>`.
 The request body contains the history segment, optionally encoded using any encoding supported by actix-web.
 The content-type must be `application/vnd.taskchampion.history-segment`.
 
@@ -25,7 +25,7 @@ Other error responses (4xx or 5xx) may be returned and should be treated appropr
 
 ## GetChildVersion
 
-The request is a `GET` to `<origin>/v1/client/get-child-version/<parentVersionId>`.
+The request is a `GET` to `<base_url>/v1/client/get-child-version/<parentVersionId>`.
 
 The response is determined as described above.
 The _not-found_ response is 404 NOT FOUND.
@@ -44,7 +44,7 @@ The client should, optionally after consulting the user, download and apply the 
 
 ## AddSnapshot
 
-The request is a `POST` to `<origin>/v1/client/add-snapshot/<versionId>`.
+The request is a `POST` to `<base_url>/v1/client/add-snapshot/<versionId>`.
 The request body contains the snapshot data, optionally encoded using any encoding supported by actix-web.
 The content-type must be `application/vnd.taskchampion.snapshot`.
 
@@ -53,7 +53,7 @@ The server response should be 200 OK on success.
 
 ## GetSnapshot
 
-The request is a `GET` to `<origin>/v1/client/snapshot`.
+The request is a `GET` to `<base_url>/v1/client/snapshot`.
 
 The response is a 200 OK.
 The snapshot is returned in the response body, with content-type `application/vnd.taskchampion.snapshot`.

--- a/lib/src/server.rs
+++ b/lib/src/server.rs
@@ -115,7 +115,7 @@ pub unsafe extern "C" fn tc_server_new_local(
 /// ```
 #[no_mangle]
 pub unsafe extern "C" fn tc_server_new_sync(
-    origin: TCString,
+    url: TCString,
     client_id: TCUuid,
     encryption_secret: TCString,
     error_out: *mut TCString,
@@ -123,9 +123,9 @@ pub unsafe extern "C" fn tc_server_new_sync(
     wrap(
         || {
             // SAFETY:
-            //  - origin is valid (promised by caller)
-            //  - origin ownership is transferred to this function
-            let origin = unsafe { TCString::val_from_arg(origin) }.into_string()?;
+            //  - url is valid (promised by caller)
+            //  - url ownership is transferred to this function
+            let url = unsafe { TCString::val_from_arg(url) }.into_string()?;
 
             // SAFETY:
             //  - client_id is a valid Uuid (any 8-byte sequence counts)
@@ -139,7 +139,7 @@ pub unsafe extern "C" fn tc_server_new_sync(
                 .to_vec();
 
             let server_config = ServerConfig::Remote {
-                origin,
+                url,
                 client_id,
                 encryption_secret,
             };

--- a/taskchampion/src/server/config.rs
+++ b/taskchampion/src/server/config.rs
@@ -21,8 +21,8 @@ pub enum ServerConfig {
     /// A remote taskchampion-sync-server instance
     #[cfg(feature = "server-sync")]
     Remote {
-        /// Sync server "origin"; a URL with schema and hostname but no path or trailing `/`
-        origin: String,
+        /// The base URL of the Sync server
+        url: String,
 
         /// Client ID to identify and authenticate this replica to the server
         client_id: Uuid,
@@ -56,10 +56,10 @@ impl ServerConfig {
             ServerConfig::Local { server_dir } => Box::new(LocalServer::new(server_dir)?),
             #[cfg(feature = "server-sync")]
             ServerConfig::Remote {
-                origin,
+                url,
                 client_id,
                 encryption_secret,
-            } => Box::new(SyncServer::new(origin, client_id, encryption_secret)?),
+            } => Box::new(SyncServer::new(url, client_id, encryption_secret)?),
             #[cfg(feature = "server-gcp")]
             ServerConfig::Gcp {
                 bucket,


### PR DESCRIPTION
resolves #367.

I renamed "origin" to "url" in `ServerConfig` and the C-bindings. For the `SyncServer`, I decided to use "base_url" instead to make clear that it is used to build the final endpoint URLs by appending to it.

I changed the type in `SyncServer` to be `Url` and added the new method `construct_endpoint_url` to build the final URLs. 