### PR TITLE
Support committing `Operations`

### DIFF
--- a/taskchampion/src/replica.rs
+++ b/taskchampion/src/replica.rs
@@ -1,6 +1,6 @@
 use crate::depmap::DependencyMap;
 use crate::errors::Result;
-use crate::operation::{Operations, Operation};
+use crate::operation::{Operation, Operations};
 use crate::server::{Server, SyncOp};
 use crate::storage::{Storage, TaskMap};
 use crate::task::{Status, Task};

--- a/taskchampion/src/taskdb/mod.rs
+++ b/taskchampion/src/taskdb/mod.rs
@@ -1,7 +1,10 @@
+use std::collections::HashSet;
+
 use crate::errors::Result;
 use crate::operation::Operation;
 use crate::server::{Server, SyncOp};
 use crate::storage::{Storage, TaskMap};
+use crate::Operations;
 use uuid::Uuid;
 
 mod apply;
@@ -29,6 +32,54 @@ impl TaskDb {
         use crate::storage::InMemoryStorage;
 
         TaskDb::new(Box::new(InMemoryStorage::new()))
+    }
+
+    /// Apply `operations` to the dataabase, in a single transaction.
+    ///
+    /// The resulting operations will be appended to the list of local operations, and the
+    /// set of tasks will be updated accordingly.
+    ///
+    /// Any operations for which `add_to_working_set` returns true will cause the relevant
+    /// task to be added to the working set.
+    pub(crate) fn commit_operations<F>(
+        &mut self,
+        operations: Operations,
+        add_to_working_set: F,
+    ) -> Result<()>
+    where
+        F: Fn(&Operation) -> bool,
+    {
+        let mut txn = self.storage.txn()?;
+        apply::apply_operations(txn.as_mut(), &operations)?;
+
+        // Calculate the task(s) to add to the working set.
+        let mut to_add = Vec::new();
+        for operation in &operations {
+            if add_to_working_set(operation) {
+                if let Some(uuid) = match operation {
+                    Operation::Create { uuid } => Some(*uuid),
+                    Operation::Update { uuid, .. } => Some(*uuid),
+                    Operation::Delete { uuid, .. } => Some(*uuid),
+                    _ => None,
+                } {
+                    to_add.push(uuid);
+                }
+            }
+        }
+        let mut in_working_set: HashSet<Uuid> =
+            txn.get_working_set()?.iter().filter_map(|u| *u).collect();
+        for uuid in to_add {
+            if !in_working_set.contains(&uuid) {
+                txn.add_to_working_set(uuid)?;
+                in_working_set.insert(uuid);
+            }
+        }
+
+        for operation in operations {
+            txn.add_operation(operation)?;
+        }
+
+        txn.commit()
     }
 
     /// Apply an operation to the TaskDb.  This will update the set of tasks and add a Operation to
@@ -190,6 +241,87 @@ mod tests {
     use pretty_assertions::assert_eq;
     use proptest::prelude::*;
     use uuid::Uuid;
+
+    #[test]
+    fn commit_operations() -> Result<()> {
+        let mut db = TaskDb::new_inmemory();
+        let uuid = Uuid::new_v4();
+        let now = Utc::now();
+        let mut ops = Operations::new();
+        ops.add(Operation::Create { uuid });
+        ops.add(Operation::Update {
+            uuid,
+            property: String::from("title"),
+            value: Some("my task".into()),
+            timestamp: now,
+            old_value: Some("old".into()),
+        });
+
+        db.commit_operations(ops, |_| false)?;
+
+        assert_eq!(
+            db.sorted_tasks(),
+            vec![(uuid, vec![("title".into(), "my task".into())])]
+        );
+        assert_eq!(
+            db.operations(),
+            vec![
+                Operation::Create { uuid },
+                Operation::Update {
+                    uuid,
+                    property: String::from("title"),
+                    value: Some("my task".into()),
+                    timestamp: now,
+                    old_value: Some("old".into()),
+                },
+            ]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn commit_operations_update_working_set() -> Result<()> {
+        let mut db = TaskDb::new_inmemory();
+        let mut uuids = [Uuid::new_v4(), Uuid::new_v4(), Uuid::new_v4()];
+        uuids.sort();
+        let [uuid1, uuid2, uuid3] = uuids;
+
+        // uuid1 already exists in the working set.
+        db.add_to_working_set(uuid1)?;
+
+        let mut ops = Operations::new();
+        ops.add(Operation::Create { uuid: uuid1 });
+        ops.add(Operation::Create { uuid: uuid2 });
+        ops.add(Operation::Create { uuid: uuid3 });
+        ops.add(Operation::Create { uuid: uuid2 });
+        ops.add(Operation::Create { uuid: uuid3 });
+
+        // return true for updates to uuid1 or uuid2.
+        let add_to_working_set = |op: &Operation| match op {
+            Operation::Create { uuid } => *uuid == uuid1 || *uuid == uuid2,
+            _ => false,
+        };
+        db.commit_operations(ops, add_to_working_set)?;
+
+        assert_eq!(
+            db.sorted_tasks(),
+            vec![(uuid1, vec![]), (uuid2, vec![]), (uuid3, vec![]),]
+        );
+        assert_eq!(
+            db.operations(),
+            vec![
+                Operation::Create { uuid: uuid1 },
+                Operation::Create { uuid: uuid2 },
+                Operation::Create { uuid: uuid3 },
+                Operation::Create { uuid: uuid2 },
+                Operation::Create { uuid: uuid3 },
+            ]
+        );
+
+        // uuid2 was added to the working set, once, and uuid3 was not.
+        assert_eq!(db.working_set()?, vec![None, Some(uuid1), Some(uuid2)],);
+        Ok(())
+    }
 
     #[test]
     fn test_apply() {


### PR DESCRIPTION
A full set of Operations can be committed in one transaction, complete with updates to the task properties and the working set.

The next in #372. This has a merge conflict with #424 in the `use` declarations in `replica.rs` but it is trivially resolved.