### PR TITLE
Actually make AWS credentials public

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -26,7 +26,7 @@ mod sync;
 #[cfg(feature = "cloud")]
 mod cloud;
 
-pub use config::ServerConfig;
+pub use config::*;
 pub use types::*;
 
 pub(crate) use op::SyncOp;


### PR DESCRIPTION
I actually verified with `cargo doc` this time. In #506 I made the type public in `::taskchampion::server::config`, but that module is not public.