### PR TITLE
Introduce an access mode for SQLite storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2623,7 +2623,7 @@ dependencies = [
 
 [[package]]
 name = "taskchampion"
-version = "1.0.3-pre"
+version = "2.0.0-pre"
 dependencies = [
  "anyhow",
  "aws-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taskchampion"
-version = "1.0.3-pre"
+version = "2.0.0-pre"
 authors = ["Dustin J. Mitchell <dustin@mozilla.com>"]
 description = "Personal task-tracking"
 homepage = "https://gothenburgbitfactory.github.io/taskchampion/"

--- a/src/storage/config.rs
+++ b/src/storage/config.rs
@@ -2,15 +2,26 @@ use super::{InMemoryStorage, SqliteStorage, Storage};
 use crate::errors::Result;
 use std::path::PathBuf;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AccessMode {
+    ReadOnly,
+    ReadWrite,
+}
+
 /// The configuration required for a replica's storage.
+#[non_exhaustive]
 pub enum StorageConfig {
     /// Store the data on disk.  This is the common choice.
     OnDisk {
         /// Path containing the task DB.
         taskdb_dir: PathBuf,
 
-        /// Create the DB if it does not already exist
+        /// Create the DB if it does not already exist. This will occur
+        /// even if access_mode is `ReadOnly`.
         create_if_missing: bool,
+
+        /// Access mode for this database.
+        access_mode: AccessMode,
     },
     /// Store the data in memory.  This is only useful for testing.
     InMemory,
@@ -22,7 +33,12 @@ impl StorageConfig {
             StorageConfig::OnDisk {
                 taskdb_dir,
                 create_if_missing,
-            } => Box::new(SqliteStorage::new(taskdb_dir, create_if_missing)?),
+                access_mode,
+            } => Box::new(SqliteStorage::new(
+                taskdb_dir,
+                access_mode,
+                create_if_missing,
+            )?),
             StorageConfig::InMemory => Box::new(InMemoryStorage::new()),
         })
     }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -21,7 +21,7 @@ mod config;
 mod inmemory;
 pub(crate) mod sqlite;
 
-pub use config::StorageConfig;
+pub use config::{AccessMode, StorageConfig};
 pub use inmemory::InMemoryStorage;
 pub use sqlite::SqliteStorage;
 


### PR DESCRIPTION
The storage implementation checks this access mode for all methods, but also opens SQLite in read-only mode when appropriate, which causes SQLite to skip creating a WAL log or updating the access time in the database.

As a concession to ease-of-use with a new task database, the database is opened in read-write mode and the schema set up if it does not exist, regardless of the passed `AccessMode`.

This is a breaking change because:

 - The publicly-visible method `SqliteStorage::new` now takes a
   different number of parameters.
 - The public enum `StorageConfig` has been marked #[non_exhaustive].
   Pattern-matching on it outside of its crate must now include a
   wildcard pattern like `_`, or it will fail to compile.
 - `StorageConfig::OnDisk` has an additional field, `access_mode`, which
   has to be included when constructing or matching on this variant.

[edited to add the breaking-change justification]