### PR TITLE
Add `get_task_operations`

### DIFF
--- a/taskchampion/src/replica.rs
+++ b/taskchampion/src/replica.rs
@@ -194,12 +194,21 @@ impl Replica {
             .map(move |tm| Task::new(TaskData::new(uuid, tm), depmap)))
     }
 
-    /// get an existing task by its UUID, as a [`TaskData`](crate::TaskData).
+    /// Get an existing task by its UUID, as a [`TaskData`](crate::TaskData).
     pub fn get_task_data(&mut self, uuid: Uuid) -> Result<Option<TaskData>> {
         Ok(self
             .taskdb
             .get_task(uuid)?
             .map(move |tm| TaskData::new(uuid, tm)))
+    }
+
+    /// Get the operations that led to the given task.
+    ///
+    /// Note: the returned set of operations is not guaranteed to be sufficient to reconstruct the
+    /// task; that is, it may not begin with a `Create` operation. This can occur if the task was
+    /// created using a TaskChampion version before 0.8.0 or if older operations have been deleted.
+    pub fn get_task_operations(&mut self, uuid: Uuid) -> Result<Operations> {
+        self.taskdb.get_task_operations(uuid)
     }
 
     /// Create a new task, setting `modified`, `description`, `status`, and `entry`.
@@ -442,10 +451,42 @@ impl Replica {
 mod tests {
     use super::*;
     use crate::task::Status;
-    use chrono::TimeZone;
+    use chrono::{DateTime, TimeZone};
     use pretty_assertions::assert_eq;
     use std::collections::HashSet;
     use uuid::Uuid;
+
+    const JUST_NOW: Option<DateTime<Utc>> = DateTime::from_timestamp(1800000000, 0);
+
+    /// Rewrite automatically-created dates to "just-now" or `JUST_NOW` for ease of testing.
+    fn clean_op(op: Operation) -> Operation {
+        if let Operation::Update {
+            uuid,
+            property,
+            mut old_value,
+            mut value,
+            ..
+        } = op
+        {
+            if property == "modified" || property == "end" || property == "entry" {
+                if value.is_some() {
+                    value = Some("just-now".into());
+                }
+                if old_value.is_some() {
+                    old_value = Some("just-now".into());
+                }
+            }
+            Operation::Update {
+                uuid,
+                property,
+                old_value,
+                value,
+                timestamp: JUST_NOW.unwrap(),
+            }
+        } else {
+            op
+        }
+    }
 
     #[test]
     fn new_task() {
@@ -487,37 +528,6 @@ mod tests {
 
         // and check for the corresponding operations, cleaning out the timestamps
         // and modified properties as these are based on the current time
-        let now = Utc::now();
-        let clean_op = |op: Operation| {
-            if let Operation::Update {
-                uuid,
-                property,
-                mut old_value,
-                mut value,
-                ..
-            } = op
-            {
-                // rewrite automatically-created dates to "just-now" for ease
-                // of testing
-                if property == "modified" || property == "end" || property == "entry" {
-                    if value.is_some() {
-                        value = Some("just-now".into());
-                    }
-                    if old_value.is_some() {
-                        old_value = Some("just-now".into());
-                    }
-                }
-                Operation::Update {
-                    uuid,
-                    property,
-                    old_value,
-                    value,
-                    timestamp: now,
-                }
-            } else {
-                op
-            }
-        };
         assert_eq!(
             rep.taskdb
                 .operations()
@@ -532,56 +542,56 @@ mod tests {
                     property: "modified".into(),
                     old_value: None,
                     value: Some("just-now".into()),
-                    timestamp: now,
+                    timestamp: JUST_NOW.unwrap(),
                 },
                 Operation::Update {
                     uuid: t.get_uuid(),
                     property: "description".into(),
                     old_value: None,
                     value: Some("a task".into()),
-                    timestamp: now,
+                    timestamp: JUST_NOW.unwrap(),
                 },
                 Operation::Update {
                     uuid: t.get_uuid(),
                     property: "status".into(),
                     old_value: None,
                     value: Some("pending".into()),
-                    timestamp: now,
+                    timestamp: JUST_NOW.unwrap(),
                 },
                 Operation::Update {
                     uuid: t.get_uuid(),
                     property: "entry".into(),
                     old_value: None,
                     value: Some("just-now".into()),
-                    timestamp: now,
+                    timestamp: JUST_NOW.unwrap(),
                 },
                 Operation::Update {
                     uuid: t.get_uuid(),
                     property: "modified".into(),
                     old_value: Some("just-now".into()),
                     value: Some("just-now".into()),
-                    timestamp: now,
+                    timestamp: JUST_NOW.unwrap(),
                 },
                 Operation::Update {
                     uuid: t.get_uuid(),
                     property: "description".into(),
                     old_value: Some("a task".into()),
                     value: Some("past tense".into()),
-                    timestamp: now,
+                    timestamp: JUST_NOW.unwrap(),
                 },
                 Operation::Update {
                     uuid: t.get_uuid(),
                     property: "end".into(),
                     old_value: None,
                     value: Some("just-now".into()),
-                    timestamp: now,
+                    timestamp: JUST_NOW.unwrap(),
                 },
                 Operation::Update {
                     uuid: t.get_uuid(),
                     property: "status".into(),
                     old_value: Some("pending".into()),
                     value: Some("completed".into()),
-                    timestamp: now,
+                    timestamp: JUST_NOW.unwrap(),
                 },
             ]
         );
@@ -779,20 +789,49 @@ mod tests {
     }
 
     #[test]
-    fn get_task_data() {
+    fn get_task_data_and_operations() {
         let mut rep = Replica::new_inmemory();
 
-        let uuid = Uuid::new_v4();
+        let uuid1 = Uuid::new_v4();
+        let uuid2 = Uuid::new_v4();
         let mut ops = Operations::new();
-        let mut t = rep.create_task(uuid, &mut ops).unwrap();
+        let mut t = rep.create_task(uuid1, &mut ops).unwrap();
         t.set_description("another task".into(), &mut ops).unwrap();
+        let mut t2 = rep.create_task(uuid2, &mut ops).unwrap();
+        t2.set_description("a distraction!".into(), &mut ops)
+            .unwrap();
         rep.commit_operations(ops).unwrap();
 
-        let t = rep.get_task_data(uuid).unwrap().unwrap();
-        assert_eq!(t.get_uuid(), uuid);
+        let t = rep.get_task_data(uuid1).unwrap().unwrap();
+        assert_eq!(t.get_uuid(), uuid1);
         assert_eq!(t.get("description"), Some("another task"));
+        assert_eq!(
+            rep.get_task_operations(uuid1)
+                .unwrap()
+                .into_iter()
+                .map(clean_op)
+                .collect::<Vec<_>>(),
+            vec![
+                Operation::Create { uuid: uuid1 },
+                Operation::Update {
+                    uuid: uuid1,
+                    property: "modified".into(),
+                    old_value: None,
+                    value: Some("just-now".into()),
+                    timestamp: JUST_NOW.unwrap(),
+                },
+                Operation::Update {
+                    uuid: uuid1,
+                    property: "description".into(),
+                    old_value: None,
+                    value: Some("another task".into()),
+                    timestamp: JUST_NOW.unwrap(),
+                },
+            ]
+        );
 
         assert!(rep.get_task_data(Uuid::new_v4()).unwrap().is_none());
+        assert_eq!(rep.get_task_operations(Uuid::new_v4()).unwrap(), vec![]);
     }
 
     #[test]

--- a/taskchampion/src/storage/inmemory.rs
+++ b/taskchampion/src/storage/inmemory.rs
@@ -89,6 +89,21 @@ impl<'t> StorageTxn for Txn<'t> {
         Ok(())
     }
 
+    fn get_task_operations(&mut self, uuid: Uuid) -> Result<Vec<Operation>> {
+        Ok(self
+            .data_ref()
+            .operations
+            .iter()
+            .filter(|op| match op {
+                Operation::Create { uuid: u } => *u == uuid,
+                Operation::Delete { uuid: u, .. } => *u == uuid,
+                Operation::Update { uuid: u, .. } => *u == uuid,
+                Operation::UndoPoint => false,
+            })
+            .cloned()
+            .collect())
+    }
+
     fn operations(&mut self) -> Result<Vec<Operation>> {
         Ok(self.data_ref().operations.clone())
     }

--- a/taskchampion/src/storage/mod.rs
+++ b/taskchampion/src/storage/mod.rs
@@ -84,6 +84,9 @@ pub trait StorageTxn {
     /// Set the current base_version for this storage.
     fn set_base_version(&mut self, version: VersionId) -> Result<()>;
 
+    /// Get the set of operations for the given task.
+    fn get_task_operations(&mut self, uuid: Uuid) -> Result<Vec<Operation>>;
+
     /// Get the current set of outstanding operations (operations that have not been sync'd to the
     /// server yet)
     fn operations(&mut self) -> Result<Vec<Operation>>;

--- a/taskchampion/src/storage/sqlite.rs
+++ b/taskchampion/src/storage/sqlite.rs
@@ -279,6 +279,22 @@ impl<'t> StorageTxn for Txn<'t> {
         Ok(())
     }
 
+    fn get_task_operations(&mut self, uuid: Uuid) -> Result<Vec<Operation>> {
+        let t = self.get_txn()?;
+
+        let mut q = t.prepare("SELECT data FROM operations where uuid=? ORDER BY id ASC")?;
+        let rows = q.query_map([&StoredUuid(uuid)], |r| {
+            let data: Operation = r.get("data")?;
+            Ok(data)
+        })?;
+
+        let mut ret = vec![];
+        for r in rows {
+            ret.push(r?);
+        }
+        Ok(ret)
+    }
+
     fn operations(&mut self) -> Result<Vec<Operation>> {
         let t = self.get_txn()?;
 
@@ -906,6 +922,71 @@ mod test {
             );
             assert_eq!(txn.num_operations()?, 4);
         }
+        Ok(())
+    }
+
+    #[test]
+    fn test_task_operations() -> Result<()> {
+        let tmp_dir = TempDir::new()?;
+        let mut storage = SqliteStorage::new(tmp_dir.path(), true)?;
+        let uuid1 = Uuid::new_v4();
+        let uuid2 = Uuid::new_v4();
+        let uuid3 = Uuid::new_v4();
+        let now = Utc::now();
+
+        // create some operations
+        {
+            let mut txn = storage.txn()?;
+            txn.add_operation(Operation::UndoPoint)?;
+            txn.add_operation(Operation::Create { uuid: uuid1 })?;
+            txn.add_operation(Operation::Create { uuid: uuid1 })?;
+            txn.add_operation(Operation::UndoPoint)?;
+            txn.add_operation(Operation::Delete {
+                uuid: uuid2,
+                old_task: TaskMap::new(),
+            })?;
+            txn.add_operation(Operation::Update {
+                uuid: uuid3,
+                property: "p".into(),
+                old_value: None,
+                value: Some("P".into()),
+                timestamp: now,
+            })?;
+            txn.commit()?;
+        }
+
+        // read them back
+        {
+            let mut txn = storage.txn()?;
+            let ops = txn.get_task_operations(uuid1)?;
+            assert_eq!(
+                ops,
+                vec![
+                    Operation::Create { uuid: uuid1 },
+                    Operation::Create { uuid: uuid1 },
+                ]
+            );
+            let ops = txn.get_task_operations(uuid2)?;
+            assert_eq!(
+                ops,
+                vec![Operation::Delete {
+                    uuid: uuid2,
+                    old_task: TaskMap::new()
+                }]
+            );
+            let ops = txn.get_task_operations(uuid3)?;
+            assert_eq!(
+                ops,
+                vec![Operation::Update {
+                    uuid: uuid3,
+                    property: "p".into(),
+                    old_value: None,
+                    value: Some("P".into()),
+                    timestamp: now,
+                }]
+            );
+        }
+
         Ok(())
     }
 

--- a/taskchampion/src/taskdb/mod.rs
+++ b/taskchampion/src/taskdb/mod.rs
@@ -105,6 +105,11 @@ impl TaskDb {
         txn.get_task(uuid)
     }
 
+    pub(crate) fn get_task_operations(&mut self, uuid: Uuid) -> Result<Operations> {
+        let mut txn = self.storage.txn()?;
+        txn.get_task_operations(uuid)
+    }
+
     /// Rebuild the working set using a function to identify tasks that should be in the set.  This
     /// renumbers the existing working-set tasks to eliminate gaps, and also adds any tasks that
     /// are not already in the working set but should be.  The rebuild occurs in a single


### PR DESCRIPTION
Thread this method through from Replica, via TaskDB, to Storage.

This is the next step in #373.