### PR TITLE
Make AccessMode type public

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -66,7 +66,7 @@ impl From<ureq::Error> for Error {
     }
 }
 
-pub type Result<T> = std::result::Result<T, Error>;
+pub(crate) type Result<T> = std::result::Result<T, Error>;
 
 #[cfg(test)]
 mod test {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(clippy::all)]
+#![deny(unreachable_pub)]
 #![doc = include_str!("crate-doc.md")]
 
 mod depmap;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![deny(clippy::all)]
 #![deny(unreachable_pub)]
+#![deny(unnameable_types)]
 #![doc = include_str!("crate-doc.md")]
 
 mod depmap;

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -21,7 +21,7 @@ mod config;
 mod inmemory;
 pub(crate) mod sqlite;
 
-pub use config::StorageConfig;
+pub use config::{AccessMode, StorageConfig};
 
 #[doc(hidden)]
 /// For compatibility with 0.6 and earlier, [`Operation`] is re-exported here.

--- a/src/task/data.rs
+++ b/src/task/data.rs
@@ -131,7 +131,7 @@ mod test {
 
     /// Set all operations' timestamps to the given timestamp, to ease use of
     /// `assert_eq!`.
-    pub fn set_all_timestamps(ops: &mut Operations, set_to: DateTime<Utc>) {
+    fn set_all_timestamps(ops: &mut Operations, set_to: DateTime<Utc>) {
         for op in ops {
             if let Operation::Update { timestamp, .. } = op {
                 *timestamp = set_to;

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -11,4 +11,5 @@ pub use data::TaskData;
 pub use status::Status;
 pub use tag::Tag;
 pub use task::Task;
-pub use time::{utc_timestamp, Timestamp};
+pub use time::utc_timestamp;
+pub(crate) use time::Timestamp;

--- a/src/task/tag.rs
+++ b/src/task/tag.rs
@@ -20,7 +20,7 @@ pub(super) enum TagInner {
 }
 
 // see doc comment for Tag, above
-pub const INVALID_TAG_CHARACTERS: &str = "+-*/(<>^! %=~";
+pub(crate) const INVALID_TAG_CHARACTERS: &str = "+-*/(<>^! %=~";
 
 impl Tag {
     /// True if this tag is a synthetic tag

--- a/src/task/time.rs
+++ b/src/task/time.rs
@@ -1,6 +1,6 @@
 use chrono::{offset::LocalResult, DateTime, TimeZone, Utc};
 
-pub type Timestamp = DateTime<Utc>;
+pub(crate) type Timestamp = DateTime<Utc>;
 
 pub fn utc_timestamp(secs: i64) -> Timestamp {
     match Utc.timestamp_opt(secs, 0) {

--- a/src/taskdb/undo.rs
+++ b/src/taskdb/undo.rs
@@ -11,7 +11,7 @@ use log::{debug, info, trace};
 ///
 /// The operations are returned in the order they were applied. Use [`commit_reversed_operations`]
 /// to "undo" them.
-pub fn get_undo_operations(txn: &mut dyn StorageTxn) -> Result<Operations> {
+pub(crate) fn get_undo_operations(txn: &mut dyn StorageTxn) -> Result<Operations> {
     let local_ops = txn.unsynced_operations().unwrap();
     let last_undo_op_idx = local_ops
         .iter()
@@ -66,7 +66,10 @@ fn reverse_ops(op: Operation) -> Vec<SyncOp> {
 ///
 /// This method only supports reversing operations if they precisely match local operations that
 /// have not yet been synchronized, and will return `false` if this is not the case.
-pub fn commit_reversed_operations(txn: &mut dyn StorageTxn, undo_ops: Operations) -> Result<bool> {
+pub(crate) fn commit_reversed_operations(
+    txn: &mut dyn StorageTxn,
+    undo_ops: Operations,
+) -> Result<bool> {
     let mut applied = false;
     let local_ops = txn.unsynced_operations().unwrap();
     let mut undo_ops = undo_ops.to_vec();

--- a/src/taskdb/working_set.rs
+++ b/src/taskdb/working_set.rs
@@ -6,7 +6,7 @@ use std::collections::HashSet;
 /// renumbers the existing working-set tasks to eliminate gaps, and also adds any tasks that
 /// are not already in the working set but should be.  The rebuild occurs in a single
 /// trasnsaction against the storage backend.
-pub fn rebuild<F>(txn: &mut dyn StorageTxn, in_working_set: F, renumber: bool) -> Result<()>
+pub(crate) fn rebuild<F>(txn: &mut dyn StorageTxn, in_working_set: F, renumber: bool) -> Result<()>
 where
     F: Fn(&TaskMap) -> bool,
 {


### PR DESCRIPTION
I did it again:

![image](https://github.com/user-attachments/assets/7b100aa1-7202-4afb-846f-791bc1e37fd0)

That's a private type (here seen as not linkified) in a public type. This is why we had 1.0.2 as well. I tried enabling the `unreachable_pub` lint, but it didn't help -- I [think that's a bug](https://github.com/rust-lang/rust/issues/135134).