### PR TITLE
Replace `Storage::set_operations` with `sync_complete` and `remove_operation`.`

### DIFF
--- a/taskchampion/src/storage/inmemory.rs
+++ b/taskchampion/src/storage/inmemory.rs
@@ -117,8 +117,20 @@ impl<'t> StorageTxn for Txn<'t> {
         Ok(())
     }
 
-    fn set_operations(&mut self, ops: Vec<Operation>) -> Result<()> {
-        self.mut_data_ref().operations = ops;
+    fn remove_operation(&mut self, op: Operation) -> Result<()> {
+        let last_op = self.data_ref().operations.last();
+        if last_op != Some(&op) {
+            return Err(Error::Database(
+                "Last operation does not match -- cannot remove".to_string(),
+            ));
+        }
+
+        self.mut_data_ref().operations.pop();
+        Ok(())
+    }
+
+    fn sync_complete(&mut self) -> Result<()> {
+        self.mut_data_ref().operations = Vec::new();
         Ok(())
     }
 

--- a/taskchampion/src/storage/mod.rs
+++ b/taskchampion/src/storage/mod.rs
@@ -99,8 +99,14 @@ pub trait StorageTxn {
     /// merely *stores* the operation; it is up to the TaskDb to apply it.
     fn add_operation(&mut self, op: Operation) -> Result<()>;
 
-    /// Replace the current list of operations with a new list.
-    fn set_operations(&mut self, ops: Vec<Operation>) -> Result<()>;
+    /// Remove an operation from the end of the list of operations in the storage.  The operation
+    /// must exactly match the most recent operation. Note that like `add_operation` this only
+    /// affects the list of operations.
+    fn remove_operation(&mut self, op: Operation) -> Result<()>;
+
+    /// A sync has been completed, so all operations should be marked as synced. The storage
+    /// may perform additional cleanup at this time.
+    fn sync_complete(&mut self) -> Result<()>;
 
     /// Get the entire working set, with each task UUID at its appropriate (1-based) index.
     /// Element 0 is always None.

--- a/taskchampion/src/taskdb/sync.rs
+++ b/taskchampion/src/taskdb/sync.rs
@@ -129,7 +129,7 @@ pub(super) fn sync(
         }
     }
 
-    txn.set_operations(vec![])?;
+    txn.sync_complete()?;
     txn.commit()?;
     Ok(())
 }

--- a/taskchampion/src/taskdb/undo.rs
+++ b/taskchampion/src/taskdb/undo.rs
@@ -68,26 +68,32 @@ fn reverse_ops(op: Operation) -> Vec<SyncOp> {
 /// have not yet been synchronized, and will return `false` if this is not the case.
 pub fn commit_reversed_operations(txn: &mut dyn StorageTxn, undo_ops: Operations) -> Result<bool> {
     let mut applied = false;
-    let mut local_ops = txn.operations().unwrap();
+    let local_ops = txn.operations().unwrap();
     let mut undo_ops = undo_ops.to_vec();
 
-    // Drop undo_ops iff they're the latest operations.
+    if undo_ops.is_empty() {
+        return Ok(false);
+    }
+
     // TODO Support concurrent undo by adding the reverse of undo_ops rather than popping from operations.
-    let old_len = local_ops.len();
-    let undo_len = undo_ops.len();
-    let new_len = old_len - undo_len;
-    let local_undo_ops = &local_ops[new_len..old_len];
-    if local_undo_ops != undo_ops {
+
+    // Verify that undo_ops are the most recent local ops.
+    let mut ok = false;
+    let local_undo_ops;
+    if undo_ops.len() <= local_ops.len() {
+        let new_len = local_ops.len() - undo_ops.len();
+        local_undo_ops = &local_ops[new_len..];
+        if local_undo_ops == undo_ops {
+            ok = true;
+        }
+    }
+    if !ok {
         info!("Undo failed: concurrent changes to the database occurred.");
-        debug!(
-            "local_undo_ops={:#?}\nundo_ops={:#?}",
-            local_undo_ops, undo_ops
-        );
+        debug!("local_ops={:#?}\nundo_ops={:#?}", local_ops, undo_ops);
         return Ok(applied);
     }
-    undo_ops.reverse();
-    local_ops.truncate(new_len);
 
+    undo_ops.reverse();
     for op in undo_ops {
         debug!("Reversing operation {:?}", op);
         let rev_ops = reverse_ops(op.clone());
@@ -99,9 +105,7 @@ pub fn commit_reversed_operations(txn: &mut dyn StorageTxn, undo_ops: Operations
         txn.remove_operation(op)?;
     }
 
-    if undo_len != 0 {
-        txn.commit()?;
-    }
+    txn.commit()?;
 
     Ok(applied)
 }

--- a/taskchampion/src/taskdb/undo.rs
+++ b/taskchampion/src/taskdb/undo.rs
@@ -90,16 +90,16 @@ pub fn commit_reversed_operations(txn: &mut dyn StorageTxn, undo_ops: Operations
 
     for op in undo_ops {
         debug!("Reversing operation {:?}", op);
-        let rev_ops = reverse_ops(op);
+        let rev_ops = reverse_ops(op.clone());
         for op in rev_ops {
             trace!("Applying reversed operation {:?}", op);
             apply::apply_op(txn, &op)?;
             applied = true;
         }
+        txn.remove_operation(op)?;
     }
 
     if undo_len != 0 {
-        txn.set_operations(local_ops)?;
         txn.commit()?;
     }
 


### PR DESCRIPTION
When #373 is complete, we will be keeping the set of operations around, so clearing it or setting it to a specific set of operations no longer makes sense. Instead, we push or pop operations, and track when the current set of operations has been synced.