### PR TITLE
Fix credential path

### DIFF
--- a/taskchampion/src/server/cloud/gcp.rs
+++ b/taskchampion/src/server/cloud/gcp.rs
@@ -180,7 +180,7 @@ impl<'a> ObjectIterator<'a> {
     fn fetch_batch(&mut self) -> Result<()> {
         let mut page_token = None;
         if let Some(ref resp) = self.last_response {
-            page_token.clone_from(&resp.next_page_token.clone());
+            page_token.clone_from(&resp.next_page_token);
         }
         self.last_response = Some(self.service.rt.block_on(self.service.client.list_objects(
             &objects::list::ListObjectsRequest {

--- a/taskchampion/src/server/cloud/gcp.rs
+++ b/taskchampion/src/server/cloud/gcp.rs
@@ -29,12 +29,11 @@ impl GcpService {
     pub(in crate::server) fn new(bucket: String, credential_path: Option<String>) -> Result<Self> {
         let rt = Runtime::new()?;
 
-        let config: ClientConfig = if credential_path.is_none() {
-            rt.block_on(ClientConfig::default().with_auth())?
-        } else {
-            let credentialpathstring = credential_path.unwrap();
-            let credentials = rt.block_on(CredentialsFile::new_from_file(credentialpathstring))?;
+        let config: ClientConfig = if let Some(credentials) = credential_path {
+            let credentials = rt.block_on(CredentialsFile::new_from_file(credentials))?;
             rt.block_on(ClientConfig::default().with_credentials(credentials))?
+        } else {
+            rt.block_on(ClientConfig::default().with_auth())?
         };
 
         Ok(Self {

--- a/taskchampion/src/server/cloud/gcp.rs
+++ b/taskchampion/src/server/cloud/gcp.rs
@@ -29,10 +29,10 @@ impl GcpService {
     pub(in crate::server) fn new(bucket: String, credential_path: Option<String>) -> Result<Self> {
         let rt = Runtime::new()?;
 
-        let credentialpathstring = credential_path.clone().expect("gcp credential_path not set");
         let config: ClientConfig = if credential_path.is_none() {
             rt.block_on(ClientConfig::default().with_auth())?
         } else {
+            let credentialpathstring = credential_path.expect("gcp credential_path not set");
             let credentials = rt.block_on(CredentialsFile::new_from_file(credentialpathstring))?;
             rt.block_on(ClientConfig::default().with_credentials(credentials))?
         };

--- a/taskchampion/src/server/cloud/gcp.rs
+++ b/taskchampion/src/server/cloud/gcp.rs
@@ -32,7 +32,7 @@ impl GcpService {
         let config: ClientConfig = if credential_path.is_none() {
             rt.block_on(ClientConfig::default().with_auth())?
         } else {
-            let credentialpathstring = credential_path.expect("gcp credential_path not set");
+            let credentialpathstring = credential_path.unwrap();
             let credentials = rt.block_on(CredentialsFile::new_from_file(credentialpathstring))?;
             rt.block_on(ClientConfig::default().with_credentials(credentials))?
         };
@@ -181,7 +181,7 @@ impl<'a> ObjectIterator<'a> {
     fn fetch_batch(&mut self) -> Result<()> {
         let mut page_token = None;
         if let Some(ref resp) = self.last_response {
-            page_token = resp.next_page_token.clone();
+            page_token.clone_from(&resp.next_page_token.clone());
         }
         self.last_response = Some(self.service.rt.block_on(self.service.client.list_objects(
             &objects::list::ListObjectsRequest {

--- a/taskchampion/src/server/cloud/gcp.rs
+++ b/taskchampion/src/server/cloud/gcp.rs
@@ -29,8 +29,8 @@ impl GcpService {
     pub(in crate::server) fn new(bucket: String, credential_path: Option<String>) -> Result<Self> {
         let rt = Runtime::new()?;
 
-        let credentialpathstring = credential_path.clone().unwrap();
-        let config: ClientConfig = if credential_path.unwrap() == "" {
+        let credentialpathstring = credential_path.clone().expect("gcp credential_path not set");
+        let config: ClientConfig = if credential_path.is_none() {
             rt.block_on(ClientConfig::default().with_auth())?
         } else {
             let credentials = rt.block_on(CredentialsFile::new_from_file(credentialpathstring))?;

--- a/taskchampion/src/server/sync/mod.rs
+++ b/taskchampion/src/server/sync/mod.rs
@@ -159,9 +159,7 @@ impl Server for SyncServer {
                     history_segment,
                 })
             }
-            Err(ureq::Error::Status(404, _)) => {
-                Ok(GetVersionResult::NoSuchVersion)
-            }
+            Err(ureq::Error::Status(404, _)) => Ok(GetVersionResult::NoSuchVersion),
             Err(err) => Err(err.into()),
         }
     }

--- a/taskchampion/src/server/sync/mod.rs
+++ b/taskchampion/src/server/sync/mod.rs
@@ -125,7 +125,7 @@ impl Server for SyncServer {
                     get_snapshot_urgency(&resp),
                 ))
             }
-            Err(ureq::Error::Status(status, resp)) if status == 409 => {
+            Err(ureq::Error::Status(409, resp)) => {
                 let parent_version_id = get_uuid_header(&resp, "X-Parent-Version-Id")?;
                 Ok((
                     AddVersionResult::ExpectedParentVersion(parent_version_id),
@@ -159,7 +159,7 @@ impl Server for SyncServer {
                     history_segment,
                 })
             }
-            Err(ureq::Error::Status(status, _)) if status == 404 => {
+            Err(ureq::Error::Status(404, _)) => {
                 Ok(GetVersionResult::NoSuchVersion)
             }
             Err(err) => Err(err.into()),
@@ -197,7 +197,7 @@ impl Server for SyncServer {
                 let snapshot = self.cryptor.unseal(sealed)?.payload;
                 Ok(Some((version_id, snapshot)))
             }
-            Err(ureq::Error::Status(status, _)) if status == 404 => Ok(None),
+            Err(ureq::Error::Status(404, _)) => Ok(None),
             Err(err) => Err(err.into()),
         }
     }


### PR DESCRIPTION
A few things fixed here:
* `credential_path.unwrap() == ""` doesn't work - `unwrap()` forcibly crashes the program if the `Option` is `None`, therefore it can't be compared to a string. `is_none()` is what we want here.
* the `credential_path.is_none()` was impossible to evaluate as true anyway, because if the credential path wasn't set, the `unwrap()` on line 32 would have crashed the program before line 33 got to resolve.
* moving the setting of `credentialpathstring` after the `is_none()` check (which doesn't take ownership of the variable) both fixes that and removes the need for the `clone()`.

This should mean that if the default credential path isn't set, `ClientConfig::default().with_auth()` which was unreachable before, should successfully run.