### PR TITLE
Include generate_headers in release builds, too

### DIFF
--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -165,7 +165,6 @@ pub(crate) mod types {
     pub(crate) use crate::workingset::TCWorkingSet;
 }
 
-#[cfg(debug_assertions)]
 /// Generate the taskchapion.h header
 pub fn generate_header() -> String {
     ffizz_header::generate()


### PR DESCRIPTION
This fixes #400 by always including this symbol. It means that release builds include the full text of the header file, but for the moment that's a small price to pay.