### PR TITLE
Add `BasicTask` and link it to Replica.

### DIFF
--- a/taskchampion/src/lib.rs
+++ b/taskchampion/src/lib.rs
@@ -66,11 +66,11 @@ mod workingset;
 
 pub use depmap::DependencyMap;
 pub use errors::Error;
-pub use operation::Operation;
+pub use operation::{Operation, Operations};
 pub use replica::Replica;
 pub use server::{Server, ServerConfig};
 pub use storage::StorageConfig;
-pub use task::{utc_timestamp, Annotation, Status, Tag, Task, TaskMut};
+pub use task::{utc_timestamp, Annotation, BasicTask, Status, Tag, Task, TaskMut};
 pub use workingset::WorkingSet;
 
 /// Re-exported type from the `uuid` crate, for ease of compatibility for consumers of this crate.

--- a/taskchampion/src/task/basictask.rs
+++ b/taskchampion/src/task/basictask.rs
@@ -1,0 +1,251 @@
+use crate::{storage::TaskMap, Operation, Operations};
+use chrono::Utc;
+use uuid::Uuid;
+
+/// A task.
+///
+/// This type presents a low-level interface consisting only of a key/value map. Interpretation of
+/// fields is up to the user, and modifications both modify the [`BasicTask`] and create one or
+/// more [`Operation`](crate::Operation) values that can later be committed to the replica.
+///
+/// This interface is intended for sophisticated applications like Taskwarrior which give meaning
+/// to key and values themselves. Use [`Task`](crate::Task) for a higher-level interface with
+/// methods to update status, set tags, and so on.
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct BasicTask {
+    uuid: Uuid,
+    taskmap: TaskMap,
+}
+
+impl BasicTask {
+    /// Constructor for a BasicTask representing an existing task.
+    pub(crate) fn new(uuid: Uuid, taskmap: TaskMap) -> Self {
+        Self { uuid, taskmap }
+    }
+
+    /// Create a new, empty task with the given UUID.
+    pub fn create(uuid: Uuid, operations: &mut Operations) -> Self {
+        operations.add(Operation::Create { uuid });
+        Self {
+            uuid,
+            taskmap: TaskMap::new(),
+        }
+    }
+
+    /// Get this task's UUID.
+    pub fn uuid(&self) -> Uuid {
+        self.uuid
+    }
+
+    /// Get a value on this task.
+    pub fn get(&self, property: impl AsRef<str>) -> Option<&str> {
+        self.taskmap.get(property.as_ref()).map(|v| v.as_str())
+    }
+
+    /// Check if the given property is set.
+    pub fn has(&self, property: impl AsRef<str>) -> bool {
+        self.taskmap.contains_key(property.as_ref())
+    }
+
+    /// Enumerate all properties on this task, in arbitrary order.
+    pub fn properties(&self) -> impl Iterator<Item = &String> {
+        self.taskmap.keys()
+    }
+
+    /// Enumerate all properties and their values on this task, in arbitrary order.
+    pub fn iter(&self) -> impl Iterator<Item = (&String, &String)> {
+        self.taskmap.iter()
+    }
+
+    /// Set or remove a value on this task, adding an Update operation to the
+    /// set of operations.
+    ///
+    /// Setting a value to `None` removes that value from the task.
+    pub fn update(
+        &mut self,
+        property: impl Into<String>,
+        value: Option<String>,
+        operations: &mut Operations,
+    ) {
+        let property = property.into();
+        let old_value = self.taskmap.get(&property).cloned();
+        if let Some(value) = &value {
+            self.taskmap.insert(property.clone(), value.clone());
+        } else {
+            self.taskmap.remove(&property);
+        }
+        operations.add(Operation::Update {
+            uuid: self.uuid,
+            property,
+            old_value,
+            value,
+            timestamp: Utc::now(),
+        });
+    }
+
+    /// Delete this task.
+    ///
+    /// Note that this is different from setting status to [`Deleted`](crate::Status::Deleted):
+    /// the resulting operation removes the task from the database.
+    ///
+    /// Deletion may interact poorly with modifications to the same task on other replicas. For
+    /// example, if a task is deleted on replica 1 and its description modified on replica 2, then
+    /// after both replicas have fully synced, the resulting task will only have a `description`
+    /// property.
+    pub fn delete(self, operations: &mut Operations) {
+        operations.add(Operation::Delete {
+            uuid: self.uuid,
+            old_task: self.taskmap,
+        });
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    const TEST_UUID: Uuid = Uuid::from_u128(1234);
+
+    fn make_ops(ops: &[Operation]) -> Operations {
+        let mut res = Operations::new();
+        for op in ops {
+            res.add(op.clone());
+        }
+        res
+    }
+
+    #[test]
+    fn create() {
+        let mut ops = Operations::new();
+        let t = BasicTask::create(TEST_UUID, &mut ops);
+        assert_eq!(t.uuid, TEST_UUID);
+        assert_eq!(t.uuid(), TEST_UUID);
+        assert_eq!(t.taskmap, TaskMap::new());
+        assert_eq!(ops, make_ops(&[Operation::Create { uuid: TEST_UUID }]));
+    }
+
+    #[test]
+    fn uuid() {
+        let t = BasicTask::new(TEST_UUID, TaskMap::new());
+        assert_eq!(t.uuid(), TEST_UUID);
+    }
+
+    #[test]
+    fn get() {
+        let t = BasicTask::new(TEST_UUID, [("prop".to_string(), "val".to_string())].into());
+        assert_eq!(t.get("prop"), Some("val"));
+        assert_eq!(t.get("nosuch"), None)
+    }
+
+    #[test]
+    fn has() {
+        let t = BasicTask::new(TEST_UUID, [("prop".to_string(), "val".to_string())].into());
+        assert!(t.has("prop"));
+        assert!(!t.has("nosuch"));
+    }
+
+    #[test]
+    fn properties() {
+        let t = BasicTask::new(
+            TEST_UUID,
+            [
+                ("prop1".to_string(), "val".to_string()),
+                ("prop2".to_string(), "val".to_string()),
+            ]
+            .into(),
+        );
+        let mut props: Vec<_> = t.properties().collect();
+        props.sort();
+        assert_eq!(props, vec!["prop1", "prop2"]);
+    }
+
+    #[test]
+    fn iter() {
+        let t = BasicTask::new(
+            TEST_UUID,
+            [
+                ("prop1".to_string(), "val1".to_string()),
+                ("prop2".to_string(), "val2".to_string()),
+            ]
+            .into(),
+        );
+        let mut props: Vec<_> = t.iter().map(|(p, v)| (p.as_str(), v.as_str())).collect();
+        props.sort();
+        assert_eq!(props, vec![("prop1", "val1"), ("prop2", "val2")]);
+    }
+
+    #[test]
+    fn update_new_prop() {
+        let mut ops = Operations::new();
+        let mut t = BasicTask::new(TEST_UUID, TaskMap::new());
+        t.update("prop1", Some("val1".into()), &mut ops);
+        let now = Utc::now();
+        ops.set_all_timestamps(now);
+        assert_eq!(
+            ops,
+            make_ops(&[Operation::Update {
+                uuid: TEST_UUID,
+                property: "prop1".into(),
+                old_value: None,
+                value: Some("val1".into()),
+                timestamp: now,
+            }])
+        );
+        assert_eq!(t.get("prop1"), Some("val1"));
+    }
+
+    #[test]
+    fn update_existing_prop() {
+        let mut ops = Operations::new();
+        let mut t = BasicTask::new(TEST_UUID, [("prop1".to_string(), "val".to_string())].into());
+        t.update("prop1", Some("new".into()), &mut ops);
+        let now = Utc::now();
+        ops.set_all_timestamps(now);
+        assert_eq!(
+            ops,
+            make_ops(&[Operation::Update {
+                uuid: TEST_UUID,
+                property: "prop1".into(),
+                old_value: Some("val".into()),
+                value: Some("new".into()),
+                timestamp: now,
+            }])
+        );
+        assert_eq!(t.get("prop1"), Some("new"));
+    }
+
+    #[test]
+    fn update_remove_prop() {
+        let mut ops = Operations::new();
+        let mut t = BasicTask::new(TEST_UUID, [("prop1".to_string(), "val".to_string())].into());
+        t.update("prop1", None, &mut ops);
+        let now = Utc::now();
+        ops.set_all_timestamps(now);
+        assert_eq!(
+            ops,
+            make_ops(&[Operation::Update {
+                uuid: TEST_UUID,
+                property: "prop1".into(),
+                old_value: Some("val".into()),
+                value: None,
+                timestamp: now,
+            }])
+        );
+        assert_eq!(t.get("prop1"), None);
+    }
+
+    #[test]
+    fn delete() {
+        let mut ops = Operations::new();
+        let t = BasicTask::new(TEST_UUID, [("prop1".to_string(), "val".to_string())].into());
+        t.delete(&mut ops);
+        assert_eq!(
+            ops,
+            make_ops(&[Operation::Delete {
+                uuid: TEST_UUID,
+                old_task: [("prop1".to_string(), "val".to_string())].into(),
+            }])
+        );
+    }
+}

--- a/taskchampion/src/task/mod.rs
+++ b/taskchampion/src/task/mod.rs
@@ -1,11 +1,13 @@
 #![allow(clippy::module_inception)]
 mod annotation;
+mod basictask;
 mod status;
 mod tag;
 mod task;
 mod time;
 
 pub use annotation::Annotation;
+pub use basictask::BasicTask;
 pub use status::Status;
 pub use tag::Tag;
 pub use task::{Task, TaskMut};


### PR DESCRIPTION
This adds a new, lower-level task API, without changing the existing `Task` and `TaskMut` types.

For the moment, I want to stick to non-breaking changes, and that precludes using the name `Task` for this type. We can consider renaming this later (rust-analyzer makes it really easy!) before a release.

Another step in #372.