### PR TITLE
Documentation clean-up

### DIFF
--- a/taskchampion/src/lib.rs
+++ b/taskchampion/src/lib.rs
@@ -16,22 +16,22 @@ A TaskChampion replica is a local copy of a user's task data.  As the name sugge
 replicas of the same data can exist (such as on a user's laptop and on their phone) and can
 synchronize with one another.
 
-Replicas are accessed using the [`Replica`](crate::Replica) type.
+Replicas are accessed using the [`Replica`] type.
 
 # Task Storage
 
 Replicas access the task database via a [storage object](crate::storage::Storage).
-Create a storage object with [`StorageConfig`](crate::storage::StorageConfig).
+Create a storage object with [`StorageConfig`].
 
-The [`storage`](crate::storage) module supports pluggable storage for a replica's data.
+The [`storage`] module supports pluggable storage for a replica's data.
 An implementation is provided, but users of this crate can provide their own implementation as well.
 
 # Server
 
 Replica synchronization takes place against a server.
-Create a server with [`ServerConfig`](crate::ServerConfig).
+Create a server with [`ServerConfig`].
 
-The [`server`](crate::server) module defines the interface a server must meet.
+The [`server`] module defines the interface a server must meet.
 Users can define their own server impelementations.
 
 # Feature Flags

--- a/taskchampion/src/operation.rs
+++ b/taskchampion/src/operation.rs
@@ -46,7 +46,7 @@ impl Operation {
 }
 
 /// Operations contains a sequence of [`Operation`] values, which can be committed in a single
-/// transaction with [`Replica::commit`](crate::Replica::commit).
+/// transaction with [`Replica::commit`](crate::Replica::commit_operations).
 #[derive(PartialEq, Eq, Debug, Default)]
 pub struct Operations(Vec<Operation>);
 

--- a/taskchampion/src/replica.rs
+++ b/taskchampion/src/replica.rs
@@ -19,11 +19,10 @@ use uuid::Uuid;
 ///
 /// ## Tasks
 ///
-/// Tasks are uniquely identified by UUIDs.
-/// Most task modifications are performed via the [`Task`](crate::Task) and
-/// [`TaskMut`](crate::TaskMut) types.  Use of two types for tasks allows easy
-/// read-only manipulation of lots of tasks, with exclusive access required only
-/// for modifications.
+/// Tasks are uniquely identified by UUIDs. Most task modifications are performed via the
+/// [`TaskData`](crate::TaskData) or [`Task`](crate::Task) types. The first is a lower-level type
+/// that wraps the key-value store representing a task, while the second is a higher-level type
+/// that supports methods to update specific properties, maintain dependencies and tags, and so on.
 ///
 /// ## Working Set
 ///
@@ -333,7 +332,7 @@ impl Replica {
     /// no undo point is found.
     ///
     /// The operations are returned in the order they were applied. Use
-    /// [`commit_reversed_operations`] to "undo" them.
+    /// [`Replica::commit_reversed_operations`] to "undo" them.
     pub fn get_undo_operations(&mut self) -> Result<Operations> {
         self.taskdb.get_undo_operations()
     }

--- a/taskchampion/src/server/config.rs
+++ b/taskchampion/src/server/config.rs
@@ -58,8 +58,8 @@ pub enum ServerConfig {
         /// - storage.objects.delete
         ///
         /// See the following GCP resources for more information:
-        /// - https://cloud.google.com/docs/authentication#service-accounts
-        /// - https://cloud.google.com/iam/docs/keys-create-delete#creating
+        /// - <https://cloud.google.com/docs/authentication#service-accounts>
+        /// - <https://cloud.google.com/iam/docs/keys-create-delete#creating>
         credential_path: Option<String>,
         /// Private encryption secret used to encrypt all data sent to the server.  This can
         /// be any suitably un-guessable string of bytes.

--- a/taskchampion/src/server/mod.rs
+++ b/taskchampion/src/server/mod.rs
@@ -1,11 +1,12 @@
-/**
-
+/*!
 This module defines the client interface to TaskChampion sync servers.
-It defines a [trait](crate::server::Server) for servers, and implements both local and remote servers.
 
-Typical uses of this crate do not interact directly with this module; [`ServerConfig`](crate::ServerConfig) is sufficient.
-However, users who wish to implement their own server interfaces can implement the traits defined here and pass the result to [`Replica`](crate::Replica).
+It defines a [trait](crate::server::Server) for servers, and implements both local and remote
+servers.
 
+Typical uses of this crate do not interact directly with this module; [`ServerConfig`] is
+sufficient. However, users who wish to implement their own server interfaces can implement the
+traits defined here and pass the result to [`Replica`](crate::Replica).
 */
 
 #[cfg(test)]

--- a/taskchampion/src/storage/mod.rs
+++ b/taskchampion/src/storage/mod.rs
@@ -1,10 +1,14 @@
 /*!
 This module defines the backend storage used by [`Replica`](crate::Replica).
-It defines a [trait](crate::storage::Storage) for storage implementations, and provides a default on-disk implementation as well as an in-memory implementation for testing.
 
-Typical uses of this crate do not interact directly with this module; [`StorageConfig`](crate::StorageConfig) is sufficient.
-However, users who wish to implement their own storage backends can implement the traits defined here and pass the result to [`Replica`](crate::Replica).
+It defines a [trait](crate::storage::Storage) for storage implementations, and provides a default
+on-disk implementation as well as an in-memory implementation for testing.
+
+Typical uses of this crate do not interact directly with this module; [`StorageConfig`] is
+sufficient. However, users who wish to implement their own storage backends can implement the
+traits defined here and pass the result to [`Replica`](crate::Replica).
 */
+
 use crate::errors::Result;
 use crate::operation::Operation;
 use std::collections::HashMap;

--- a/taskchampion/src/task/task.rs
+++ b/taskchampion/src/task/task.rs
@@ -362,7 +362,7 @@ impl Task {
         Ok(())
     }
 
-    /// Start the task by creating "start": "<timestamp>", if the task is not already
+    /// Start the task by setting "start" to the current timestamp, if the task is not already
     /// active.
     pub fn start(&mut self, ops: &mut Operations) -> Result<()> {
         if self.is_active() {


### PR DESCRIPTION
This fixes several warnings from `cargo doc` and other minor out-of-date or missing documentation.