### PR TITLE
Make storage backends an optional (default enabled) feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,13 +21,15 @@ resolver = "2"
 default = ["sync", "bundled", "storage"]
 
 # Support for all sync solutions
-sync = ["server-sync", "server-gcp", "server-aws"]
+sync = ["server-sync", "server-gcp", "server-aws", "server-local"]
 # Support for sync to a server
 server-sync = ["encryption", "dep:ureq", "dep:url"]
 # Support for sync to GCP
 server-gcp = ["cloud", "encryption", "dep:google-cloud-storage", "dep:tokio"]
 # Support for sync to AWS
 server-aws = ["cloud", "encryption", "dep:aws-sdk-s3", "dep:aws-config", "dep:aws-credential-types", "dep:tokio"]
+# Suppport for sync to another SQLite database on the same machine
+server-local = ["storage-sqlite"]
 # Support for all task storage backends
 storage = ["storage-sqlite"]
 # Support for SQLite task storage

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [ "xtask" ]
 resolver = "2"
 
 [features]
-default = ["sync", "bundled"]
+default = ["sync", "bundled", "storage"]
 
 # Support for all sync solutions
 sync = ["server-sync", "server-gcp", "server-aws"]
@@ -28,6 +28,12 @@ server-sync = ["encryption", "dep:ureq", "dep:url"]
 server-gcp = ["cloud", "encryption", "dep:google-cloud-storage", "dep:tokio"]
 # Support for sync to AWS
 server-aws = ["cloud", "encryption", "dep:aws-sdk-s3", "dep:aws-config", "dep:aws-credential-types", "dep:tokio"]
+# Support for all task storage backends
+storage = ["storage-sqlite", "storage-memory"]
+# Support for SQLite task storage
+storage-sqlite = ["dep:rusqlite"]
+# Support for in-memory task storage
+storage-memory = []
 # (private) Support for sync protocol encryption
 encryption = ["dep:ring"]
 # (private) Generic support for cloud sync
@@ -51,7 +57,7 @@ flate2 = "1"
 google-cloud-storage = { version = "0.24.0", default-features = false, features = ["rustls-tls", "auth"], optional = true }
 log = "^0.4.17"
 ring = { version = "0.17", optional = true }
-rusqlite = { version = "0.35"}
+rusqlite = { version = "0.35", optional = true}
 serde_json = "^1.0"
 serde = { version = "^1.0.147", features = ["derive"] }
 strum = "0.27"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,11 +29,9 @@ server-gcp = ["cloud", "encryption", "dep:google-cloud-storage", "dep:tokio"]
 # Support for sync to AWS
 server-aws = ["cloud", "encryption", "dep:aws-sdk-s3", "dep:aws-config", "dep:aws-credential-types", "dep:tokio"]
 # Support for all task storage backends
-storage = ["storage-sqlite", "storage-memory"]
+storage = ["storage-sqlite"]
 # Support for SQLite task storage
 storage-sqlite = ["dep:rusqlite"]
-# Support for in-memory task storage
-storage-memory = []
 # (private) Support for sync protocol encryption
 encryption = ["dep:ring"]
 # (private) Generic support for cloud sync

--- a/src/crate-doc.md
+++ b/src/crate-doc.md
@@ -34,6 +34,8 @@ Several server implementations are included, and users can define their own impl
 # Example
 
 ```rust
+# #[cfg(feature = "storage-sqlite")]
+# {
 # use taskchampion::{storage::AccessMode, ServerConfig, Replica, StorageConfig};
 # use tempfile::TempDir;
 # fn main() -> anyhow::Result<()> {
@@ -57,6 +59,7 @@ let mut server = server_config.into_server()?;
 replica.sync(&mut server, true)?;
 #
 # Ok(())
+# }
 # }
 ```
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -36,8 +36,12 @@ macro_rules! other_error {
 }
 other_error!(io::Error);
 other_error!(serde_json::Error);
+
+#[cfg(feature = "storage-sqlite")]
 other_error!(rusqlite::Error);
+#[cfg(feature = "storage-sqlite")]
 other_error!(crate::storage::sqlite::SqliteError);
+
 #[cfg(feature = "server-gcp")]
 other_error!(google_cloud_storage::http::Error);
 #[cfg(feature = "server-gcp")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ pub use errors::Error;
 pub use operation::{Operation, Operations};
 pub use replica::Replica;
 pub use server::{Server, ServerConfig};
+#[cfg(feature = "storage-sqlite")]
 pub use storage::StorageConfig;
 pub use task::{utc_timestamp, Annotation, Status, Tag, Task, TaskData};
 pub use workingset::WorkingSet;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,6 @@ pub use errors::Error;
 pub use operation::{Operation, Operations};
 pub use replica::Replica;
 pub use server::{Server, ServerConfig};
-#[cfg(feature = "storage-sqlite")]
 pub use storage::StorageConfig;
 pub use task::{utc_timestamp, Annotation, Status, Tag, Task, TaskData};
 pub use workingset::WorkingSet;

--- a/src/replica.rs
+++ b/src/replica.rs
@@ -32,6 +32,8 @@ use uuid::Uuid;
 /// are not reflected in the Replica's storage until committed with [`Replica::commit_operations`].
 /**
 ```rust
+# #[cfg(feature = "storage-sqlite")]
+# {
 # use taskchampion::chrono::{TimeZone, Utc};
 # use taskchampion::{storage::AccessMode, Operations, Replica, Status, StorageConfig, Uuid};
 # use tempfile::TempDir;
@@ -54,6 +56,7 @@ t.set_entry(Some(Utc::now()), &mut ops)?;
 replica.commit_operations(ops)?;
 #
 # Ok(())
+# }
 # }
 ```
 **/

--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -8,7 +8,7 @@ use crate::server::cloud::aws::AwsService;
 use crate::server::cloud::gcp::GcpService;
 #[cfg(feature = "cloud")]
 use crate::server::cloud::CloudServer;
-#[cfg(feature = "storage-sqlite")]
+#[cfg(feature = "server-local")]
 use crate::server::local::LocalServer;
 #[cfg(feature = "server-sync")]
 use crate::server::sync::SyncServer;
@@ -23,7 +23,7 @@ use uuid::Uuid;
 #[non_exhaustive]
 pub enum ServerConfig {
     /// A local task database, for situations with a single replica.
-    #[cfg(feature = "storage-sqlite")]
+    #[cfg(feature = "server-local")]
     Local {
         /// Path containing the server's DB
         server_dir: PathBuf,
@@ -97,7 +97,7 @@ impl ServerConfig {
     /// Get a server based on this configuration
     pub fn into_server(self) -> Result<Box<dyn Server>> {
         Ok(match self {
-            #[cfg(feature = "storage-sqlite")]
+            #[cfg(feature = "server-local")]
             ServerConfig::Local { server_dir } => Box::new(LocalServer::new(server_dir)?),
             #[cfg(feature = "server-sync")]
             ServerConfig::Remote {

--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -8,6 +8,7 @@ use crate::server::cloud::aws::AwsService;
 use crate::server::cloud::gcp::GcpService;
 #[cfg(feature = "cloud")]
 use crate::server::cloud::CloudServer;
+#[cfg(feature = "storage-sqlite")]
 use crate::server::local::LocalServer;
 #[cfg(feature = "server-sync")]
 use crate::server::sync::SyncServer;
@@ -22,6 +23,7 @@ use uuid::Uuid;
 #[non_exhaustive]
 pub enum ServerConfig {
     /// A local task database, for situations with a single replica.
+    #[cfg(feature = "storage-sqlite")]
     Local {
         /// Path containing the server's DB
         server_dir: PathBuf,
@@ -95,6 +97,7 @@ impl ServerConfig {
     /// Get a server based on this configuration
     pub fn into_server(self) -> Result<Box<dyn Server>> {
         Ok(match self {
+            #[cfg(feature = "storage-sqlite")]
             ServerConfig::Local { server_dir } => Box::new(LocalServer::new(server_dir)?),
             #[cfg(feature = "server-sync")]
             ServerConfig::Remote {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -13,13 +13,14 @@ traits defined here and pass the result to [`Replica`](crate::Replica).
 pub(crate) mod test;
 
 mod config;
-#[cfg(feature = "storage-sqlite")]
-mod local;
 mod op;
 mod types;
 
 #[cfg(feature = "encryption")]
 mod encryption;
+
+#[cfg(feature = "server-local")]
+mod local;
 
 #[cfg(feature = "server-sync")]
 mod sync;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -13,6 +13,7 @@ traits defined here and pass the result to [`Replica`](crate::Replica).
 pub(crate) mod test;
 
 mod config;
+#[cfg(feature = "storage-sqlite")]
 mod local;
 mod op;
 mod types;

--- a/src/storage/config.rs
+++ b/src/storage/config.rs
@@ -1,8 +1,6 @@
-#[cfg(feature = "storage-memory")]
-use super::inmemory::InMemoryStorage;
 #[cfg(feature = "storage-sqlite")]
 use super::sqlite::SqliteStorage;
-use super::Storage;
+use super::{inmemory::InMemoryStorage, Storage};
 use crate::errors::Result;
 use std::path::PathBuf;
 
@@ -29,7 +27,6 @@ pub enum StorageConfig {
         access_mode: AccessMode,
     },
     /// Store the data in memory.  This is only useful for testing.
-    #[cfg(feature = "storage-memory")]
     InMemory,
 }
 
@@ -46,7 +43,6 @@ impl StorageConfig {
                 access_mode,
                 create_if_missing,
             )?),
-            #[cfg(feature = "storage-memory")]
             StorageConfig::InMemory => Box::new(InMemoryStorage::new()),
         })
     }

--- a/src/storage/config.rs
+++ b/src/storage/config.rs
@@ -1,4 +1,8 @@
-use super::{inmemory::InMemoryStorage, sqlite::SqliteStorage, Storage};
+#[cfg(feature = "storage-memory")]
+use super::inmemory::InMemoryStorage;
+#[cfg(feature = "storage-sqlite")]
+use super::sqlite::SqliteStorage;
+use super::Storage;
 use crate::errors::Result;
 use std::path::PathBuf;
 
@@ -12,6 +16,7 @@ pub enum AccessMode {
 #[non_exhaustive]
 pub enum StorageConfig {
     /// Store the data on disk.  This is the common choice.
+    #[cfg(feature = "storage-sqlite")]
     OnDisk {
         /// Path containing the task DB.
         taskdb_dir: PathBuf,
@@ -24,12 +29,14 @@ pub enum StorageConfig {
         access_mode: AccessMode,
     },
     /// Store the data in memory.  This is only useful for testing.
+    #[cfg(feature = "storage-memory")]
     InMemory,
 }
 
 impl StorageConfig {
     pub fn into_storage(self) -> Result<Box<dyn Storage>> {
         Ok(match self {
+            #[cfg(feature = "storage-sqlite")]
             StorageConfig::OnDisk {
                 taskdb_dir,
                 create_if_missing,
@@ -39,6 +46,7 @@ impl StorageConfig {
                 access_mode,
                 create_if_missing,
             )?),
+            #[cfg(feature = "storage-memory")]
             StorageConfig::InMemory => Box::new(InMemoryStorage::new()),
         })
     }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -17,13 +17,11 @@ use uuid::Uuid;
 #[cfg(test)]
 mod test;
 
-#[cfg(feature = "storage-sqlite")]
 mod config;
 
 #[cfg(feature = "storage-sqlite")]
 pub(crate) mod sqlite;
 
-#[cfg(feature = "storage-sqlite")]
 pub use config::{AccessMode, StorageConfig};
 
 #[cfg(feature = "storage-memory")]

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -24,7 +24,6 @@ pub(crate) mod sqlite;
 
 pub use config::{AccessMode, StorageConfig};
 
-#[cfg(feature = "storage-memory")]
 mod inmemory;
 
 #[doc(hidden)]

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -17,11 +17,17 @@ use uuid::Uuid;
 #[cfg(test)]
 mod test;
 
+#[cfg(feature = "storage-sqlite")]
 mod config;
-mod inmemory;
+
+#[cfg(feature = "storage-sqlite")]
 pub(crate) mod sqlite;
 
+#[cfg(feature = "storage-sqlite")]
 pub use config::{AccessMode, StorageConfig};
+
+#[cfg(feature = "storage-memory")]
+mod inmemory;
 
 #[doc(hidden)]
 /// For compatibility with 0.6 and earlier, [`Operation`] is re-exported here.

--- a/tests/cross-sync.rs
+++ b/tests/cross-sync.rs
@@ -4,7 +4,7 @@ use taskchampion::{Operations, Replica, ServerConfig, Status, StorageConfig, Uui
 use tempfile::TempDir;
 
 #[test]
-#[cfg(feature = "storage-sqlite")]
+#[cfg(feature = "server-local")]
 fn cross_sync() -> anyhow::Result<()> {
     // set up two replicas, and demonstrate replication between them
     let mut rep1 = Replica::new(StorageConfig::InMemory.into_storage()?);

--- a/tests/cross-sync.rs
+++ b/tests/cross-sync.rs
@@ -4,6 +4,7 @@ use taskchampion::{Operations, Replica, ServerConfig, Status, StorageConfig, Uui
 use tempfile::TempDir;
 
 #[test]
+#[cfg(feature = "storage-sqlite")]
 fn cross_sync() -> anyhow::Result<()> {
     // set up two replicas, and demonstrate replication between them
     let mut rep1 = Replica::new(StorageConfig::InMemory.into_storage()?);

--- a/tests/syncing-proptest.rs
+++ b/tests/syncing-proptest.rs
@@ -1,5 +1,6 @@
 use pretty_assertions::assert_eq;
 use proptest::prelude::*;
+#[cfg(feature = "storage-sqlite")]
 use taskchampion::{Operations, Replica, ServerConfig, StorageConfig, TaskData, Uuid};
 use tempfile::TempDir;
 
@@ -26,6 +27,7 @@ fn actions() -> impl Strategy<Value = Vec<(Action, u8)>> {
 
 proptest! {
 #[test]
+#[cfg(feature = "storage-sqlite")]
 /// Check that various sequences of operations on mulitple db's do not get the db's into an
 /// incompatible state.  The main concern here is that there might be a sequence of operations
 /// that results in a task being in different states in different replicas. Different tasks

--- a/tests/update-and-delete-sync.rs
+++ b/tests/update-and-delete-sync.rs
@@ -3,11 +3,13 @@ use taskchampion::{Operations, Replica, ServerConfig, Status, StorageConfig, Uui
 use tempfile::TempDir;
 
 #[test]
+#[cfg(feature = "storage-sqlite")]
 fn update_and_delete_sync_delete_first() -> anyhow::Result<()> {
     update_and_delete_sync(true)
 }
 
 #[test]
+#[cfg(feature = "storage-sqlite")]
 fn update_and_delete_sync_update_first() -> anyhow::Result<()> {
     update_and_delete_sync(false)
 }
@@ -15,6 +17,7 @@ fn update_and_delete_sync_update_first() -> anyhow::Result<()> {
 /// Test what happens when an update is sync'd into a repo after a task is deleted.
 /// If delete_first, then the deletion is sync'd to the server first; otherwise
 /// the update is sync'd first.  Either way, the task is gone.
+#[cfg(feature = "storage-sqlite")]
 fn update_and_delete_sync(delete_first: bool) -> anyhow::Result<()> {
     // set up two replicas, and demonstrate replication between them
     let mut rep1 = Replica::new(StorageConfig::InMemory.into_storage()?);

--- a/tests/update-and-delete-sync.rs
+++ b/tests/update-and-delete-sync.rs
@@ -3,13 +3,13 @@ use taskchampion::{Operations, Replica, ServerConfig, Status, StorageConfig, Uui
 use tempfile::TempDir;
 
 #[test]
-#[cfg(feature = "storage-sqlite")]
+#[cfg(feature = "server-local")]
 fn update_and_delete_sync_delete_first() -> anyhow::Result<()> {
     update_and_delete_sync(true)
 }
 
 #[test]
-#[cfg(feature = "storage-sqlite")]
+#[cfg(feature = "server-local")]
 fn update_and_delete_sync_update_first() -> anyhow::Result<()> {
     update_and_delete_sync(false)
 }
@@ -17,7 +17,7 @@ fn update_and_delete_sync_update_first() -> anyhow::Result<()> {
 /// Test what happens when an update is sync'd into a repo after a task is deleted.
 /// If delete_first, then the deletion is sync'd to the server first; otherwise
 /// the update is sync'd first.  Either way, the task is gone.
-#[cfg(feature = "storage-sqlite")]
+#[cfg(feature = "server-local")]
 fn update_and_delete_sync(delete_first: bool) -> anyhow::Result<()> {
     // set up two replicas, and demonstrate replication between them
     let mut rep1 = Replica::new(StorageConfig::InMemory.into_storage()?);


### PR DESCRIPTION
Taskchampion's storage implementation is meant to be pluggable, providing the `Storage` and `StorageTxn` traits that a consumer of the library could implement to provide their own storage backend.

Someone in that scenario might want to disable the default SQLite storage backend implementation if they're not using it -- especially since it adds an external C dependency (libsqlite) which must be either bundled into the application or else already present on the target system.

This PR adds the new feature flags `storage` and `storage-sqlite` , which are enabled by default. Now if the library is built without default features, those default implementations will be absent.