### PR TITLE
Fix rustdoc not-a-link

### DIFF
--- a/src/replica.rs
+++ b/src/replica.rs
@@ -306,7 +306,7 @@ impl Replica {
 
     /// Create a new task.
     ///
-    /// Use ['Uuid::new_v4`] to invent a new task ID, if necessary. If the task already
+    /// Use [Uuid::new_v4] to invent a new task ID, if necessary. If the task already
     /// exists, it is returned.
     pub fn create_task(&mut self, uuid: Uuid, ops: &mut Operations) -> Result<Task> {
         if let Some(task) = self.get_task(uuid)? {


### PR DESCRIPTION
In #601 we noticed a new failure on rustdoc.

It wasn't happening locally for me, so I went and checked with nightly (it looks like our `rustdoc` action uses nightly) + the recent changelog for rust.  This landed just a few days ago: rust-lang/rust/pull/132748 and seems very suspiciously the culprit.

I don't fully understand what our intention was here, but I swapped to _no_ backticks based on this comment:

```rust
// If there's no backticks, be lenient and revert to the old behavior.
```

I have no idea if this was the right solution, besides the fact CI passes :rofl: .

