### PR TITLE
Set up to use cargo-semver-checks on PRs and releases

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -101,3 +101,10 @@ jobs:
           command: fmt
           args: --all -- --check
 
+
+  semver-checks:
+    runs-on: ubuntu-latest
+    name: "Cargo Semver Checks"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: obi1kenobi/cargo-semver-checks-action@v2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,3 +49,6 @@ You can generate the documentation for the `taskchampion` crate with `cargo doc 
 We expect contributors to follow the [GitHub Flow](https://guides.github.com/introduction/flow/).
 Aside from that, we have no particular requirements on pull requests.
 Make your patch, double-check that it's complete (tests? docs? documentation comments?), and make a new pull request.
+
+If your pull request makes a breaking change, then `Cargo Semver Checks` check may fail.
+If this change is intentional, update the version accordingly in `taskchampion/Cargo.toml` (maintaining the `-pre` suffix), and the check should succeed.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1590,7 +1590,7 @@ dependencies = [
 
 [[package]]
 name = "taskchampion"
-version = "0.7.0"
+version = "0.8.0-pre"
 dependencies = [
  "anyhow",
  "byteorder",

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -3,11 +3,14 @@
 1. Run `git pull upstream main`
 1. Run `cargo test`
 1. Run `cargo clean && cargo clippy`
+1. Remove the `-pre` from `version` in `taskchampion/Cargo.toml`.
+1. Run `cargo semver-checks` (https://crates.io/crates/cargo-semver-checks)
 1. Run `mdbook test docs`
-1. Update `version` in `*/Cargo.toml`.  All versions should match.
-1. Run `cargo build --release -p taskchampion` and `-p taskchampion-lib`.
+1. Run `cargo build --release -p taskchampion`
 1. Commit the changes (Cargo.lock will change too) with comment `vX.Y.Z`.
 1. Run `git tag vX.Y.Z`
+1. Bump the patch version in `taskchampion/Cargo.toml` and add the `-pre` suffix. This allows `cargo-semver-checks` to check for changes not accounted for in the version delta.
+1. Commit that change with comment "Bump to -pre version".
 1. Run `git push upstream`
 1. Run `git push --tags upstream`
 1. Run `(cd taskchampion; cargo publish)`

--- a/taskchampion/Cargo.toml
+++ b/taskchampion/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taskchampion"
-version = "0.7.0"
+version = "0.8.0-pre"
 authors = ["Dustin J. Mitchell <dustin@mozilla.com>"]
 description = "Personal task-tracking"
 homepage = "https://gothenburgbitfactory.github.io/taskchampion/"


### PR DESCRIPTION
The check should read from the version in `taskchampion/Cargo.toml` so if that represents a major version bump then changes are allowed, as is the case here -- we have added and removed methods in the un-sealed trait `StorageTxn`. We should seal that, too.