### PR TITLE
  Modify the working set in-place rather than clearing and rewriting

### DIFF
--- a/src/taskdb/working_set.rs
+++ b/src/taskdb/working_set.rs
@@ -10,6 +10,7 @@ pub(crate) fn rebuild<F>(txn: &mut dyn StorageTxn, in_working_set: F, renumber: 
 where
     F: Fn(&TaskMap) -> bool,
 {
+    let old_ws = txn.get_working_set()?;
     let mut new_ws = vec![None]; // index 0 is always None
     let mut seen = HashSet::new();
 
@@ -17,35 +18,25 @@ where
     // we begin by scanning the current working set and inserting any tasks that should still
     // be in the set into new_ws, implicitly dropping any tasks that are no longer in the
     // working set.
-    for elt in txn.get_working_set()?.drain(1..) {
+    for elt in &old_ws[1..] {
         if let Some(uuid) = elt {
-            if let Some(task) = txn.get_task(uuid)? {
+            if let Some(task) = txn.get_task(*uuid)? {
                 if in_working_set(&task) {
-                    new_ws.push(Some(uuid));
-                    seen.insert(uuid);
-                    continue;
+                    // The existing working-set item is still in the working set -- no change.
+                    new_ws.push(Some(*uuid));
+                    seen.insert(*uuid);
+                } else {
+                    // The item should not be present. If we are not renumbering, then insert a
+                    // blank working-set item here
+                    if !renumber {
+                        new_ws.push(None);
+                    }
                 }
+                continue;
             }
-        }
-
-        // if we are not renumbering, then insert a blank working-set entry here
-        if !renumber {
+        } else {
+            // This item was already None.
             new_ws.push(None);
-        }
-    }
-
-    // if renumbering, clear the working set and re-add
-    if renumber {
-        txn.clear_working_set()?;
-        for elt in new_ws.drain(1..new_ws.len()).flatten() {
-            txn.add_to_working_set(elt)?;
-        }
-    } else {
-        // ..otherwise, just clear the None items determined above from the working set
-        for (i, elt) in new_ws.iter().enumerate().skip(1) {
-            if elt.is_none() {
-                txn.set_working_set_item(i, None)?;
-            }
         }
     }
 
@@ -53,7 +44,34 @@ where
     // end of the list, whether renumbering or not
     for (uuid, task) in txn.all_tasks()? {
         if !seen.contains(&uuid) && in_working_set(&task) {
-            txn.add_to_working_set(uuid)?;
+            new_ws.push(Some(uuid));
+        }
+    }
+
+    // Now use `set_working_set_item` to update any items within the range of the current
+    // working set.
+    for (i, (old, new)) in old_ws.iter().zip(new_ws.iter()).enumerate() {
+        if old != new {
+            txn.set_working_set_item(i, *new)?;
+        }
+    }
+
+    // If there are more new items, add them.
+    match new_ws.len().cmp(&old_ws.len()) {
+        std::cmp::Ordering::Less => {
+            // Overall working set has shrunk, so set remaining items to None.
+            for (i, item) in old_ws.iter().enumerate().skip(new_ws.len()) {
+                if item.is_some() {
+                    txn.set_working_set_item(i, None)?;
+                }
+            }
+        }
+        std::cmp::Ordering::Equal => {}
+        std::cmp::Ordering::Greater => {
+            // Overall working set has grown, so add new items to the end.
+            for uuid in &new_ws[old_ws.len()..] {
+                txn.add_to_working_set(uuid.expect("new ws items should not be None"))?;
+            }
         }
     }
 
@@ -150,6 +168,115 @@ mod test {
 
         assert_eq!(db.working_set()?, exp);
 
+        Ok(())
+    }
+
+    #[test]
+    fn rebuild_working_set_no_change() -> Result<()> {
+        let mut db = TaskDb::new_inmemory();
+
+        let mut uuids = vec![];
+        uuids.push(Uuid::new_v4());
+        println!("uuids[0]: {:?} - pending, in working set", uuids[0]);
+        uuids.push(Uuid::new_v4());
+        println!("uuids[1]: {:?} - pending, in working set", uuids[1]);
+        uuids.push(Uuid::new_v4());
+        println!("uuids[2]: {:?} - pending, not in working set", uuids[2]);
+
+        // add everything to the TaskDb
+        let mut ops = Operations::new();
+        for uuid in &uuids {
+            ops.push(Operation::Create { uuid: *uuid });
+            ops.push(Operation::Update {
+                uuid: *uuid,
+                property: String::from("status"),
+                value: Some("pending".into()),
+                old_value: None,
+                timestamp: Utc::now(),
+            });
+        }
+        db.commit_operations(ops, |_| false)?;
+
+        // set the existing working_set as we want it, containing UUIDs 0 and 1.
+        {
+            let mut txn = db.storage.txn()?;
+            txn.clear_working_set()?;
+
+            for i in &[0, 1] {
+                txn.add_to_working_set(uuids[*i])?;
+            }
+
+            txn.commit()?;
+        }
+        rebuild(
+            db.storage.txn()?.as_mut(),
+            |t| {
+                if let Some(status) = t.get("status") {
+                    status == "pending"
+                } else {
+                    false
+                }
+            },
+            true,
+        )?;
+
+        assert_eq!(
+            db.working_set()?,
+            vec![None, Some(uuids[0]), Some(uuids[1]), Some(uuids[2])]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn rebuild_working_set_shrinks() -> Result<()> {
+        let mut db = TaskDb::new_inmemory();
+
+        let mut uuids = vec![];
+        uuids.push(Uuid::new_v4());
+        println!("uuids[0]: {:?} - pending, in working set", uuids[0]);
+        uuids.push(Uuid::new_v4());
+        println!("uuids[1]: {:?} - not pending, in working set", uuids[1]);
+        uuids.push(Uuid::new_v4());
+        println!("uuids[2]: {:?} - not pending, in working set", uuids[2]);
+
+        // add everything to the TaskDb
+        let mut ops = Operations::new();
+        for uuid in &uuids {
+            ops.push(Operation::Create { uuid: *uuid });
+        }
+        ops.push(Operation::Update {
+            uuid: uuids[0],
+            property: String::from("status"),
+            value: Some("pending".into()),
+            old_value: None,
+            timestamp: Utc::now(),
+        });
+        db.commit_operations(ops, |_| false)?;
+
+        // set the existing working_set as we want it, containing UUIDs 0 and 1.
+        {
+            let mut txn = db.storage.txn()?;
+            txn.clear_working_set()?;
+
+            for uuid in &uuids {
+                txn.add_to_working_set(*uuid)?;
+            }
+
+            txn.commit()?;
+        }
+        rebuild(
+            db.storage.txn()?.as_mut(),
+            |t| {
+                if let Some(status) = t.get("status") {
+                    status == "pending"
+                } else {
+                    false
+                }
+            },
+            true,
+        )?;
+
+        assert_eq!(db.working_set()?, vec![None, Some(uuids[0])]);
         Ok(())
     }
 }

--- a/src/taskdb/working_set.rs
+++ b/src/taskdb/working_set.rs
@@ -253,7 +253,7 @@ mod test {
         });
         db.commit_operations(ops, |_| false)?;
 
-        // set the existing working_set as we want it, containing UUIDs 0 and 1.
+        // set the existing working_set as we want it, containing all three UUIDs.
         {
             let mut txn = db.storage.txn()?;
             txn.clear_working_set()?;


### PR DESCRIPTION
This saves a lot of time in the common case of no change to the working set, as no changes are made. But the next-most-common cases are adding a new item (just one call to `add_to_working_set`) or removing a no-longer-pending item (a few calls to `set_working_set_item` for items  that have shifted their position).

This should be faster without any functional change.

Note that this includes #556, as without it cross_sync doesn't pass!