### PR TITLE
Use a specific version of auditcheck

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -15,6 +15,6 @@ jobs:
     name: "Audit Rust Dependencies"
     steps:
       - uses: actions/checkout@v4
-      - uses: rustsec/audit-check@main
+      - uses: rustsec/audit-check@v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The `main` branch doesn't exist, but anyway we should probably be tracking a released version of the action.