### PR TITLE
Make inmemory and on-disk storage 'set_working_set_item' match

### DIFF
--- a/src/storage/inmemory.rs
+++ b/src/storage/inmemory.rs
@@ -39,6 +39,14 @@ impl Txn<'_> {
             &self.storage.data
         }
     }
+
+    // Remove any "None" items from the end of the working set.
+    fn normalize_working_set(&mut self) {
+        let working_set = &mut self.mut_data_ref().working_set;
+        while let Some(None) = &working_set[1..].last() {
+            working_set.pop();
+        }
+    }
 }
 
 impl StorageTxn for Txn<'_> {
@@ -203,6 +211,8 @@ impl StorageTxn for Txn<'_> {
             )));
         }
         working_set[index] = uuid;
+
+        self.normalize_working_set();
         Ok(())
     }
 

--- a/src/storage/test.rs
+++ b/src/storage/test.rs
@@ -698,5 +698,20 @@ pub(super) fn set_working_set_item(mut storage: impl Storage) -> Result<()> {
         assert_eq!(ws, vec![None, None, Some(uuid1)]);
     }
 
+    // Set the last item to None
+    {
+        let mut txn = storage.txn()?;
+        txn.set_working_set_item(1, Some(uuid1))?;
+        txn.set_working_set_item(2, None)?;
+        txn.commit()?;
+    }
+
+    {
+        let mut txn = storage.txn()?;
+        let ws = txn.get_working_set()?;
+        // Note no trailing `None`.
+        assert_eq!(ws, vec![None, Some(uuid1)]);
+    }
+
     Ok(())
 }


### PR DESCRIPTION
I noticed this small discrepancy in `set_working_set_item` behavior while working on #414.

```
task add one
task add two
task 2 del
task list
task add two-again
```

With the sqlite backend, "two-again" will have ID 2. With the inmemory implementation, it would be 3. Since inmemory is used for lots of tests, it's best that its behavior match others as precisely as possible.