### PR TITLE
Make AwsCredentials type public

### DIFF
--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -1,7 +1,9 @@
 use super::types::Server;
 use crate::errors::Result;
 #[cfg(feature = "server-aws")]
-use crate::server::cloud::aws::{AwsCredentials, AwsService};
+pub use crate::server::cloud::aws::AwsCredentials;
+#[cfg(feature = "server-aws")]
+use crate::server::cloud::aws::AwsService;
 #[cfg(feature = "server-gcp")]
 use crate::server::cloud::gcp::GcpService;
 #[cfg(feature = "cloud")]


### PR DESCRIPTION
I went to look at https://docs.rs/taskchampion/latest/taskchampion/server/enum.ServerConfig.html and this type is private. Oops :(