### PR TITLE
implement Replica::pending_tasks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ proptest = "^1.5.0"
 regex = "^1.10.2"
 ring = "0.17"
 rstest = "0.17"
-rusqlite = { version = "0.29", features = ["array", "bundled"] }
+rusqlite = { version = "0.29"}
 serde_json = "^1.0"
 serde = { version = "^1.0.147", features = ["derive"] }
 strum = "0.25"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ proptest = "^1.5.0"
 regex = "^1.10.2"
 ring = "0.17"
 rstest = "0.17"
-rusqlite = { version = "0.29"}
+rusqlite = { version = "0.29", features = ["array", "bundled"] }
 serde_json = "^1.0"
 serde = { version = "^1.0.147", features = ["derive"] }
 strum = "0.25"

--- a/taskchampion/src/replica.rs
+++ b/taskchampion/src/replica.rs
@@ -119,15 +119,9 @@ impl Replica {
     }
 
     pub fn pending_task_data(&mut self) -> Result<Vec<TaskData>> {
-        let uuids = self
-            .working_set()?
-            .iter()
-            .map(|(_, uuid)| uuid)
-            .collect::<Vec<Uuid>>();
-
         let res = self
             .taskdb
-            .get_tasks(uuids)?
+            .get_pending_tasks()?
             .into_iter()
             .map(|(uuid, taskmap)| TaskData::new(uuid, taskmap))
             .collect::<Vec<_>>();

--- a/taskchampion/src/replica.rs
+++ b/taskchampion/src/replica.rs
@@ -679,10 +679,10 @@ mod tests {
 
         rep.commit_operations(ops).unwrap();
 
-        let all_tasks = rep.pending_tasks().unwrap();
-        assert_eq!(all_tasks.len(), 2);
-        assert_eq!(all_tasks.get(0).unwrap().get_uuid(), uuid1);
-        assert_eq!(all_tasks.get(1).unwrap().get_uuid(), uuid2);
+        let pending_tasks = rep.pending_tasks().unwrap();
+        assert_eq!(pending_tasks.len(), 2);
+        assert_eq!(pending_tasks.get(0).unwrap().get_uuid(), uuid1);
+        assert_eq!(pending_tasks.get(1).unwrap().get_uuid(), uuid2);
     }
 
     #[test]

--- a/taskchampion/src/storage/inmemory.rs
+++ b/taskchampion/src/storage/inmemory.rs
@@ -54,6 +54,10 @@ impl<'t> StorageTxn for Txn<'t> {
             .get_working_set()?
             .iter()
             .filter_map(|uuid| {
+                // Since uuid is wrapped in an Option and get(&inner_uuid)
+                // also returns an Option, the resulting type will be
+                // Option<Option<(Uuid, TaskMap)>>. To turn that into
+                // an Option<(Uuid, TaskMap)>, flatten is called
                 uuid.map(|inner_uuid| {
                     self.data_ref()
                         .tasks

--- a/taskchampion/src/storage/inmemory.rs
+++ b/taskchampion/src/storage/inmemory.rs
@@ -49,6 +49,20 @@ impl<'t> StorageTxn for Txn<'t> {
         }
     }
 
+    fn get_tasks(&mut self, uuids: Vec<Uuid>) -> Result<Vec<(Uuid, TaskMap)>> {
+        let res = uuids
+            .iter()
+            .filter_map(|uuid| {
+                self.data_ref()
+                    .tasks
+                    .get(uuid)
+                    .map(|taskmap| (*uuid, taskmap.clone()))
+            })
+            .collect::<Vec<_>>();
+
+        Ok(res)
+    }
+
     fn create_task(&mut self, uuid: Uuid) -> Result<bool> {
         if let ent @ Entry::Vacant(_) = self.mut_data_ref().tasks.entry(uuid) {
             ent.or_insert_with(TaskMap::new);

--- a/taskchampion/src/storage/inmemory.rs
+++ b/taskchampion/src/storage/inmemory.rs
@@ -49,14 +49,18 @@ impl<'t> StorageTxn for Txn<'t> {
         }
     }
 
-    fn get_tasks(&mut self, uuids: Vec<Uuid>) -> Result<Vec<(Uuid, TaskMap)>> {
-        let res = uuids
+    fn get_pending_tasks(&mut self) -> Result<Vec<(Uuid, TaskMap)>> {
+        let res = self
+            .get_working_set()?
             .iter()
             .filter_map(|uuid| {
-                self.data_ref()
-                    .tasks
-                    .get(uuid)
-                    .map(|taskmap| (*uuid, taskmap.clone()))
+                uuid.map(|inner_uuid| {
+                    self.data_ref()
+                        .tasks
+                        .get(&inner_uuid)
+                        .map(|taskmap| (inner_uuid, taskmap.clone()))
+                })
+                .flatten()
             })
             .collect::<Vec<_>>();
 

--- a/taskchampion/src/storage/mod.rs
+++ b/taskchampion/src/storage/mod.rs
@@ -64,8 +64,8 @@ pub trait StorageTxn {
     /// Get an (immutable) task, if it is in the storage
     fn get_task(&mut self, uuid: Uuid) -> Result<Option<TaskMap>>;
 
-    /// Get a vector of (immutable) tasks, if they are in the storage
-    fn get_tasks(&mut self, uuids: Vec<Uuid>) -> Result<Vec<(Uuid, TaskMap)>>;
+    /// Get a vector of all pending tasks from the working_set
+    fn get_pending_tasks(&mut self) -> Result<Vec<(Uuid, TaskMap)>>;
 
     /// Create an (empty) task, only if it does not already exist.  Returns true if
     /// the task was created (did not already exist).

--- a/taskchampion/src/storage/mod.rs
+++ b/taskchampion/src/storage/mod.rs
@@ -64,6 +64,9 @@ pub trait StorageTxn {
     /// Get an (immutable) task, if it is in the storage
     fn get_task(&mut self, uuid: Uuid) -> Result<Option<TaskMap>>;
 
+    /// Get a vector of (immutable) tasks, if they are in the storage
+    fn get_tasks(&mut self, uuids: Vec<Uuid>) -> Result<Vec<(Uuid, TaskMap)>>;
+
     /// Create an (empty) task, only if it does not already exist.  Returns true if
     /// the task was created (did not already exist).
     fn create_task(&mut self, uuid: Uuid) -> Result<bool>;

--- a/taskchampion/src/storage/sqlite.rs
+++ b/taskchampion/src/storage/sqlite.rs
@@ -94,9 +94,6 @@ impl SqliteStorage {
         }
         let con = Connection::open_with_flags(db_file, flags)?;
 
-        // Load the rarray module so it's possible to run vectorized queries
-        rusqlite::vtab::array::load_module(&con)?;
-
         // Initialize database
         con.query_row("PRAGMA journal_mode=WAL", [], |_row| Ok(()))
             .context("Setting journal_mode=WAL")?;
@@ -188,17 +185,13 @@ impl<'t> StorageTxn for Txn<'t> {
         Ok(result.map(|t| t.0))
     }
 
-    fn get_tasks(&mut self, uuids: Vec<Uuid>) -> Result<Vec<(Uuid, TaskMap)>> {
+    fn get_pending_tasks(&mut self) -> Result<Vec<(Uuid, TaskMap)>> {
         let t = self.get_txn()?;
 
-        let stored_uuids = uuids
-            .into_iter()
-            .map(|uuid| rusqlite::types::Value::from(uuid.to_string()))
-            .collect::<Vec<_>>();
-        let ptr = std::rc::Rc::new(stored_uuids);
-
-        let mut q = t.prepare("SELECT uuid, data FROM tasks WHERE uuid IN rarray(?1)")?;
-        let rows = q.query_map([&ptr], |r| {
+        let mut q = t.prepare(
+            "SELECT tasks.* FROM tasks LEFT JOIN working_set ON tasks.uuid = working_set.uuid",
+        )?;
+        let rows = q.query_map([], |r| {
             let uuid: StoredUuid = r.get("uuid")?;
             let data: StoredTaskMap = r.get("data")?;
             Ok((uuid.0, data.0))

--- a/taskchampion/src/storage/sqlite.rs
+++ b/taskchampion/src/storage/sqlite.rs
@@ -189,7 +189,7 @@ impl<'t> StorageTxn for Txn<'t> {
         let t = self.get_txn()?;
 
         let mut q = t.prepare(
-            "SELECT tasks.* FROM tasks LEFT JOIN working_set ON tasks.uuid = working_set.uuid",
+            "SELECT tasks.* FROM tasks JOIN working_set ON tasks.uuid = working_set.uuid",
         )?;
         let rows = q.query_map([], |r| {
             let uuid: StoredUuid = r.get("uuid")?;

--- a/taskchampion/src/storage/test.rs
+++ b/taskchampion/src/storage/test.rs
@@ -273,18 +273,17 @@ pub(super) fn delete_task_exists(mut storage: impl Storage) -> Result<()> {
 }
 
 pub(super) fn get_pending_tasks(mut storage: impl Storage) -> Result<()> {
-    let uuid1 = Uuid::new_v4();
-    let uuid2 = Uuid::new_v4();
+    let uuid1 = Uuid::new_v4(); // in working set
+    let uuid2 = Uuid::new_v4(); // in working set
+    let uuid3 = Uuid::new_v4(); // in working set but does not exist
+    let uuid4 = Uuid::new_v4(); // not in working set but exists= Uuid::new_v4();
 
     {
         let mut txn = storage.txn()?;
         txn.add_to_working_set(uuid1)?;
         txn.add_to_working_set(uuid2)?;
-        txn.commit()?;
-    }
+        txn.add_to_working_set(uuid3)?;
 
-    {
-        let mut txn = storage.txn()?;
         assert!(txn.create_task(uuid1)?);
         txn.set_task(
             uuid1,
@@ -294,6 +293,11 @@ pub(super) fn get_pending_tasks(mut storage: impl Storage) -> Result<()> {
         txn.set_task(
             uuid2,
             taskmap_with(vec![("num".to_string(), "2".to_string())]),
+        )?;
+        assert!(txn.create_task(uuid4)?);
+        txn.set_task(
+            uuid4,
+            taskmap_with(vec![("num".to_string(), "4".to_string())]),
         )?;
         txn.commit()?;
     }

--- a/taskchampion/src/storage/test.rs
+++ b/taskchampion/src/storage/test.rs
@@ -276,7 +276,7 @@ pub(super) fn get_pending_tasks(mut storage: impl Storage) -> Result<()> {
     let uuid1 = Uuid::new_v4(); // in working set
     let uuid2 = Uuid::new_v4(); // in working set
     let uuid3 = Uuid::new_v4(); // in working set but does not exist
-    let uuid4 = Uuid::new_v4(); // not in working set but exists= Uuid::new_v4();
+    let uuid4 = Uuid::new_v4(); // not in working set but exists
 
     {
         let mut txn = storage.txn()?;

--- a/taskchampion/src/taskdb/mod.rs
+++ b/taskchampion/src/taskdb/mod.rs
@@ -105,10 +105,10 @@ impl TaskDb {
         txn.get_task(uuid)
     }
 
-    /// Get multiple tasks by uuid.
-    pub(crate) fn get_tasks(&mut self, uuids: Vec<Uuid>) -> Result<Vec<(Uuid, TaskMap)>> {
+    /// Get all pending tasks from the working set
+    pub(crate) fn get_pending_tasks(&mut self) -> Result<Vec<(Uuid, TaskMap)>> {
         let mut txn = self.storage.txn()?;
-        txn.get_tasks(uuids)
+        txn.get_pending_tasks()
     }
 
     pub(crate) fn get_task_operations(&mut self, uuid: Uuid) -> Result<Operations> {

--- a/taskchampion/src/taskdb/mod.rs
+++ b/taskchampion/src/taskdb/mod.rs
@@ -105,6 +105,12 @@ impl TaskDb {
         txn.get_task(uuid)
     }
 
+    /// Get multiple tasks by uuid.
+    pub(crate) fn get_tasks(&mut self, uuids: Vec<Uuid>) -> Result<Vec<(Uuid, TaskMap)>> {
+        let mut txn = self.storage.txn()?;
+        txn.get_tasks(uuids)
+    }
+
     pub(crate) fn get_task_operations(&mut self, uuid: Uuid) -> Result<Operations> {
         let mut txn = self.storage.txn()?;
         txn.get_task_operations(uuid)


### PR DESCRIPTION
This is a first attempt at #452. 

I've implemented two different approaches in the storage layer and I'm looking for feedback on whether either of these, or a third approach, would be most optimal. 

Currently the `taskdb` layer use the more "naive" approach, which follows the original c++ code more closely. 

The alternative approach would use the `get_tasks_by_status` to query for `pending` tasks. I am however not sure whether there could potentially be an inconsistency between the `working_set` and the sqlite database, which would make that solution unfeasible.

