### PR TITLE
Expose sqlite bundling as a feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ proptest = "^1.5.0"
 regex = "^1.10.2"
 ring = "0.17"
 rstest = "0.17"
-rusqlite = { version = "0.29", features = ["bundled"] }
+rusqlite = { version = "0.29"}
 serde_json = "^1.0"
 serde = { version = "^1.0.147", features = ["derive"] }
 strum = "0.25"

--- a/taskchampion/Cargo.toml
+++ b/taskchampion/Cargo.toml
@@ -12,8 +12,10 @@ edition = "2021"
 rust-version = "1.70.0"
 
 [features]
-default = ["server-sync", "server-gcp"]
+default = ["sync", "bundled"]
 
+# Support for all sync solutions
+sync = ["server-sync", "server-gcp"]
 # Support for sync to a server
 server-sync = ["encryption", "dep:ureq", "dep:url"]
 # Support for sync to GCP
@@ -22,6 +24,8 @@ server-gcp = ["cloud", "encryption", "dep:google-cloud-storage", "dep:tokio"]
 encryption = ["dep:ring"]
 # (private) Generic support for cloud sync
 cloud = []
+# static bundling of dependencies
+bundled = ["rusqlite/bundled"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/taskchampion/src/lib.rs
+++ b/taskchampion/src/lib.rs
@@ -38,10 +38,12 @@ Users can define their own server impelementations.
 
 Support for some optional functionality is controlled by feature flags.
 
-Sync server client support:
-
  * `server-gcp` - sync to Google Cloud Platform
  * `server-sync` - sync to the taskchampion-sync-server
+ * `sync` - enables all of the sync features above
+ * `bundled` - activates bundling system libraries like sqlite
+
+ By default, `sync` and `bundled` are enabled.
 
 # See Also
 


### PR DESCRIPTION
Linux distributions usually don't want the libraries to be statically linked. Before the repos for taskchampion and taskwarrior were split, it was easy to get rid of the bundled sqlite by patching, but with taskchampion moved to a separate repository this became more complicated.

I do get why you want to default to bundling sqlite, so I made it so that the default behaviour is still that it's being bundled.
