### PR TITLE
Run clippy with --no-deps

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features
+          args: --all-features --no-deps
           name: "Clippy Results"
 
   mdbook:


### PR DESCRIPTION
There's no sense checking the dependencies for lint errors!