### PR TITLE
Prefer `Operation` instead of `SyncOp` in tests

### DIFF
--- a/taskchampion/src/taskdb/undo.rs
+++ b/taskchampion/src/taskdb/undo.rs
@@ -106,7 +106,8 @@ pub fn commit_undo_ops(txn: &mut dyn StorageTxn, mut undo_ops: Vec<Operation>) -
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{storage::taskmap_with, taskdb::TaskDb, Operations};
+    use crate::{storage::taskmap_with, taskdb::TaskDb};
+    use crate::{Operation, Operations};
     use chrono::Utc;
     use pretty_assertions::assert_eq;
     use uuid::Uuid;

--- a/taskchampion/src/taskdb/working_set.rs
+++ b/taskchampion/src/taskdb/working_set.rs
@@ -64,8 +64,8 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::server::SyncOp;
     use crate::taskdb::TaskDb;
+    use crate::{Operation, Operations};
     use chrono::Utc;
     use uuid::Uuid;
 
@@ -94,17 +94,20 @@ mod test {
         println!("uuids[4]: {:?} - pending, in working set", uuids[4]);
 
         // add everything to the TaskDb
+        let mut ops = Operations::new();
         for uuid in &uuids {
-            db.apply(SyncOp::Create { uuid: *uuid })?;
+            ops.add(Operation::Create { uuid: *uuid });
         }
         for i in &[0usize, 1, 4] {
-            db.apply(SyncOp::Update {
+            ops.add(Operation::Update {
                 uuid: uuids[*i],
                 property: String::from("status"),
                 value: Some("pending".into()),
+                old_value: None,
                 timestamp: Utc::now(),
-            })?;
+            });
         }
+        db.commit_operations(ops, |_| false)?;
 
         // set the existing working_set as we want it
         {

--- a/taskchampion/tests/syncing-proptest.rs
+++ b/taskchampion/tests/syncing-proptest.rs
@@ -1,0 +1,90 @@
+use pretty_assertions::assert_eq;
+use proptest::prelude::*;
+use taskchampion::{Operations, Replica, ServerConfig, StorageConfig, TaskData, Uuid};
+use tempfile::TempDir;
+
+#[derive(Debug, Clone)]
+enum Action {
+    Create,
+    Update(String, String),
+    Delete,
+    Sync,
+}
+
+fn action() -> impl Strategy<Value = Action> {
+    prop_oneof![
+        Just(Action::Create),
+        ("(description|project|due)", "(a|b|c)").prop_map(|(p, v)| Action::Update(p, v)),
+        Just(Action::Delete),
+        Just(Action::Sync),
+    ]
+}
+
+fn actions() -> impl Strategy<Value = Vec<(Action, u8)>> {
+    proptest::collection::vec((action(), (0..3u8)), 0..100)
+}
+
+proptest! {
+#[test]
+/// Check that various sequences of operations on mulitple db's do not get the db's into an
+/// incompatible state.  The main concern here is that there might be a sequence of operations
+/// that results in a task being in different states in different replicas. Different tasks
+/// cannot interfere with one another, so this focuses on a single task.
+fn multi_replica_sync(action_sequence in actions()) {
+    let tmp_dir = TempDir::new().expect("TempDir failed");
+    let uuid = Uuid::parse_str("83a2f9ef-f455-4195-b92e-a54c161eebfc").unwrap();
+    let server_config = ServerConfig::Local {
+        server_dir: tmp_dir.path().to_path_buf(),
+    };
+    let mut server = server_config.into_server()?;
+    let mut replicas = [
+        Replica::new(StorageConfig::InMemory.into_storage().unwrap()),
+        Replica::new(StorageConfig::InMemory.into_storage().unwrap()),
+        Replica::new(StorageConfig::InMemory.into_storage().unwrap()),
+    ];
+
+    for (action, rep) in action_sequence {
+        println!("{:?} on rep {}", action, rep);
+
+        let rep = &mut replicas[rep as usize];
+        match action {
+            Action::Create => {
+                if rep.get_task_data(uuid).unwrap().is_none() {
+                    let mut ops = Operations::new();
+                    TaskData::create(uuid, &mut ops);
+                    rep.commit_operations(ops).unwrap();
+                }
+            },
+            Action::Update(p, v) => {
+                if let Some(mut t) = rep.get_task_data(uuid).unwrap() {
+                    let mut ops = Operations::new();
+                    t.update(p, Some(v), &mut ops);
+                    rep.commit_operations(ops).unwrap();
+                }
+            },
+            Action::Delete => {
+                if let Some(t) = rep.get_task_data(uuid).unwrap() {
+                    let mut ops = Operations::new();
+                    t.delete(&mut ops);
+                    rep.commit_operations(ops).unwrap();
+                }
+            },
+            Action::Sync => rep.sync(&mut server, false).unwrap(),
+        }
+    }
+
+    // Sync all of the replicas, twice, to flush out any un-synced changes.
+    for rep in &mut replicas {
+        rep.sync(&mut server, false).unwrap()
+    }
+    for rep in &mut replicas {
+        rep.sync(&mut server, false).unwrap()
+    }
+
+    let t0 = replicas[0].get_task_data(uuid).unwrap();
+    let t1 = replicas[1].get_task_data(uuid).unwrap();
+    let t2 = replicas[2].get_task_data(uuid).unwrap();
+    assert_eq!(t0, t1);
+    assert_eq!(t1, t2);
+}
+}


### PR DESCRIPTION
This is a test-only change: all modified code is `#[cfg(test)]`

Lots of tests used `SyncOp`, including some proptests. One of those is moved out to `tests/syncing-proptest.rs` and updated to use Replicas intead of TaskDb's. `op.rs` remains in terms of `SyncOp`, since it defines that type, but converts to `Operation` for tests.

With their uses in tests removed, two `apply_..` methods can finally be deleted.

This is the last "boring" change in #372. The next two will be breaking changes and have some open questions!