### PR TITLE
Use `Vec<Operation>` instead of newtype `Operations`

### DIFF
--- a/taskchampion/src/replica.rs
+++ b/taskchampion/src/replica.rs
@@ -422,6 +422,7 @@ impl Replica {
         let mut ops = Operations::new();
         if !self.added_undo_point {
             ops.push(Operation::UndoPoint);
+            self.added_undo_point = true;
         }
         ops
     }

--- a/taskchampion/src/replica.rs
+++ b/taskchampion/src/replica.rs
@@ -405,11 +405,11 @@ impl Replica {
     /// instance is held for a long time and used to apply more than one user-visible change.
     #[deprecated(
         since = "0.7.0",
-        note = "Use `Operations::new_with_undo_point` instead."
+        note = "Push an `Operation::UndoPoint` onto your `Operations` instead."
     )]
     pub fn add_undo_point(&mut self, force: bool) -> Result<()> {
         if force || !self.added_undo_point {
-            let ops = Operations::new_with_undo_point();
+            let ops = vec![Operation::UndoPoint];
             self.commit_operations(ops)?;
             self.added_undo_point = true;
         }
@@ -419,12 +419,11 @@ impl Replica {
     /// Make a new `Operations`, with an undo operation if one has not already been added by
     /// this `Replica` insance
     fn make_operations(&mut self) -> Operations {
-        if self.added_undo_point {
-            Operations::new()
-        } else {
-            self.added_undo_point = true;
-            Operations::new_with_undo_point()
+        let mut ops = Operations::new();
+        if !self.added_undo_point {
+            ops.push(Operation::UndoPoint);
         }
+        ops
     }
 
     /// Get the number of operations local to this replica and not yet synchronized to the server.
@@ -646,8 +645,8 @@ mod tests {
         // uuid2 is created and deleted, but this does not affect the
         // working set.
         let uuid2 = Uuid::new_v4();
-        ops.add(Operation::Create { uuid: uuid2 });
-        ops.add(Operation::Delete {
+        ops.push(Operation::Create { uuid: uuid2 });
+        ops.push(Operation::Delete {
             uuid: uuid2,
             old_task: TaskMap::new(),
         });
@@ -664,15 +663,15 @@ mod tests {
 
         // uuid3 has status deleted, so is not added to the working set.
         let uuid3 = Uuid::new_v4();
-        ops.add(update_op(uuid3, "status", None, Some("deleted")));
+        ops.push(update_op(uuid3, "status", None, Some("deleted")));
 
         // uuid4 goes from pending to pending, so is not added to the working set.
         let uuid4 = Uuid::new_v4();
-        ops.add(update_op(uuid4, "status", Some("pending"), Some("pending")));
+        ops.push(update_op(uuid4, "status", Some("pending"), Some("pending")));
 
         // uuid5 goes from recurring to recurring, so is not added to the working set.
         let uuid5 = Uuid::new_v4();
-        ops.add(update_op(
+        ops.push(update_op(
             uuid5,
             "status",
             Some("recurring"),
@@ -681,7 +680,7 @@ mod tests {
 
         // uuid6 goes from recurring to pending, so is not added to the working set.
         let uuid6 = Uuid::new_v4();
-        ops.add(update_op(
+        ops.push(update_op(
             uuid6,
             "status",
             Some("recurring"),
@@ -690,7 +689,7 @@ mod tests {
 
         // uuid7 goes from pending to recurring, so is not added to the working set.
         let uuid7 = Uuid::new_v4();
-        ops.add(update_op(
+        ops.push(update_op(
             uuid7,
             "status",
             Some("pending"),
@@ -699,15 +698,15 @@ mod tests {
 
         // uuid8 goes from no-status to recurring, so is added to the working set.
         let uuid8 = Uuid::new_v4();
-        ops.add(update_op(uuid8, "status", None, Some("recurring")));
+        ops.push(update_op(uuid8, "status", None, Some("recurring")));
 
         // uuid9 goes from no-status to pending, so is added to the working set.
         let uuid9 = Uuid::new_v4();
-        ops.add(update_op(uuid9, "status", None, Some("pending")));
+        ops.push(update_op(uuid9, "status", None, Some("pending")));
 
         // uuid10 goes from deleted to pending, so is added to the working set.
         let uuid10 = Uuid::new_v4();
-        ops.add(update_op(
+        ops.push(update_op(
             uuid10,
             "status",
             Some("deleted"),
@@ -716,7 +715,7 @@ mod tests {
 
         // uuid11 goes from pending to deleted, so is not added to the working set.
         let uuid11 = Uuid::new_v4();
-        ops.add(update_op(
+        ops.push(update_op(
             uuid11,
             "status",
             Some("pending"),
@@ -725,7 +724,7 @@ mod tests {
 
         // uuid12 goes from pending to no-status, so is not added to the working set.
         let uuid12 = Uuid::new_v4();
-        ops.add(update_op(uuid12, "status", Some("pending"), None));
+        ops.push(update_op(uuid12, "status", Some("pending"), None));
 
         rep.commit_operations(ops)?;
 

--- a/taskchampion/src/server/op.rs
+++ b/taskchampion/src/server/op.rs
@@ -268,22 +268,22 @@ mod test {
         let mut db1 = TaskDb::new_inmemory();
         let mut ops1 = Operations::new();
         if let Some(o) = setup.clone() {
-            ops1.add(o.into_op());
+            ops1.push(o.into_op());
         }
-        ops1.add(o1.into_op());
+        ops1.push(o1.into_op());
         if let Some(o) = o2p {
-            ops1.add(o.into_op());
+            ops1.push(o.into_op());
         }
         db1.commit_operations(ops1, |_| false).unwrap();
 
         let mut db2 = TaskDb::new_inmemory();
         let mut ops2 = Operations::new();
         if let Some(o) = setup {
-            ops2.add(o.into_op());
+            ops2.push(o.into_op());
         }
-        ops2.add(o2.into_op());
+        ops2.push(o2.into_op());
         if let Some(o) = o1p {
-            ops2.add(o.into_op());
+            ops2.push(o.into_op());
         }
         db2.commit_operations(ops2, |_| false).unwrap();
 
@@ -440,21 +440,21 @@ mod test {
             for o in [&o1, &o2] {
                 match o {
                     Update { uuid, .. } | Delete { uuid } => {
-                        ops1.add(Operation::Create { uuid: *uuid });
-                        ops2.add(Operation::Create { uuid: *uuid });
+                        ops1.push(Operation::Create { uuid: *uuid });
+                        ops2.push(Operation::Create { uuid: *uuid });
                     }
                     _ => {},
                 }
             }
 
-            ops1.add(o1.into_op());
-            ops2.add(o2.into_op());
+            ops1.push(o1.into_op());
+            ops2.push(o2.into_op());
 
             if let Some(o2p) = o2p {
-                ops1.add(o2p.into_op());
+                ops1.push(o2p.into_op());
             }
             if let Some(o1p) = o1p {
-                ops2.add(o1p.into_op());
+                ops2.push(o1p.into_op());
             }
 
             db1.commit_operations(ops1, |_| false).unwrap();

--- a/taskchampion/src/taskdb/apply.rs
+++ b/taskchampion/src/taskdb/apply.rs
@@ -96,7 +96,7 @@ mod tests {
         let mut db = TaskDb::new_inmemory();
         let uuid = Uuid::new_v4();
         let mut ops = Operations::new();
-        ops.add(Operation::Create { uuid });
+        ops.push(Operation::Create { uuid });
 
         {
             let mut txn = db.storage.txn()?;
@@ -121,7 +121,7 @@ mod tests {
 
         {
             let mut ops = Operations::new();
-            ops.add(Operation::Create { uuid });
+            ops.push(Operation::Create { uuid });
             let mut txn = db.storage.txn()?;
             apply_operations(txn.as_mut(), &ops)?;
             txn.commit()?;
@@ -140,8 +140,8 @@ mod tests {
         let uuid = Uuid::new_v4();
         let now = Utc::now();
         let mut ops = Operations::new();
-        ops.add(Operation::Create { uuid });
-        ops.add(Operation::Update {
+        ops.push(Operation::Create { uuid });
+        ops.push(Operation::Update {
             uuid,
             property: String::from("title"),
             value: Some("my task".into()),
@@ -168,22 +168,22 @@ mod tests {
         let uuid = Uuid::new_v4();
         let now = Utc::now();
         let mut ops = Operations::new();
-        ops.add(Operation::Create { uuid });
-        ops.add(Operation::Update {
+        ops.push(Operation::Create { uuid });
+        ops.push(Operation::Update {
             uuid,
             property: String::from("title"),
             value: Some("my task".into()),
             timestamp: now,
             old_value: None,
         });
-        ops.add(Operation::Update {
+        ops.push(Operation::Update {
             uuid,
             property: String::from("priority"),
             value: Some("H".into()),
             timestamp: now,
             old_value: None,
         });
-        ops.add(Operation::Update {
+        ops.push(Operation::Update {
             uuid,
             property: String::from("title"),
             value: None,
@@ -210,7 +210,7 @@ mod tests {
         let uuid = Uuid::new_v4();
         let now = Utc::now();
         let mut ops = Operations::new();
-        ops.add(Operation::Update {
+        ops.push(Operation::Update {
             uuid,
             property: String::from("title"),
             value: Some("my task".into()),
@@ -234,15 +234,15 @@ mod tests {
         let uuid = Uuid::new_v4();
         let now = Utc::now();
         let mut ops = Operations::new();
-        ops.add(Operation::Create { uuid });
-        ops.add(Operation::Update {
+        ops.push(Operation::Create { uuid });
+        ops.push(Operation::Update {
             uuid,
             property: String::from("title"),
             value: Some("my task".into()),
             timestamp: now,
             old_value: None,
         });
-        ops.add(Operation::Delete {
+        ops.push(Operation::Delete {
             uuid,
             old_task: taskmap_with(vec![]),
         });
@@ -262,7 +262,7 @@ mod tests {
         let mut db = TaskDb::new_inmemory();
         let uuid = Uuid::new_v4();
         let mut ops = Operations::new();
-        ops.add(Operation::Delete {
+        ops.push(Operation::Delete {
             uuid,
             old_task: taskmap_with(vec![]),
         });

--- a/taskchampion/src/taskdb/mod.rs
+++ b/taskchampion/src/taskdb/mod.rs
@@ -215,8 +215,8 @@ mod tests {
         let uuid = Uuid::new_v4();
         let now = Utc::now();
         let mut ops = Operations::new();
-        ops.add(Operation::Create { uuid });
-        ops.add(Operation::Update {
+        ops.push(Operation::Create { uuid });
+        ops.push(Operation::Update {
             uuid,
             property: String::from("title"),
             value: Some("my task".into()),
@@ -261,11 +261,11 @@ mod tests {
         }
 
         let mut ops = Operations::new();
-        ops.add(Operation::Create { uuid: uuid1 });
-        ops.add(Operation::Create { uuid: uuid2 });
-        ops.add(Operation::Create { uuid: uuid3 });
-        ops.add(Operation::Create { uuid: uuid2 });
-        ops.add(Operation::Create { uuid: uuid3 });
+        ops.push(Operation::Create { uuid: uuid1 });
+        ops.push(Operation::Create { uuid: uuid2 });
+        ops.push(Operation::Create { uuid: uuid3 });
+        ops.push(Operation::Create { uuid: uuid2 });
+        ops.push(Operation::Create { uuid: uuid3 });
 
         // return true for updates to uuid1 or uuid2.
         let add_to_working_set = |op: &Operation| match op {
@@ -298,11 +298,11 @@ mod tests {
     fn test_num_operations() {
         let mut db = TaskDb::new_inmemory();
         let mut ops = Operations::new();
-        ops.add(Operation::Create {
+        ops.push(Operation::Create {
             uuid: Uuid::new_v4(),
         });
-        ops.add(Operation::UndoPoint);
-        ops.add(Operation::Create {
+        ops.push(Operation::UndoPoint);
+        ops.push(Operation::Create {
             uuid: Uuid::new_v4(),
         });
         db.commit_operations(ops, |_| false).unwrap();
@@ -313,12 +313,12 @@ mod tests {
     fn test_num_undo_points() {
         let mut db = TaskDb::new_inmemory();
         let mut ops = Operations::new();
-        ops.add(Operation::UndoPoint);
+        ops.push(Operation::UndoPoint);
         db.commit_operations(ops, |_| false).unwrap();
         assert_eq!(db.num_undo_points().unwrap(), 1);
 
         let mut ops = Operations::new();
-        ops.add(Operation::UndoPoint);
+        ops.push(Operation::UndoPoint);
         db.commit_operations(ops, |_| false).unwrap();
         assert_eq!(db.num_undo_points().unwrap(), 2);
     }

--- a/taskchampion/src/taskdb/sync.rs
+++ b/taskchampion/src/taskdb/sync.rs
@@ -225,8 +225,8 @@ mod test {
         // make some changes in parallel to db1 and db2..
         let uuid1 = Uuid::new_v4();
         let mut ops = Operations::new();
-        ops.add(Operation::Create { uuid: uuid1 });
-        ops.add(Operation::Update {
+        ops.push(Operation::Create { uuid: uuid1 });
+        ops.push(Operation::Update {
             uuid: uuid1,
             property: "title".into(),
             value: Some("my first task".into()),
@@ -235,8 +235,8 @@ mod test {
         });
 
         let uuid2 = Uuid::new_v4();
-        ops.add(Operation::Create { uuid: uuid2 });
-        ops.add(Operation::Update {
+        ops.push(Operation::Create { uuid: uuid2 });
+        ops.push(Operation::Update {
             uuid: uuid2,
             property: "title".into(),
             value: Some("my second task".into()),
@@ -253,7 +253,7 @@ mod test {
 
         // now make updates to the same task on both sides
         let mut ops = Operations::new();
-        ops.add(Operation::Update {
+        ops.push(Operation::Update {
             uuid: uuid2,
             property: "priority".into(),
             value: Some("H".into()),
@@ -263,7 +263,7 @@ mod test {
         db1.commit_operations(ops, |_| false)?;
 
         let mut ops = Operations::new();
-        ops.add(Operation::Update {
+        ops.push(Operation::Update {
             uuid: uuid2,
             property: "project".into(),
             value: Some("personal".into()),
@@ -294,8 +294,8 @@ mod test {
         // create and update a task..
         let uuid = Uuid::new_v4();
         let mut ops = Operations::new();
-        ops.add(Operation::Create { uuid });
-        ops.add(Operation::Update {
+        ops.push(Operation::Create { uuid });
+        ops.push(Operation::Update {
             uuid,
             property: "title".into(),
             value: Some("my first task".into()),
@@ -312,12 +312,12 @@ mod test {
 
         // delete and re-create the task on db1
         let mut ops = Operations::new();
-        ops.add(Operation::Delete {
+        ops.push(Operation::Delete {
             uuid,
             old_task: TaskMap::new(),
         });
-        ops.add(Operation::Create { uuid });
-        ops.add(Operation::Update {
+        ops.push(Operation::Create { uuid });
+        ops.push(Operation::Update {
             uuid,
             property: "title".into(),
             value: Some("my second task".into()),
@@ -328,7 +328,7 @@ mod test {
 
         // and on db2, update a property of the task
         let mut ops = Operations::new();
-        ops.add(Operation::Update {
+        ops.push(Operation::Update {
             uuid,
             property: "project".into(),
             value: Some("personal".into()),
@@ -354,8 +354,8 @@ mod test {
 
         let uuid = Uuid::new_v4();
         let mut ops = Operations::new();
-        ops.add(Operation::Create { uuid });
-        ops.add(Operation::Update {
+        ops.push(Operation::Create { uuid });
+        ops.push(Operation::Update {
             uuid,
             property: "title".into(),
             value: Some("my first task".into()),
@@ -379,7 +379,7 @@ mod test {
 
         // update the taskdb and sync again
         let mut ops = Operations::new();
-        ops.add(Operation::Update {
+        ops.push(Operation::Update {
             uuid,
             property: "title".into(),
             value: Some("my first task, updated".into()),
@@ -412,7 +412,7 @@ mod test {
 
         let uuid = Uuid::new_v4();
         let mut ops = Operations::new();
-        ops.add(Operation::Create { uuid });
+        ops.push(Operation::Create { uuid });
         db1.commit_operations(ops, |_| false)?;
 
         test_server.set_snapshot_urgency(SnapshotUrgency::Low);
@@ -437,8 +437,8 @@ mod test {
         // add a task to db
         let uuid1 = Uuid::new_v4();
         let mut ops = Operations::new();
-        ops.add(Operation::Create { uuid: uuid1 });
-        ops.add(Operation::Update {
+        ops.push(Operation::Create { uuid: uuid1 });
+        ops.push(Operation::Update {
             uuid: uuid1,
             property: "title".into(),
             value: Some("my first task".into()),
@@ -456,7 +456,7 @@ mod test {
         // add some large operations to db
         let mut ops = Operations::new();
         for _ in 0..3 {
-            ops.add(Operation::Update {
+            ops.push(Operation::Update {
                 uuid: uuid1,
                 property: "description".into(),
                 value: Some(data.iter().collect()),
@@ -485,8 +485,8 @@ mod test {
         // add a task to db
         let uuid1 = Uuid::new_v4();
         let mut ops = Operations::new();
-        ops.add(Operation::Create { uuid: uuid1 });
-        ops.add(Operation::Update {
+        ops.push(Operation::Create { uuid: uuid1 });
+        ops.push(Operation::Update {
             uuid: uuid1,
             property: "title".into(),
             value: Some("my first task".into()),
@@ -501,7 +501,7 @@ mod test {
         // add an operation greater than the batch limit
         let data = vec!['a'; 1000001];
         let mut ops = Operations::new();
-        ops.add(Operation::Update {
+        ops.push(Operation::Update {
             uuid: uuid1,
             property: "description".into(),
             value: Some(data.iter().collect()),

--- a/taskchampion/src/taskdb/working_set.rs
+++ b/taskchampion/src/taskdb/working_set.rs
@@ -96,10 +96,10 @@ mod test {
         // add everything to the TaskDb
         let mut ops = Operations::new();
         for uuid in &uuids {
-            ops.add(Operation::Create { uuid: *uuid });
+            ops.push(Operation::Create { uuid: *uuid });
         }
         for i in &[0usize, 1, 4] {
-            ops.add(Operation::Update {
+            ops.push(Operation::Update {
                 uuid: uuids[*i],
                 property: String::from("status"),
                 value: Some("pending".into()),


### PR DESCRIPTION
Exposing the full functionality of a Vec here is more useful than utility functions on a newtype, especially when building a Cxx bridge.

This is a big diff, but aside from the main change in `operation.rs`, consists almost entirely of changing `ops.add` to `ops.push`, with a few related test changes.

This will be the last change for #372, and without objection I will release 0.7.0 when this is merged.