### PR TITLE
[BREAKING] Unify Task and TaskMut

### DIFF
--- a/taskchampion/src/lib.rs
+++ b/taskchampion/src/lib.rs
@@ -70,7 +70,7 @@ pub use operation::{Operation, Operations};
 pub use replica::Replica;
 pub use server::{Server, ServerConfig};
 pub use storage::StorageConfig;
-pub use task::{utc_timestamp, Annotation, Status, Tag, Task, TaskData, TaskMut};
+pub use task::{utc_timestamp, Annotation, Status, Tag, Task, TaskData};
 pub use workingset::WorkingSet;
 
 /// Re-exported type from the `uuid` crate, for ease of compatibility for consumers of this crate.

--- a/taskchampion/src/operation.rs
+++ b/taskchampion/src/operation.rs
@@ -71,6 +71,11 @@ impl Operations {
         self.0.push(op);
     }
 
+    /// Determine if this set of operations is empty.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
     /// For tests, it's useful to set the timestamps of all updates to the same value.
     #[cfg(test)]
     pub fn set_all_timestamps(&mut self, set_to: DateTime<Utc>) {

--- a/taskchampion/src/replica.rs
+++ b/taskchampion/src/replica.rs
@@ -261,7 +261,7 @@ impl Replica {
     /// property.
     #[deprecated(since = "0.7.0", note = "please use TaskData::delete")]
     pub fn delete_task(&mut self, uuid: Uuid) -> Result<()> {
-        let Some(task) = self.get_task_data(uuid)? else {
+        let Some(mut task) = self.get_task_data(uuid)? else {
             return Err(Error::Database(format!("Task {} does not exist", uuid)));
         };
         let mut ops = self.make_operations();
@@ -372,7 +372,7 @@ impl Replica {
         let mut ops = Operations::new();
         self.all_tasks()?
             .drain()
-            .filter(|(_, t)| t.get("status") == Some(Status::Deleted.to_taskmap()))
+            .filter(|(_, t)| t.get_status() == Status::Deleted)
             .filter(|(_, t)| {
                 if let Some(m) = t.get_modified() {
                     m < six_mos_ago

--- a/taskchampion/src/replica.rs
+++ b/taskchampion/src/replica.rs
@@ -83,17 +83,21 @@ impl Replica {
             .expect("task should exist after an update"))
     }
 
-    /// Add the given uuid to the working set, returning its index.
-    pub(crate) fn add_to_working_set(&mut self, uuid: Uuid) -> Result<usize> {
-        self.taskdb.add_to_working_set(uuid)
-    }
-
     /// Get all tasks represented as a map keyed by UUID
     pub fn all_tasks(&mut self) -> Result<HashMap<Uuid, Task>> {
         let depmap = self.dependency_map(false)?;
         let mut res = HashMap::new();
         for (uuid, tm) in self.taskdb.all_tasks()?.drain(..) {
-            res.insert(uuid, Task::new(uuid, tm, depmap.clone()));
+            res.insert(uuid, Task::new(TaskData::new(uuid, tm), depmap.clone()));
+        }
+        Ok(res)
+    }
+
+    /// Get all task represented as a map of [`TaskData`] keyed by UUID
+    pub fn all_task_data(&mut self) -> Result<HashMap<Uuid, TaskData>> {
+        let mut res = HashMap::new();
+        for (uuid, tm) in self.taskdb.all_tasks()?.drain(..) {
+            res.insert(uuid, TaskData::new(uuid, tm));
         }
         Ok(res)
     }
@@ -120,6 +124,9 @@ impl Replica {
     ///
     /// If `force` is true, then the result is re-calculated from the current state of the replica,
     /// although previously-returned dependency maps are not updated.
+    ///
+    /// Calculating this value requires a scan of the full working set and may not be performant.
+    /// The [`TaskData`] API avoids generating this value.
     pub fn dependency_map(&mut self, force: bool) -> Result<Rc<DependencyMap>> {
         if force || self.depmap.is_none() {
             // note: we can't use self.get_task here, as that depends on a
@@ -185,7 +192,7 @@ impl Replica {
         Ok(self
             .taskdb
             .get_task(uuid)?
-            .map(move |tm| Task::new(uuid, tm, depmap)))
+            .map(move |tm| Task::new(TaskData::new(uuid, tm), depmap)))
     }
 
     /// get an existing task by its UUID, as a [`TaskData`](crate::TaskData).
@@ -196,10 +203,14 @@ impl Replica {
             .map(move |tm| TaskData::new(uuid, tm)))
     }
 
-    /// Create a new task.
+    /// Create a new task, setting `modified`, `description`, `status`, and `entry`.
     ///
     /// This uses the high-level task interface. To create a task with the low-level
     /// interface, use [`TaskData::create`](crate::TaskData::create).
+    #[deprecated(
+        since = "0.7.0",
+        note = "please use `create_task` and call `Task` methods `set_status`, `set_description`, and `set_entry`"
+    )]
     pub fn new_task(&mut self, status: Status, description: String) -> Result<Task> {
         let uuid = Uuid::new_v4();
         let mut ops = self.make_operations();
@@ -216,8 +227,20 @@ impl Replica {
             .expect("Task should exist after creation"))
     }
 
+    /// Create a new task.
+    ///
+    /// Use ['Uuid::new_v4`] to invent a new task ID, if necessary. If the task already
+    /// exists, it is returned.
+    pub fn create_task(&mut self, uuid: Uuid, ops: &mut Operations) -> Result<Task> {
+        if let Some(task) = self.get_task(uuid)? {
+            return Ok(task);
+        }
+        let depmap = self.dependency_map(false)?;
+        Ok(Task::new(TaskData::create(uuid, ops), depmap))
+    }
+
     /// Create a new, empty task with the given UUID.  This is useful for importing tasks, but
-    /// otherwise should be avoided in favor of `new_task`.  If the task already exists, this
+    /// otherwise should be avoided in favor of `create_task`.  If the task already exists, this
     /// does nothing and returns the existing task.
     #[deprecated(since = "0.7.0", note = "please use TaskData instead")]
     pub fn import_task_with_uuid(&mut self, uuid: Uuid) -> Result<Task> {
@@ -236,6 +259,7 @@ impl Replica {
     /// example, if a task is deleted on replica 1 and its description modified on replica 1, then
     /// after both replicas have fully synced, the resulting task will only have a `description`
     /// property.
+    #[deprecated(since = "0.7.0", note = "please use TaskData::delete")]
     pub fn delete_task(&mut self, uuid: Uuid) -> Result<()> {
         let Some(task) = self.get_task_data(uuid)? else {
             return Err(Error::Database(format!("Task {} does not exist", uuid)));
@@ -252,6 +276,10 @@ impl Replica {
     /// All local state on the replica will be updated accordingly, including the working set and
     /// and temporarily cached data.
     pub fn commit_operations(&mut self, operations: Operations) -> Result<()> {
+        if operations.is_empty() {
+            return Ok(());
+        }
+
         // Add tasks to the working set when the status property is updated from anything other
         // than pending or recurring to one of those two statuses.
         let pending = Status::Pending.to_taskmap();
@@ -341,9 +369,10 @@ impl Replica {
     /// for 180 days (about six months). Note that completed tasks are not eligible.
     pub fn expire_tasks(&mut self) -> Result<()> {
         let six_mos_ago = Utc::now() - Duration::days(180);
+        let mut ops = Operations::new();
         self.all_tasks()?
-            .iter()
-            .filter(|(_, t)| t.get_status() == Status::Deleted)
+            .drain()
+            .filter(|(_, t)| t.get("status") == Some(Status::Deleted.to_taskmap()))
             .filter(|(_, t)| {
                 if let Some(m) = t.get_modified() {
                     m < six_mos_ago
@@ -351,15 +380,18 @@ impl Replica {
                     false
                 }
             })
-            .try_for_each(|(u, _)| self.delete_task(*u))?;
-        Ok(())
+            .for_each(|(_, t)| t.into_task_data().delete(&mut ops));
+        self.commit_operations(ops)
     }
 
     /// Add an UndoPoint, if one has not already been added by this Replica.  This occurs
     /// automatically when a change is made.  The `force` flag allows forcing a new UndoPoint
     /// even if one has already been created by this Replica, and may be useful when a Replica
     /// instance is held for a long time and used to apply more than one user-visible change.
-    #[deprecated(since = "0.7.0", note = "commit an Operation::UndoPoint instead")]
+    #[deprecated(
+        since = "0.7.0",
+        note = "Use `Operations::new_with_undo_point` instead."
+    )]
     pub fn add_undo_point(&mut self, force: bool) -> Result<()> {
         if force || !self.added_undo_point {
             let ops = Operations::new_with_undo_point();
@@ -404,6 +436,7 @@ mod tests {
     fn new_task() {
         let mut rep = Replica::new_inmemory();
 
+        #[allow(deprecated)]
         let t = rep.new_task(Status::Pending, "a task".into()).unwrap();
         assert_eq!(t.get_description(), String::from("a task"));
         assert_eq!(t.get_status(), Status::Pending);
@@ -414,21 +447,25 @@ mod tests {
     fn modify_task() {
         let mut rep = Replica::new_inmemory();
 
-        let t = rep.new_task(Status::Pending, "a task".into()).unwrap();
+        // Further test the deprecated `new_task` method.
+        #[allow(deprecated)]
+        let mut t = rep.new_task(Status::Pending, "a task".into()).unwrap();
 
-        let mut t = t.into_mut(&mut rep);
-        t.set_description(String::from("past tense")).unwrap();
-        t.set_status(Status::Completed).unwrap();
-        // check that values have changed on the TaskMut
+        let mut ops = Operations::new();
+        t.set_description(String::from("past tense"), &mut ops)
+            .unwrap();
+        t.set_status(Status::Completed, &mut ops).unwrap();
+        // check that values have changed on the Task
         assert_eq!(t.get_description(), "past tense");
         assert_eq!(t.get_status(), Status::Completed);
 
-        // check that values have changed after into_immut
-        let t = t.into_immut();
-        assert_eq!(t.get_description(), "past tense");
-        assert_eq!(t.get_status(), Status::Completed);
+        // check that values have not changed in storage, yet
+        let t = rep.get_task(t.get_uuid()).unwrap().unwrap();
+        assert_eq!(t.get_description(), "a task");
+        assert_eq!(t.get_status(), Status::Pending);
 
-        // check that values have changed in storage, too
+        // check that values have changed in storage after commit
+        rep.commit_operations(ops).unwrap();
         let t = rep.get_task(t.get_uuid()).unwrap().unwrap();
         assert_eq!(t.get_description(), "past tense");
         assert_eq!(t.get_status(), Status::Completed);
@@ -545,11 +582,35 @@ mod tests {
     fn delete_task() {
         let mut rep = Replica::new_inmemory();
 
-        let t = rep.new_task(Status::Pending, "a task".into()).unwrap();
-        let uuid = t.get_uuid();
+        let uuid = Uuid::new_v4();
+        let mut ops = Operations::new();
+        rep.create_task(uuid, &mut ops).unwrap();
+        rep.commit_operations(ops).unwrap();
 
+        #[allow(deprecated)]
         rep.delete_task(uuid).unwrap();
         assert_eq!(rep.get_task(uuid).unwrap(), None);
+    }
+
+    #[test]
+    fn all_tasks() {
+        let mut rep = Replica::new_inmemory();
+
+        let (uuid1, uuid2) = (Uuid::new_v4(), Uuid::new_v4());
+        let mut ops = Operations::new();
+        rep.create_task(uuid1, &mut ops).unwrap();
+        rep.create_task(uuid2, &mut ops).unwrap();
+        rep.commit_operations(ops).unwrap();
+
+        let all_tasks = rep.all_tasks().unwrap();
+        assert_eq!(all_tasks.len(), 2);
+        assert_eq!(all_tasks.get(&uuid1).unwrap().get_uuid(), uuid1);
+        assert_eq!(all_tasks.get(&uuid2).unwrap().get_uuid(), uuid2);
+
+        let all_tasks = rep.all_task_data().unwrap();
+        assert_eq!(all_tasks.len(), 2);
+        assert_eq!(all_tasks.get(&uuid1).unwrap().get_uuid(), uuid1);
+        assert_eq!(all_tasks.get(&uuid2).unwrap().get_uuid(), uuid2);
     }
 
     #[test]
@@ -562,10 +623,10 @@ mod tests {
         rep.dependency_map(true).unwrap();
         assert!(rep.depmap.is_some());
 
-        let t = rep.new_task(Status::Pending, "a task".into())?;
-        let uuid1 = t.get_uuid();
-
         let mut ops = Operations::new();
+        let uuid1 = Uuid::new_v4();
+        let mut t = rep.create_task(uuid1, &mut ops).unwrap();
+        t.set_status(Status::Pending, &mut ops).unwrap();
 
         // uuid2 is created and deleted, but this does not affect the
         // working set.
@@ -677,17 +738,20 @@ mod tests {
     fn get_and_modify() {
         let mut rep = Replica::new_inmemory();
 
-        let t = rep
-            .new_task(Status::Pending, "another task".into())
-            .unwrap();
-        let uuid = t.get_uuid();
+        let mut ops = Operations::new();
+        let uuid = Uuid::new_v4();
+        let mut t = rep.create_task(uuid, &mut ops).unwrap();
+        t.set_status(Status::Pending, &mut ops).unwrap();
+        t.set_description("another task".into(), &mut ops).unwrap();
+        rep.commit_operations(ops).unwrap();
 
-        let t = rep.get_task(uuid).unwrap().unwrap();
+        let mut t = rep.get_task(uuid).unwrap().unwrap();
         assert_eq!(t.get_description(), String::from("another task"));
 
-        let mut t = t.into_mut(&mut rep);
-        t.set_status(Status::Deleted).unwrap();
-        t.set_description("gone".into()).unwrap();
+        let mut ops = Operations::new();
+        t.set_status(Status::Deleted, &mut ops).unwrap();
+        t.set_description("gone".into(), &mut ops).unwrap();
+        rep.commit_operations(ops).unwrap();
 
         let t = rep.get_task(uuid).unwrap().unwrap();
         assert_eq!(t.get_status(), Status::Deleted);
@@ -703,10 +767,11 @@ mod tests {
     fn get_task_data() {
         let mut rep = Replica::new_inmemory();
 
-        let t = rep
-            .new_task(Status::Pending, "another task".into())
-            .unwrap();
-        let uuid = t.get_uuid();
+        let uuid = Uuid::new_v4();
+        let mut ops = Operations::new();
+        let mut t = rep.create_task(uuid, &mut ops).unwrap();
+        t.set_description("another task".into(), &mut ops).unwrap();
+        rep.commit_operations(ops).unwrap();
 
         let t = rep.get_task_data(uuid).unwrap().unwrap();
         assert_eq!(t.get_uuid(), uuid);
@@ -719,16 +784,16 @@ mod tests {
     fn rebuild_working_set_includes_recurring() {
         let mut rep = Replica::new_inmemory();
 
-        let t = rep
-            .new_task(Status::Completed, "another task".into())
-            .unwrap();
-        let uuid = t.get_uuid();
+        let uuid = Uuid::new_v4();
+        let mut ops = Operations::new();
+        let mut t = rep.create_task(uuid, &mut ops).unwrap();
+        t.set_status(Status::Completed, &mut ops).unwrap();
+        rep.commit_operations(ops).unwrap();
 
-        let t = rep.get_task(uuid).unwrap().unwrap();
-        {
-            let mut t = t.into_mut(&mut rep);
-            t.set_status(Status::Recurring).unwrap();
-        }
+        let mut t = rep.get_task(uuid).unwrap().unwrap();
+        let mut ops = Operations::new();
+        t.set_status(Status::Recurring, &mut ops).unwrap();
+        rep.commit_operations(ops).unwrap();
 
         rep.rebuild_working_set(true).unwrap();
 
@@ -740,10 +805,11 @@ mod tests {
     fn new_pending_adds_to_working_set() {
         let mut rep = Replica::new_inmemory();
 
-        let t = rep
-            .new_task(Status::Pending, "to-be-pending".into())
-            .unwrap();
-        let uuid = t.get_uuid();
+        let uuid = Uuid::new_v4();
+        let mut ops = Operations::new();
+        let mut t = rep.create_task(uuid, &mut ops).unwrap();
+        t.set_status(Status::Pending, &mut ops).unwrap();
+        rep.commit_operations(ops).unwrap();
 
         let ws = rep.working_set().unwrap();
         assert_eq!(ws.len(), 1); // only one non-none value
@@ -758,10 +824,11 @@ mod tests {
     fn new_recurring_adds_to_working_set() {
         let mut rep = Replica::new_inmemory();
 
-        let t = rep
-            .new_task(Status::Recurring, "to-be-recurring".into())
-            .unwrap();
-        let uuid = t.get_uuid();
+        let uuid = Uuid::new_v4();
+        let mut ops = Operations::new();
+        let mut t = rep.create_task(uuid, &mut ops).unwrap();
+        t.set_status(Status::Recurring, &mut ops).unwrap();
+        rep.commit_operations(ops).unwrap();
 
         let ws = rep.working_set().unwrap();
         assert_eq!(ws.len(), 1); // only one non-none value
@@ -782,24 +849,35 @@ mod tests {
     #[test]
     fn expire() {
         let mut rep = Replica::new_inmemory();
-        let mut t;
+        let mut ops = Operations::new();
 
-        rep.new_task(Status::Pending, "keeper 1".into()).unwrap();
-        rep.new_task(Status::Completed, "keeper 2".into()).unwrap();
+        // uuid1 is pending, so is not expired.
+        let uuid1 = Uuid::new_v4();
+        let mut t = rep.create_task(uuid1, &mut ops).unwrap();
+        t.set_description("keeper 1".into(), &mut ops).unwrap();
+        t.set_status(Status::Pending, &mut ops).unwrap();
 
-        t = rep.new_task(Status::Deleted, "keeper 3".into()).unwrap();
-        {
-            let mut t = t.into_mut(&mut rep);
-            // set entry, with modification set as a side-effect
-            t.set_entry(Some(Utc::now())).unwrap();
-        }
+        // uuid2 is completed, so is not expired.
+        let uuid2 = Uuid::new_v4();
+        let mut t = rep.create_task(uuid2, &mut ops).unwrap();
+        t.set_description("keeper 2".into(), &mut ops).unwrap();
+        t.set_status(Status::Completed, &mut ops).unwrap();
 
-        t = rep.new_task(Status::Deleted, "goner".into()).unwrap();
-        {
-            let mut t = t.into_mut(&mut rep);
-            t.set_modified(Utc.with_ymd_and_hms(1980, 1, 1, 0, 0, 0).unwrap())
-                .unwrap();
-        }
+        // uuid3 is deleted but recently modified, so is not expired.
+        let uuid3 = Uuid::new_v4();
+        let mut t = rep.create_task(uuid3, &mut ops).unwrap();
+        t.set_description("keeper 3".into(), &mut ops).unwrap();
+        t.set_status(Status::Deleted, &mut ops).unwrap();
+        t.set_entry(Some(Utc::now()), &mut ops).unwrap();
+
+        // uuid4 was deleted long ago, so it is expired.
+        let uuid4 = Uuid::new_v4();
+        let mut t = rep.create_task(uuid4, &mut ops).unwrap();
+        t.set_description("goner".into(), &mut ops).unwrap();
+        t.set_status(Status::Deleted, &mut ops).unwrap();
+        t.set_modified(Utc.with_ymd_and_hms(1980, 1, 1, 0, 0, 0).unwrap(), &mut ops)
+            .unwrap();
+        rep.commit_operations(ops).unwrap();
 
         rep.expire_tasks().unwrap();
 
@@ -814,34 +892,32 @@ mod tests {
         let mut rep = Replica::new_inmemory();
 
         let mut tasks = vec![];
+        let mut ops = Operations::new();
         for _ in 0..4 {
-            tasks.push(rep.new_task(Status::Pending, "t".into()).unwrap());
+            let mut t = rep.create_task(Uuid::new_v4(), &mut ops).unwrap();
+            t.set_status(Status::Pending, &mut ops).unwrap();
+            tasks.push(t);
         }
-
         let uuids: Vec<_> = tasks.iter().map(|t| t.get_uuid()).collect();
 
         // t[3] depends on t[2], and t[1]
-        {
-            let mut t = tasks.pop().unwrap().into_mut(&mut rep);
-            t.add_dependency(uuids[2]).unwrap();
-            t.add_dependency(uuids[1]).unwrap();
-        }
+        let mut t = tasks.pop().unwrap();
+        t.add_dependency(uuids[2], &mut ops).unwrap();
+        t.add_dependency(uuids[1], &mut ops).unwrap();
 
         // t[2] depends on t[0]
-        {
-            let mut t = tasks.pop().unwrap().into_mut(&mut rep);
-            t.add_dependency(uuids[0]).unwrap();
-        }
+        let mut t = tasks.pop().unwrap();
+        t.add_dependency(uuids[0], &mut ops).unwrap();
 
         // t[1] depends on t[0]
-        {
-            let mut t = tasks.pop().unwrap().into_mut(&mut rep);
-            t.add_dependency(uuids[0]).unwrap();
-        }
+        let mut t = tasks.pop().unwrap();
+        t.add_dependency(uuids[0], &mut ops).unwrap();
 
-        // generate the dependency map, forcing an update based on the newly-added
-        // dependencies
-        let dm = rep.dependency_map(true).unwrap();
+        rep.commit_operations(ops).unwrap();
+
+        // generate the dependency map, forcing an update based on the newly-added dependencies.
+        // This need not be forced since the `commit_operations` invalidated the cached value.
+        let dm = rep.dependency_map(false).unwrap();
 
         assert_eq!(
             dm.dependencies(uuids[3]).collect::<HashSet<_>>(),
@@ -878,13 +954,14 @@ mod tests {
         );
 
         // mark t[0] as done, removing it from the working set
+        let mut ops = Operations::new();
         rep.get_task(uuids[0])
             .unwrap()
             .unwrap()
-            .into_mut(&mut rep)
-            .done()
+            .done(&mut ops)
             .unwrap();
-        let dm = rep.dependency_map(true).unwrap();
+        rep.commit_operations(ops).unwrap();
+        let dm = rep.dependency_map(false).unwrap();
 
         assert_eq!(
             dm.dependencies(uuids[3]).collect::<HashSet<_>>(),

--- a/taskchampion/src/task/data.rs
+++ b/taskchampion/src/task/data.rs
@@ -99,10 +99,13 @@ impl TaskData {
     /// example, if a task is deleted on replica 1 and its description modified on replica 2, then
     /// after both replicas have fully synced, the resulting task will only have a `description`
     /// property.
-    pub fn delete(self, operations: &mut Operations) {
+    ///
+    /// After this call, the `TaskData` value still exists but has no properties and should be
+    /// dropped.
+    pub fn delete(&mut self, operations: &mut Operations) {
         operations.add(Operation::Delete {
             uuid: self.uuid,
-            old_task: self.taskmap,
+            old_task: std::mem::take(&mut self.taskmap),
         });
     }
 }
@@ -245,7 +248,7 @@ mod test {
     #[test]
     fn delete() {
         let mut ops = Operations::new();
-        let t = TaskData::new(TEST_UUID, [("prop1".to_string(), "val".to_string())].into());
+        let mut t = TaskData::new(TEST_UUID, [("prop1".to_string(), "val".to_string())].into());
         t.delete(&mut ops);
         assert_eq!(
             ops,

--- a/taskchampion/src/task/data.rs
+++ b/taskchampion/src/task/data.rs
@@ -14,8 +14,7 @@ use uuid::Uuid;
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct TaskData {
     uuid: Uuid,
-    // Temporarily pub(crate) to allow access from Task.
-    pub(crate) taskmap: TaskMap,
+    taskmap: TaskMap,
 }
 
 impl TaskData {
@@ -36,6 +35,11 @@ impl TaskData {
     /// Get this task's UUID.
     pub fn get_uuid(&self) -> Uuid {
         self.uuid
+    }
+
+    /// Get the taskmap (used only for deprecated `Task::get_taskmap`).
+    pub(in crate::task) fn get_taskmap(&self) -> &TaskMap {
+        &self.taskmap
     }
 
     /// Get a value on this task.
@@ -62,6 +66,8 @@ impl TaskData {
     /// set of operations.
     ///
     /// Setting a value to `None` removes that value from the task.
+    ///
+    /// This method does not have any special handling of the `modified` property.
     pub fn update(
         &mut self,
         property: impl Into<String>,
@@ -127,7 +133,7 @@ mod test {
     }
 
     #[test]
-    fn uuid() {
+    fn get_uuid() {
         let t = TaskData::new(TEST_UUID, TaskMap::new());
         assert_eq!(t.get_uuid(), TEST_UUID);
     }

--- a/taskchampion/src/task/mod.rs
+++ b/taskchampion/src/task/mod.rs
@@ -10,5 +10,5 @@ pub use annotation::Annotation;
 pub use data::TaskData;
 pub use status::Status;
 pub use tag::Tag;
-pub use task::{Task, TaskMut};
+pub use task::Task;
 pub use time::{utc_timestamp, Timestamp};

--- a/taskchampion/src/task/task.rs
+++ b/taskchampion/src/task/task.rs
@@ -917,7 +917,7 @@ mod test {
         with_mut_task(
             |task, ops| {
                 task.data
-                    .update("annotation_1635301873", Some("left message".into()), ops);
+                    .update("annotation_1635301883", Some("left message".into()), ops);
                 task.set_value(
                     "annotation_1635301883",
                     Some("left another message".into()),
@@ -925,19 +925,13 @@ mod test {
                 )
                 .unwrap();
 
-                task.remove_annotation(Utc.timestamp_opt(1635301873, 0).unwrap(), ops)
+                task.remove_annotation(Utc.timestamp_opt(1635301883, 0).unwrap(), ops)
                     .unwrap();
             },
             |task| {
                 let mut anns: Vec<_> = task.get_annotations().collect();
                 anns.sort();
-                assert_eq!(
-                    anns,
-                    vec![Annotation {
-                        entry: Utc.timestamp_opt(1635301883, 0).unwrap(),
-                        description: "left another message".into()
-                    }]
-                );
+                assert_eq!(anns, vec![]);
             },
         );
     }

--- a/taskchampion/src/task/task.rs
+++ b/taskchampion/src/task/task.rs
@@ -1342,6 +1342,7 @@ mod test {
             |task| {
                 let deps = task.get_dependencies().collect::<Vec<_>>();
                 assert!(deps.contains(&dep1));
+                assert!(!deps.contains(&dep2));
             },
         )
     }

--- a/taskchampion/tests/cross-sync.rs
+++ b/taskchampion/tests/cross-sync.rs
@@ -1,5 +1,6 @@
+use chrono::Utc;
 use pretty_assertions::assert_eq;
-use taskchampion::{Replica, ServerConfig, Status, StorageConfig};
+use taskchampion::{Operations, Replica, ServerConfig, Status, StorageConfig, Uuid};
 use tempfile::TempDir;
 
 #[test]
@@ -14,25 +15,30 @@ fn cross_sync() -> anyhow::Result<()> {
     };
     let mut server = server_config.into_server()?;
 
+    let (uuid1, uuid2) = (Uuid::new_v4(), Uuid::new_v4());
+    let mut ops = Operations::new();
+
     // add some tasks on rep1
-    let t1 = rep1.new_task(Status::Pending, "test 1".into())?;
-    let t2 = rep1.new_task(Status::Pending, "test 2".into())?;
+    let mut t1 = rep1.create_task(uuid1, &mut ops)?;
+    t1.set_description("test 1".into(), &mut ops)?;
+    t1.set_status(Status::Pending, &mut ops)?;
+    t1.set_entry(Some(Utc::now()), &mut ops)?;
+    let mut t2 = rep1.create_task(uuid2, &mut ops)?;
+    t2.set_description("test 2".into(), &mut ops)?;
+    t2.set_status(Status::Pending, &mut ops)?;
+    t2.set_entry(Some(Utc::now()), &mut ops)?;
 
     // modify t1
-    let mut t1 = t1.into_mut(&mut rep1);
-    t1.start()?;
-    let t1 = t1.into_immut();
+    t1.start(&mut ops)?;
+
+    rep1.commit_operations(ops)?;
 
     rep1.sync(&mut server, false)?;
     rep2.sync(&mut server, false)?;
 
     // those tasks should exist on rep2 now
-    let t12 = rep2
-        .get_task(t1.get_uuid())?
-        .expect("expected task 1 on rep2");
-    let t22 = rep2
-        .get_task(t2.get_uuid())?
-        .expect("expected task 2 on rep2");
+    let mut t12 = rep2.get_task(uuid1)?.expect("expected task 1 on rep2");
+    let t22 = rep2.get_task(uuid2)?.expect("expected task 2 on rep2");
 
     assert_eq!(t12.get_description(), "test 1");
     assert_eq!(t12.is_active(), true);
@@ -40,26 +46,23 @@ fn cross_sync() -> anyhow::Result<()> {
     assert_eq!(t22.is_active(), false);
 
     // make non-conflicting changes on the two replicas
-    let mut t2 = t2.into_mut(&mut rep1);
-    t2.set_status(Status::Completed)?;
-    let t2 = t2.into_immut();
+    let mut ops = Operations::new();
+    t2.set_status(Status::Completed, &mut ops)?;
+    rep2.commit_operations(ops)?;
 
-    let mut t12 = t12.into_mut(&mut rep2);
-    t12.set_status(Status::Completed)?;
+    let mut ops = Operations::new();
+    t12.set_status(Status::Completed, &mut ops)?;
+    rep2.commit_operations(ops)?;
 
     // sync those changes back and forth
     rep1.sync(&mut server, false)?; // rep1 -> server
     rep2.sync(&mut server, false)?; // server -> rep2, rep2 -> server
     rep1.sync(&mut server, false)?; // server -> rep1
 
-    let t1 = rep1
-        .get_task(t1.get_uuid())?
-        .expect("expected task 1 on rep1");
+    let t1 = rep1.get_task(uuid1)?.expect("expected task 1 on rep1");
     assert_eq!(t1.get_status(), Status::Completed);
 
-    let t22 = rep2
-        .get_task(t2.get_uuid())?
-        .expect("expected task 2 on rep2");
+    let t22 = rep2.get_task(uuid2)?.expect("expected task 2 on rep2");
     assert_eq!(t22.get_status(), Status::Completed);
 
     Ok(())

--- a/taskchampion/tests/syncing-proptest.rs
+++ b/taskchampion/tests/syncing-proptest.rs
@@ -63,7 +63,7 @@ fn multi_replica_sync(action_sequence in actions()) {
                 }
             },
             Action::Delete => {
-                if let Some(t) = rep.get_task_data(uuid).unwrap() {
+                if let Some(mut t) = rep.get_task_data(uuid).unwrap() {
                     let mut ops = Operations::new();
                     t.delete(&mut ops);
                     rep.commit_operations(ops).unwrap();

--- a/taskchampion/tests/update-and-delete-sync.rs
+++ b/taskchampion/tests/update-and-delete-sync.rs
@@ -42,7 +42,7 @@ fn update_and_delete_sync(delete_first: bool) -> anyhow::Result<()> {
     {
         let mut ops = Operations::new();
         let mut t = rep2.get_task(u)?.unwrap();
-        t.delete(&mut ops)?;
+        t.set_status(Status::Deleted, &mut ops)?;
         t.set_modified(Utc.with_ymd_and_hms(1980, 1, 1, 0, 0, 0).unwrap(), &mut ops)?;
         rep2.commit_operations(ops)?;
     }


### PR DESCRIPTION
This breaking change removes the `TaskMut` type and moves its high-level setters to `Task`. `Task` derefs to `TaskData`, making the methods of that type available for `Task` values.

Several methods are deprecated, as detailed below. While these methods remain, they may be less performant than the recommended methods, either by reading unnecessary data from the database (e.g., to construct a dependency map) or by modifying the database in multiple transactions.

Breaking Changes:

 - `Task`:
   - All `TaskMut` setters are now methods on `Task`, and take `&mut ops` as their last argument.
   - `Task::into_mut` is removed.
   - `Task::delete` is deprecated. Use `Task::set_status` with `Status::Deleted` instead.

 - `Replica`:
   - `Replica::add_to_working_set` is removed - working set maintenance is now entirely automatic.
   - `Replica::new_task` is deprecated - prefer `Replica::create_task` and setting the `entry`, `description`, and `status` properties directly.
   - `Replica::import_task_with_uuid` is deprecated - prefer `Replica::create_task`.
   - `Replica::update_task` is deprecated - prefer `TaskData::update`.
   - `Replica::delete_task` is deprecated - prefer `TaskData::delete`.
   - Management of undo points in the replica, including `Replica::add_undo_point` and automatically adding undo points for various operations, is no longer supported; use `Operations::new_with_undo_point` to add one when necessary.

This is the first of two breaking changes for #372, which will necessitate a 0.7.0 release.