### PR TITLE
Make clippy fail on warnings

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features --no-deps
+          args: --all-features --no-deps -- -D warnings
           name: "Clippy Results"
 
   mdbook:

--- a/taskchampion/src/replica.rs
+++ b/taskchampion/src/replica.rs
@@ -343,8 +343,6 @@ impl Replica {
         Ok(())
     }
 
-    fn unused() { todo!() }
-
     /// Add an UndoPoint, if one has not already been added by this Replica.  This occurs
     /// automatically when a change is made.  The `force` flag allows forcing a new UndoPoint
     /// even if one has already been created by this Replica, and may be useful when a Replica

--- a/taskchampion/src/replica.rs
+++ b/taskchampion/src/replica.rs
@@ -343,6 +343,8 @@ impl Replica {
         Ok(())
     }
 
+    fn unused() { todo!() }
+
     /// Add an UndoPoint, if one has not already been added by this Replica.  This occurs
     /// automatically when a change is made.  The `force` flag allows forcing a new UndoPoint
     /// even if one has already been created by this Replica, and may be useful when a Replica


### PR DESCRIPTION
As @ryneeverett noted on #428, as it stands clippy warnings aren't shown anywhere. This should "D"eny them. I've temporarily added an unused method to generate a warning.