### PR TITLE
docs(tasks.md): fix broken emphasis

### DIFF
--- a/docs/src/tasks.md
+++ b/docs/src/tasks.md
@@ -5,7 +5,7 @@ Display layers should apply appropriate defaults where necessary.
 
 ## Validity
 
-Any_ key/value map is a valid task, including an empty task.
+_Any_ key/value map is a valid task, including an empty task.
 Consumers of task data must make a best effort to interpret any map, even if it contains apparently contradictory information.
 For example, a task with status "completed" but no "end" key present should be interpreted as completed at an unknown time.
 


### PR DESCRIPTION
In commit 2ab47269afebb8a541c71b180bfb5d16857b29a8 the emphasis for this word was broken. It currently appears as a single underscore on the published book website.

![image](https://github.com/user-attachments/assets/03cb96fa-95cc-4bd1-a01e-9f62ce04a17a)
