### PR TITLE
Silence deprecation warnings in tests

### DIFF
--- a/src/task/task.rs
+++ b/src/task/task.rs
@@ -576,6 +576,7 @@ impl Task {
 }
 
 #[cfg(test)]
+#[allow(deprecated)]
 mod test {
     use super::*;
     use crate::Replica;


### PR DESCRIPTION
This silences some warnings due to #545.