### PR TITLE
Update sync protocol docs

### DIFF
--- a/docs/src/http.md
+++ b/docs/src/http.md
@@ -35,6 +35,7 @@ Neither has a response body.
 On success, the response is a 200 OK.
 The version's history segment is returned in the response body, with content-type `application/vnd.taskchampion.history-segment`.
 The version ID appears in the `X-Version-Id` header.
+The requested parent version ID appears in the `X-Parent-Version-Id` header.
 The response body may be encoded, in accordance with any `Accept-Encoding` header in the request.
 
 On failure, a client should treat a 404 NOT FOUND as indicating that it is up-to-date.

--- a/docs/src/sync-protocol.md
+++ b/docs/src/sync-protocol.md
@@ -95,7 +95,7 @@ If found, it returns the version's
 If found, it returns a _not-found_ indication.
 Note that this circumstance is not an error, and occurs during every successful sync process.
 
-Implementations may return a different error code if the version is "gone": not found _and would not be accepted by AddVersion_, in order to provide better error messages to the user.
+Implementations may return a different error code if the version is "gone" (not found _and would not be accepted by AddVersion_) in order to provide better error messages to the user.
 This may occur if a client has not been synced for a long time and its base version has expired, or if the server storage has been corrupted.
 
 Note that `GetChildVersion` should return the _not-found_ when no versions exist.

--- a/docs/src/sync-protocol.md
+++ b/docs/src/sync-protocol.md
@@ -92,8 +92,14 @@ If found, it returns the version's
  * parent version ID (matching that in the request), and
  * encrypted version data.
 
-If not found, it returns an indication that no such version exists.
+If found, it returns a _not-found_ indication.
 Note that this circumstance is not an error, and occurs during every successful sync process.
+
+Implementations may return a different error code if the version is "gone": not found _and would not be accepted by AddVersion_, in order to provide better error messages to the user.
+This may occur if a client has not been synced for a long time and its base version has expired, or if the server storage has been corrupted.
+
+Note that `GetChildVersion` should return the _not-found_ when no versions exist.
+This allows a client to switch to a new server and continue uploading the same sequence of versions.
 
 ### AddSnapshot
 


### PR DESCRIPTION
This
 * clarifies when _gone_ and _not-found_ responses should be sent
 * includes `X-Parent-Version-Id` in the `GetChildVersion` response, since taskchampion-sync-server is already sending that value.

See GothenburgBitFactory/taskchampion-sync-server#47.