### PR TITLE
Include HTTP status text in error messages from ureq

### DIFF
--- a/taskchampion/src/errors.rs
+++ b/taskchampion/src/errors.rs
@@ -49,7 +49,12 @@ impl From<ureq::Error> for Error {
     fn from(ureq_err: ureq::Error) -> Self {
         match ureq_err {
             ureq::Error::Status(status, response) => {
-                let msg = format!("{} responded with {} {}", response.get_url(), status, response.status_text());
+                let msg = format!(
+                    "{} responded with {} {}",
+                    response.get_url(),
+                    status,
+                    response.status_text()
+                );
                 Self::Server(msg)
             }
             ureq::Error::Transport(_) => Self::Server(ureq_err.to_string()),
@@ -66,7 +71,13 @@ mod test {
     #[cfg(feature = "server-sync")]
     #[test]
     fn ureq_error_status() {
-        let err = ureq::Error::Status(418, ureq::Response::new(418, "I Am a Teapot", "uhoh").unwrap());
-        assert_eq!(Error::from(err).to_string(), "Server Error: https://example.com/ responded with 418 I Am a Teapot");
+        let err = ureq::Error::Status(
+            418,
+            ureq::Response::new(418, "I Am a Teapot", "uhoh").unwrap(),
+        );
+        assert_eq!(
+            Error::from(err).to_string(),
+            "Server Error: https://example.com/ responded with 418 I Am a Teapot"
+        );
     }
 }

--- a/taskchampion/src/errors.rs
+++ b/taskchampion/src/errors.rs
@@ -63,6 +63,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 mod test {
     use super::*;
 
+    #[cfg(feature = "server-sync")]
     #[test]
     fn ureq_error_status() {
         let err = ureq::Error::Status(418, ureq::Response::new(418, "I Am a Teapot", "uhoh").unwrap());

--- a/taskchampion/src/errors.rs
+++ b/taskchampion/src/errors.rs
@@ -50,7 +50,7 @@ impl From<ureq::Error> for Error {
         match ureq_err {
             ureq::Error::Status(status, response) => {
                 let msg = format!("{} responded with {} {}", response.get_url(), status, response.status_text());
-                Self::Server(msg.into())
+                Self::Server(msg)
             }
             ureq::Error::Transport(_) => Self::Server(ureq_err.to_string()),
         }


### PR DESCRIPTION
The default display of a ureq::Error (which ends up being used by anyhow::Error) just includes the HTTP status, not the status text. So, this overrides the conversion to include the status text as well.

This also presents errors from ureq as Error::Server, rather than Error::Other.

This addresses GothenburgBitFactory/taskwarrior#3332.