### PR TITLE
Use SQLite in WAL mode, with IMMEDIATE transactions

### DIFF
--- a/taskchampion/src/storage/sqlite.rs
+++ b/taskchampion/src/storage/sqlite.rs
@@ -837,7 +837,7 @@ mod test {
                 thread::sleep(Duration::from_millis(100));
                 txn.commit().unwrap();
             });
-            // Second thread begins a transaction, waits 50ms, and begins a transaction. This
+            // Second thread waits 50ms, and begins a transaction. This
             // should wait for the first to complete, but the regression would be a SQLITE_BUSY
             // failure.
             scope.spawn(|| {


### PR DESCRIPTION
WAL mode is generally better, and allows concurrent reads to happen concurrently with other reads and writes. It does not allow writes concurrently with writes, though, failing with SQLITE_BUSY if that occurs.

SQLite's `busy_timeout` allows retrying on SQLITE_BUSY, but that does not work if a read-only transaction is upgraded to a write transaction, which is what `TransactionBehavior::Deferred` (a.k.a. `BEGIN DEFERRED`) does. `TransactionBehavior::Immediate` always begins a write transaction immediately, fails with SQLITE_BUSY if that is not allowed, and uses the `busy_timeout` logic to try to wait for the running transaction to finish.

This includes a unit test, but as the issue is a race condition, the test does not always fail without the fix. However, it reliably passes with the fix, which is really the important bit.

This fixes GothenburgBitFactory/taskwarrior#3325.