### PR TITLE
Deprecated namespaced UDAs; promote legacy UDAs to be default (#540)

### DIFF
--- a/docs/src/tasks.md
+++ b/docs/src/tasks.md
@@ -48,7 +48,3 @@ Any unrecognized keys are treated as "user-defined attributes" (UDAs).
 These attributes can be used to store additional data associated with a task.
 For example, applications that synchronize tasks with other systems such as calendars or team planning services might store unique identifiers for those systems as UDAs.
 The application defining a UDA defines the format of the value.
-
-UDAs _should_ have a namespaced structure of the form `<namespace>.<key>`, where `<namespace>` identifies the application defining the UDA.
-For example, a service named "DevSync" synchronizing tasks from GitHub might use UDAs like `devsync.github.issue-id`.
-Note that many existing UDAs for Taskwarrior integrations do not follow this pattern; these are referred to as legacy UDAs.


### PR DESCRIPTION
This commit:
- Adds documentation about why namespaced UDAs existed and how they are an old idea
- Deprecates functions for namespaced and legacy UDAs
- Adds functions for handling taskwarrior compatible UDAs instead of relying on functions using the `legacy` word

About the deprecation of namespaced UDAs:

When TaskChampion was first implemented there was an idea to only use
namespaced keys in the future. This was before TaskChampion was integrated into
Taskwarrior 3, but it lead to UDAs that are currently being used being referenced
as "legacy" UDAs.

This commit changes that idea: Namespaced UDAs are deprecated, and what was called
legacy will be the way for UDAs going forward.