### PR TITLE
[BREAKING] Update undo support to use Operations

### DIFF
--- a/taskchampion/src/operation.rs
+++ b/taskchampion/src/operation.rs
@@ -71,11 +71,6 @@ impl Operations {
         self.0.push(op);
     }
 
-    /// Determine if this set of operations is empty.
-    pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
-    }
-
     /// For tests, it's useful to set the timestamps of all updates to the same value.
     #[cfg(test)]
     pub fn set_all_timestamps(&mut self, set_to: DateTime<Utc>) {
@@ -84,6 +79,20 @@ impl Operations {
                 *timestamp = set_to;
             }
         }
+    }
+}
+
+impl From<Vec<Operation>> for Operations {
+    fn from(value: Vec<Operation>) -> Self {
+        Self(value)
+    }
+}
+
+impl std::ops::Deref for Operations {
+    type Target = [Operation];
+
+    fn deref(&self) -> &Self::Target {
+        self.0.deref()
     }
 }
 


### PR DESCRIPTION
This updates the existing "undo" support to use `Operations`, while making some additional changes to look forward to more general undo support (#427 being the next step on that journey).

Breaking changes:

 - `Replica::get_undo_ops` is now `Replica::get_undo_operations` and returns an `Operations` value. It now returns the operations in the order they were applied, and includes the undo point operation, if one exists.
 - `Replica::commit_undo_ops` is now `Replica::commit_reversed_operations` and takes an `Operations` value as provided by `get_undo_operations`.

This is the second of the two planned breaking changes in #372.