### PR TITLE
Fix docs about status property

### DIFF
--- a/docs/src/tasks.md
+++ b/docs/src/tasks.md
@@ -29,7 +29,7 @@ Timestamps are stored as UNIX epoch timestamps, in the form of an integer.
 
 The following keys, and key formats, are defined:
 
-* `status` - one of `P` for a pending task (the default), `C` for completed, `D` for deleted, or `R` for recurring
+* `status` - one of `pending` for a pending task (the default), `completed`, `deleted`, or `recurring`
 * `description` - the one-line summary of the task
 * `modified` - the time of the last modification of this task
 * `start` - the most recent time at which this task was started (a task with no `start` key is not active)


### PR DESCRIPTION
We used single letters in TaskChampion, but switched to full words for compatibility with Taskwarrior. This doc wasn't updated at the time.