### PR TITLE
Refactor to closure-based tx signature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2664,7 +2664,7 @@ dependencies = [
 
 [[package]]
 name = "taskchampion"
-version = "2.0.4-pre"
+version = "3.0.0-pre"
 dependencies = [
  "anyhow",
  "aws-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taskchampion"
-version = "2.0.4-pre"
+version = "3.0.0-pre"
 authors = ["Dustin J. Mitchell <dustin@mozilla.com>"]
 description = "Personal task-tracking"
 homepage = "https://gothenburgbitfactory.github.io/taskchampion/"

--- a/src/crate-doc.md
+++ b/src/crate-doc.md
@@ -18,7 +18,6 @@ Replicas are accessed using the [`Replica`] type.
 # Task Storage
 
 Replicas access the task database via a [storage object](crate::storage::Storage).
-Create a storage object with [`StorageConfig`].
 
 The [`storage`] module supports pluggable storage for a replica's data.
 An implementation is provided, but users of this crate can provide their own implementation as well.
@@ -36,7 +35,7 @@ Several server implementations are included, and users can define their own impl
 ```rust
 # #[cfg(feature = "storage-sqlite")]
 # {
-# use taskchampion::{storage::AccessMode, ServerConfig, Replica, StorageConfig};
+# use taskchampion::{storage::AccessMode, ServerConfig, Replica, storage::InMemoryStorage};
 # use tempfile::TempDir;
 # fn main() -> anyhow::Result<()> {
 # let taskdb_dir = TempDir::new()?;
@@ -44,12 +43,8 @@ Several server implementations are included, and users can define their own impl
 # let server_dir = TempDir::new()?;
 # let server_dir = server_dir.path().to_path_buf();
 // Create a new Replica, storing data on disk.
-let storage = StorageConfig::OnDisk {
-  taskdb_dir,
-  create_if_missing: true,
-  access_mode: AccessMode::ReadWrite,
-}.into_storage()?;
-let mut replica = Replica::new(storage);
+let storage = InMemoryStorage::new();
+let mut replica: Replica<InMemoryStorage> = Replica::new(storage);
 
 // Set up a local, on-disk server.
 let server_config = ServerConfig::Local { server_dir };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,6 @@ pub use errors::Error;
 pub use operation::{Operation, Operations};
 pub use replica::Replica;
 pub use server::{Server, ServerConfig};
-pub use storage::StorageConfig;
 pub use task::{utc_timestamp, Annotation, Status, Tag, Task, TaskData};
 pub use workingset::WorkingSet;
 

--- a/src/storage/config.rs
+++ b/src/storage/config.rs
@@ -1,49 +1,5 @@
-#[cfg(feature = "storage-sqlite")]
-use super::sqlite::SqliteStorage;
-use super::{inmemory::InMemoryStorage, Storage};
-use crate::errors::Result;
-use std::path::PathBuf;
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AccessMode {
     ReadOnly,
     ReadWrite,
-}
-
-/// The configuration required for a replica's storage.
-#[non_exhaustive]
-pub enum StorageConfig {
-    /// Store the data on disk.  This is the common choice.
-    #[cfg(feature = "storage-sqlite")]
-    OnDisk {
-        /// Path containing the task DB.
-        taskdb_dir: PathBuf,
-
-        /// Create the DB if it does not already exist. This will occur
-        /// even if access_mode is `ReadOnly`.
-        create_if_missing: bool,
-
-        /// Access mode for this database.
-        access_mode: AccessMode,
-    },
-    /// Store the data in memory.  This is only useful for testing.
-    InMemory,
-}
-
-impl StorageConfig {
-    pub fn into_storage(self) -> Result<Box<dyn Storage>> {
-        Ok(match self {
-            #[cfg(feature = "storage-sqlite")]
-            StorageConfig::OnDisk {
-                taskdb_dir,
-                create_if_missing,
-                access_mode,
-            } => Box::new(SqliteStorage::new(
-                taskdb_dir,
-                access_mode,
-                create_if_missing,
-            )?),
-            StorageConfig::InMemory => Box::new(InMemoryStorage::new()),
-        })
-    }
 }

--- a/src/storage/inmemory.rs
+++ b/src/storage/inmemory.rs
@@ -233,12 +233,12 @@ impl StorageTxn for Txn<'_> {
 /// InMemoryStorage is a simple in-memory task storage implementation.  It is not useful for
 /// production data, but is useful for testing purposes.
 #[derive(PartialEq, Debug, Clone)]
-pub(super) struct InMemoryStorage {
+pub struct InMemoryStorage {
     data: Data,
 }
 
 impl InMemoryStorage {
-    pub(super) fn new() -> InMemoryStorage {
+    pub fn new() -> InMemoryStorage {
         InMemoryStorage {
             data: Data {
                 tasks: HashMap::new(),
@@ -251,11 +251,14 @@ impl InMemoryStorage {
 }
 
 impl Storage for InMemoryStorage {
-    fn txn<'a>(&'a mut self) -> Result<Box<dyn StorageTxn + 'a>> {
-        Ok(Box::new(Txn {
+    fn txn<F, R>(&mut self, f: F) -> Result<R>
+    where
+        F: for<'a> FnOnce(&'a mut (dyn StorageTxn + 'a)) -> Result<R>,
+    {
+        f(&mut Txn {
             storage: self,
             new_data: None,
-        }))
+        })
     }
 }
 

--- a/src/storage/test.rs
+++ b/src/storage/test.rs
@@ -4,7 +4,8 @@
 use super::{Storage, TaskMap};
 use crate::errors::Result;
 use crate::storage::{taskmap_with, DEFAULT_BASE_VERSION};
-use crate::Operation;
+use crate::{Error, Operation};
+use anyhow::anyhow;
 use chrono::Utc;
 use pretty_assertions::assert_eq;
 use uuid::Uuid;
@@ -111,184 +112,165 @@ macro_rules! storage_tests {
 pub(crate) use storage_tests;
 
 pub(super) fn get_working_set_empty(mut storage: impl Storage) -> Result<()> {
-    {
-        let mut txn = storage.txn()?;
+    storage.txn(|txn| {
         let ws = txn.get_working_set()?;
         assert_eq!(ws, vec![None]);
-    }
-
-    Ok(())
+        Ok(())
+    })
 }
 
 pub(super) fn add_to_working_set(mut storage: impl Storage) -> Result<()> {
     let uuid1 = Uuid::new_v4();
     let uuid2 = Uuid::new_v4();
 
-    {
-        let mut txn = storage.txn()?;
+    storage.txn(|txn| {
         txn.add_to_working_set(uuid1)?;
         txn.add_to_working_set(uuid2)?;
-        txn.commit()?;
-    }
+        txn.commit()
+    })?;
 
-    {
-        let mut txn = storage.txn()?;
+    storage.txn(|txn| {
         let ws = txn.get_working_set()?;
         assert_eq!(ws, vec![None, Some(uuid1), Some(uuid2)]);
-    }
-
-    Ok(())
+        Ok(())
+    })
 }
 
 pub(super) fn clear_working_set(mut storage: impl Storage) -> Result<()> {
     let uuid1 = Uuid::new_v4();
     let uuid2 = Uuid::new_v4();
 
-    {
-        let mut txn = storage.txn()?;
+    storage.txn(|txn| {
         txn.add_to_working_set(uuid1)?;
         txn.add_to_working_set(uuid2)?;
-        txn.commit()?;
-    }
+        txn.commit()
+    })?;
 
-    {
-        let mut txn = storage.txn()?;
+    storage.txn(|txn| {
         txn.clear_working_set()?;
         txn.add_to_working_set(uuid2)?;
         txn.add_to_working_set(uuid1)?;
-        txn.commit()?;
-    }
+        txn.commit()
+    })?;
 
-    {
-        let mut txn = storage.txn()?;
+    storage.txn(|txn| {
         let ws = txn.get_working_set()?;
         assert_eq!(ws, vec![None, Some(uuid2), Some(uuid1)]);
-    }
-
-    Ok(())
+        Ok(())
+    })
 }
 
 pub(super) fn drop_transaction(mut storage: impl Storage) -> Result<()> {
     let uuid1 = Uuid::new_v4();
     let uuid2 = Uuid::new_v4();
 
-    {
-        let mut txn = storage.txn()?;
+    storage.txn(|txn| {
         assert!(txn.create_task(uuid1)?);
-        txn.commit()?;
-    }
+        txn.commit()
+    })?;
 
-    {
-        let mut txn = storage.txn()?;
+    let result: Result<()> = storage.txn(|txn| {
         assert!(txn.create_task(uuid2)?);
-        std::mem::drop(txn); // Unnecessary explicit drop of transaction
-    }
+        Err(Error::Other(anyhow!("Intentional error")))
+    });
 
-    {
-        let mut txn = storage.txn()?;
+    assert!(result.is_err());
+
+    storage.txn(|txn| {
         let uuids = txn.all_task_uuids()?;
-
         assert_eq!(uuids, [uuid1]);
-    }
-
-    Ok(())
+        Ok(())
+    })
 }
 
 pub(super) fn create(mut storage: impl Storage) -> Result<()> {
     let uuid = Uuid::new_v4();
-    {
-        let mut txn = storage.txn()?;
+
+    storage.txn(|txn| {
         assert!(txn.create_task(uuid)?);
-        txn.commit()?;
-    }
-    {
-        let mut txn = storage.txn()?;
+        txn.commit()
+    })?;
+
+    storage.txn(|txn| {
         let task = txn.get_task(uuid)?;
         assert_eq!(task, Some(taskmap_with(vec![])));
-    }
-    Ok(())
+        Ok(())
+    })
 }
 
 pub(super) fn create_exists(mut storage: impl Storage) -> Result<()> {
     let uuid = Uuid::new_v4();
-    {
-        let mut txn = storage.txn()?;
+
+    storage.txn(|txn| {
         assert!(txn.create_task(uuid)?);
-        txn.commit()?;
-    }
-    {
-        let mut txn = storage.txn()?;
+        txn.commit()
+    })?;
+
+    storage.txn(|txn| {
         assert!(!txn.create_task(uuid)?);
-        txn.commit()?;
-    }
-    Ok(())
+        txn.commit()
+    })
 }
 
 pub(super) fn get_missing(mut storage: impl Storage) -> Result<()> {
     let uuid = Uuid::new_v4();
-    {
-        let mut txn = storage.txn()?;
+    storage.txn(|txn| {
         let task = txn.get_task(uuid)?;
         assert_eq!(task, None);
-    }
-    Ok(())
+        Ok(())
+    })
 }
 
 pub(super) fn set_task(mut storage: impl Storage) -> Result<()> {
     let uuid = Uuid::new_v4();
-    {
-        let mut txn = storage.txn()?;
+    storage.txn(|txn| {
         txn.set_task(uuid, taskmap_with(vec![("k".to_string(), "v".to_string())]))?;
-        txn.commit()?;
-    }
-    {
-        let mut txn = storage.txn()?;
+        txn.commit()
+    })?;
+
+    storage.txn(|txn| {
         let task = txn.get_task(uuid)?;
         assert_eq!(
             task,
             Some(taskmap_with(vec![("k".to_string(), "v".to_string())]))
         );
-    }
-    Ok(())
+        Ok(())
+    })
 }
 
 pub(super) fn delete_task_missing(mut storage: impl Storage) -> Result<()> {
     let uuid = Uuid::new_v4();
-    {
-        let mut txn = storage.txn()?;
+    storage.txn(|txn| {
         assert!(!txn.delete_task(uuid)?);
-    }
-    Ok(())
+        Ok(())
+    })
 }
 
 pub(super) fn delete_task_exists(mut storage: impl Storage) -> Result<()> {
     let uuid = Uuid::new_v4();
-    {
-        let mut txn = storage.txn()?;
+    storage.txn(|txn| {
         assert!(txn.create_task(uuid)?);
-        txn.commit()?;
-    }
-    {
-        let mut txn = storage.txn()?;
+        txn.commit()
+    })?;
+
+    storage.txn(|txn| {
         assert!(txn.delete_task(uuid)?);
-    }
-    Ok(())
+        txn.commit()
+    })
 }
 
 pub(super) fn all_tasks_empty(mut storage: impl Storage) -> Result<()> {
-    {
-        let mut txn = storage.txn()?;
+    storage.txn(|txn| {
         let tasks = txn.all_tasks()?;
         assert_eq!(tasks, vec![]);
-    }
-    Ok(())
+        Ok(())
+    })
 }
 
 pub(super) fn all_tasks_and_uuids(mut storage: impl Storage) -> Result<()> {
     let uuid1 = Uuid::new_v4();
     let uuid2 = Uuid::new_v4();
-    {
-        let mut txn = storage.txn()?;
+    storage.txn(|txn| {
         assert!(txn.create_task(uuid1)?);
         txn.set_task(
             uuid1,
@@ -299,10 +281,10 @@ pub(super) fn all_tasks_and_uuids(mut storage: impl Storage) -> Result<()> {
             uuid2,
             taskmap_with(vec![("num".to_string(), "2".to_string())]),
         )?;
-        txn.commit()?;
-    }
-    {
-        let mut txn = storage.txn()?;
+        txn.commit()
+    })?;
+
+    storage.txn(|txn| {
         let mut tasks = txn.all_tasks()?;
 
         // order is nondeterministic, so sort by uuid
@@ -321,9 +303,10 @@ pub(super) fn all_tasks_and_uuids(mut storage: impl Storage) -> Result<()> {
         exp.sort_by(|a, b| a.0.cmp(&b.0));
 
         assert_eq!(tasks, exp);
-    }
-    {
-        let mut txn = storage.txn()?;
+        Ok(())
+    })?;
+
+    storage.txn(|txn| {
         let mut uuids = txn.all_task_uuids()?;
         uuids.sort();
 
@@ -331,30 +314,28 @@ pub(super) fn all_tasks_and_uuids(mut storage: impl Storage) -> Result<()> {
         exp.sort();
 
         assert_eq!(uuids, exp);
-    }
-    Ok(())
+        Ok(())
+    })
 }
 
 pub(super) fn base_version_default(mut storage: impl Storage) -> Result<()> {
-    {
-        let mut txn = storage.txn()?;
+    storage.txn(|txn| {
         assert_eq!(txn.base_version()?, DEFAULT_BASE_VERSION);
-    }
-    Ok(())
+        Ok(())
+    })
 }
 
 pub(super) fn base_version_setting(mut storage: impl Storage) -> Result<()> {
     let u = Uuid::new_v4();
-    {
-        let mut txn = storage.txn()?;
+    storage.txn(|txn| {
         txn.set_base_version(u)?;
-        txn.commit()?;
-    }
-    {
-        let mut txn = storage.txn()?;
+        txn.commit()
+    })?;
+
+    storage.txn(|txn| {
         assert_eq!(txn.base_version()?, u);
-    }
-    Ok(())
+        Ok(())
+    })
 }
 
 pub(super) fn unsynced_operations(mut storage: impl Storage) -> Result<()> {
@@ -363,16 +344,14 @@ pub(super) fn unsynced_operations(mut storage: impl Storage) -> Result<()> {
     let uuid3 = Uuid::new_v4();
 
     // create some operations
-    {
-        let mut txn = storage.txn()?;
+    storage.txn(|txn| {
         txn.add_operation(Operation::Create { uuid: uuid1 })?;
         txn.add_operation(Operation::Create { uuid: uuid2 })?;
-        txn.commit()?;
-    }
+        txn.commit()
+    })?;
 
     // read them back
-    {
-        let mut txn = storage.txn()?;
+    storage.txn(|txn| {
         let ops = txn.unsynced_operations()?;
         assert_eq!(
             ops,
@@ -383,29 +362,27 @@ pub(super) fn unsynced_operations(mut storage: impl Storage) -> Result<()> {
         );
 
         assert_eq!(txn.num_unsynced_operations()?, 2);
-    }
+        Ok(())
+    })?;
 
     // Sync them.
-    {
-        let mut txn = storage.txn()?;
+    storage.txn(|txn| {
         txn.sync_complete()?;
-        txn.commit()?;
-    }
+        txn.commit()
+    })?;
 
     // create some more operations (to test adding operations after sync)
-    {
-        let mut txn = storage.txn()?;
+    storage.txn(|txn| {
         txn.add_operation(Operation::Create { uuid: uuid3 })?;
         txn.add_operation(Operation::Delete {
             uuid: uuid3,
             old_task: TaskMap::new(),
         })?;
-        txn.commit()?;
-    }
+        txn.commit()
+    })?;
 
     // read them back
-    {
-        let mut txn = storage.txn()?;
+    storage.txn(|txn| {
         let ops = txn.unsynced_operations()?;
         assert_eq!(
             ops,
@@ -418,26 +395,25 @@ pub(super) fn unsynced_operations(mut storage: impl Storage) -> Result<()> {
             ]
         );
         assert_eq!(txn.num_unsynced_operations()?, 2);
-    }
+        Ok(())
+    })?;
 
     // Remove the right one
-    {
-        let mut txn = storage.txn()?;
+    storage.txn(|txn| {
         txn.remove_operation(Operation::Delete {
             uuid: uuid3,
             old_task: TaskMap::new(),
         })?;
-        txn.commit()?;
-    }
+        txn.commit()
+    })?;
 
     // read the remaining op back
-    {
-        let mut txn = storage.txn()?;
+    storage.txn(|txn| {
         let ops = txn.unsynced_operations()?;
         assert_eq!(ops, vec![Operation::Create { uuid: uuid3 },]);
         assert_eq!(txn.num_unsynced_operations()?, 1);
-    }
-    Ok(())
+        Ok(())
+    })
 }
 
 pub(super) fn remove_operations(mut storage: impl Storage) -> Result<()> {
@@ -447,9 +423,7 @@ pub(super) fn remove_operations(mut storage: impl Storage) -> Result<()> {
     let uuid4 = Uuid::new_v4();
 
     // Create some tasks and operations.
-    {
-        let mut txn = storage.txn()?;
-
+    storage.txn(|txn| {
         txn.create_task(uuid1)?;
         txn.create_task(uuid2)?;
         txn.create_task(uuid3)?;
@@ -457,49 +431,45 @@ pub(super) fn remove_operations(mut storage: impl Storage) -> Result<()> {
         txn.add_operation(Operation::Create { uuid: uuid1 })?;
         txn.add_operation(Operation::Create { uuid: uuid2 })?;
         txn.add_operation(Operation::Create { uuid: uuid3 })?;
-        txn.commit()?;
-    }
+        txn.commit()
+    })?;
 
     // Remove the uuid3 operation.
-    {
-        let mut txn = storage.txn()?;
+    storage.txn(|txn| {
         txn.remove_operation(Operation::Create { uuid: uuid3 })?;
         assert_eq!(txn.num_unsynced_operations()?, 2);
-        txn.commit()?;
-    }
+        txn.commit()
+    })?;
 
     // Remove a nonexistent operation
-    {
-        let mut txn = storage.txn()?;
+    storage.txn(|txn| {
         assert!(txn
             .remove_operation(Operation::Create { uuid: uuid4 })
             .is_err());
-    }
+        Ok(())
+    })?;
 
     // Remove an operation that is not most recent.
-    {
-        let mut txn = storage.txn()?;
+    storage.txn(|txn| {
         assert!(txn
             .remove_operation(Operation::Create { uuid: uuid1 })
             .is_err());
-    }
+        Ok(())
+    })?;
 
     // Mark operations as synced.
-    {
-        let mut txn = storage.txn()?;
+    storage.txn(|txn| {
         txn.sync_complete()?;
-        txn.commit()?;
-    }
+        txn.commit()
+    })?;
 
     // Try to remove the synced operation.
-    {
-        let mut txn = storage.txn()?;
+    storage.txn(|txn| {
         assert!(txn
             .remove_operation(Operation::Create { uuid: uuid2 })
             .is_err());
-    }
-
-    Ok(())
+        Ok(())
+    })
 }
 
 pub(super) fn task_operations(mut storage: impl Storage) -> Result<()> {
@@ -509,9 +479,7 @@ pub(super) fn task_operations(mut storage: impl Storage) -> Result<()> {
     let now = Utc::now();
 
     // Create some tasks and operations.
-    {
-        let mut txn = storage.txn()?;
-
+    storage.txn(|txn| {
         txn.create_task(uuid1)?;
         txn.create_task(uuid2)?;
         txn.create_task(uuid3)?;
@@ -536,22 +504,20 @@ pub(super) fn task_operations(mut storage: impl Storage) -> Result<()> {
             old_task: TaskMap::new(),
         })?;
 
-        txn.commit()?;
-    }
+        txn.commit()
+    })?;
 
     // remove the last operation to verify it doesn't appear
-    {
-        let mut txn = storage.txn()?;
+    storage.txn(|txn| {
         txn.remove_operation(Operation::Delete {
             uuid: uuid3,
             old_task: TaskMap::new(),
         })?;
-        txn.commit()?;
-    }
+        txn.commit()
+    })?;
 
     // read them back
-    {
-        let mut txn = storage.txn()?;
+    storage.txn(|txn| {
         let ops = txn.get_task_operations(uuid1)?;
         assert_eq!(
             ops,
@@ -579,12 +545,11 @@ pub(super) fn task_operations(mut storage: impl Storage) -> Result<()> {
                 timestamp: now,
             }]
         );
-    }
+        Ok(())
+    })?;
 
     // Sync and verify the task operations still exist.
-    {
-        let mut txn = storage.txn()?;
-
+    storage.txn(|txn| {
         txn.sync_complete()?;
 
         let ops = txn.get_task_operations(uuid1)?;
@@ -593,9 +558,8 @@ pub(super) fn task_operations(mut storage: impl Storage) -> Result<()> {
         assert_eq!(ops.len(), 1);
         let ops = txn.get_task_operations(uuid3)?;
         assert_eq!(ops.len(), 1);
-    }
-
-    Ok(())
+        Ok(())
+    })
 }
 
 pub(super) fn sync_complete(mut storage: impl Storage) -> Result<()> {
@@ -603,115 +567,101 @@ pub(super) fn sync_complete(mut storage: impl Storage) -> Result<()> {
     let uuid2 = Uuid::new_v4();
 
     // Create some tasks and operations.
-    {
-        let mut txn = storage.txn()?;
-
+    storage.txn(|txn| {
         txn.create_task(uuid1)?;
         txn.create_task(uuid2)?;
 
         txn.add_operation(Operation::Create { uuid: uuid1 })?;
         txn.add_operation(Operation::Create { uuid: uuid2 })?;
 
-        txn.commit()?;
-    }
+        txn.commit()
+    })?;
 
     // Sync and verify the task operations still exist.
-    {
-        let mut txn = storage.txn()?;
-
+    storage.txn(|txn| {
         txn.sync_complete()?;
 
         let ops = txn.get_task_operations(uuid1)?;
         assert_eq!(ops.len(), 1);
         let ops = txn.get_task_operations(uuid2)?;
         assert_eq!(ops.len(), 1);
-    }
+        Ok(())
+    })?;
 
     // Delete uuid2.
-    {
-        let mut txn = storage.txn()?;
-
+    storage.txn(|txn| {
         txn.delete_task(uuid2)?;
         txn.add_operation(Operation::Delete {
             uuid: uuid2,
             old_task: TaskMap::new(),
         })?;
 
-        txn.commit()?;
-    }
+        txn.commit()
+    })?;
 
     // Sync and verify that uuid1's operations still exist, but uuid2's do not.
-    {
-        let mut txn = storage.txn()?;
-
+    storage.txn(|txn| {
         txn.sync_complete()?;
 
         let ops = txn.get_task_operations(uuid1)?;
         assert_eq!(ops.len(), 1);
         let ops = txn.get_task_operations(uuid2)?;
         assert_eq!(ops.len(), 0);
-    }
-
-    Ok(())
+        Ok(())
+    })
 }
 
 pub(super) fn set_working_set_item(mut storage: impl Storage) -> Result<()> {
     let uuid1 = Uuid::new_v4();
     let uuid2 = Uuid::new_v4();
 
-    {
-        let mut txn = storage.txn()?;
+    storage.txn(|txn| {
         txn.add_to_working_set(uuid1)?;
         txn.add_to_working_set(uuid2)?;
-        txn.commit()?;
-    }
+        txn.commit()
+    })?;
 
-    {
-        let mut txn = storage.txn()?;
+    storage.txn(|txn| {
         let ws = txn.get_working_set()?;
         assert_eq!(ws, vec![None, Some(uuid1), Some(uuid2)]);
-    }
+        Ok(())
+    })?;
 
     // Clear one item
-    {
-        let mut txn = storage.txn()?;
+    storage.txn(|txn| {
         txn.set_working_set_item(1, None)?;
-        txn.commit()?;
-    }
+        txn.commit()
+    })?;
 
-    {
-        let mut txn = storage.txn()?;
+    storage.txn(|txn| {
         let ws = txn.get_working_set()?;
         assert_eq!(ws, vec![None, None, Some(uuid2)]);
-    }
+        Ok(())
+    })?;
 
     // Override item
-    {
-        let mut txn = storage.txn()?;
+    storage.txn(|txn| {
         txn.set_working_set_item(2, Some(uuid1))?;
-        txn.commit()?;
-    }
+        txn.commit()
+    })?;
 
-    {
-        let mut txn = storage.txn()?;
+    storage.txn(|txn| {
         let ws = txn.get_working_set()?;
         assert_eq!(ws, vec![None, None, Some(uuid1)]);
-    }
+        Ok(())
+    })?;
 
     // Set the last item to None
-    {
-        let mut txn = storage.txn()?;
+    storage.txn(|txn| {
         txn.set_working_set_item(1, Some(uuid1))?;
         txn.set_working_set_item(2, None)?;
-        txn.commit()?;
-    }
+        txn.commit()
+    })?;
 
-    {
-        let mut txn = storage.txn()?;
+    storage.txn(|txn| {
         let ws = txn.get_working_set()?;
         // Note no trailing `None`.
         assert_eq!(ws, vec![None, Some(uuid1)]);
-    }
-
-    Ok(())
+        Ok(())
+    })
 }

--- a/src/task/task.rs
+++ b/src/task/task.rs
@@ -579,7 +579,7 @@ impl Task {
 #[allow(deprecated)]
 mod test {
     use super::*;
-    use crate::Replica;
+    use crate::{storage::InMemoryStorage, Replica};
     use pretty_assertions::assert_eq;
     use std::collections::HashSet;
 
@@ -594,7 +594,7 @@ mod test {
         modify: MODIFY,
         assert: ASSERT,
     ) {
-        let mut replica = Replica::new_inmemory();
+        let mut replica = Replica::<InMemoryStorage>::new_inmemory();
         let mut ops = Operations::new();
         let uuid = Uuid::new_v4();
         let mut task = replica.create_task(uuid, &mut ops).unwrap();
@@ -1460,7 +1460,7 @@ mod test {
 
     #[test]
     fn dependencies_tags() {
-        let mut rep = Replica::new_inmemory();
+        let mut rep = Replica::<InMemoryStorage>::new_inmemory();
         let mut ops = Operations::new();
         let (uuid1, uuid2) = (Uuid::new_v4(), Uuid::new_v4());
 

--- a/src/taskdb/undo.rs
+++ b/src/taskdb/undo.rs
@@ -116,8 +116,10 @@ pub(crate) fn commit_reversed_operations(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::storage::InMemoryStorage;
+    use crate::storage::Storage;
     use crate::{storage::taskmap_with, taskdb::TaskDb};
-    use crate::{Operation, Operations, StorageConfig};
+    use crate::{Operation, Operations};
     use chrono::Utc;
     use pretty_assertions::assert_eq;
     use uuid::Uuid;
@@ -125,7 +127,7 @@ mod tests {
     #[test]
     #[allow(clippy::vec_init_then_push)]
     fn test_apply_create() -> Result<()> {
-        let mut storage = StorageConfig::InMemory.into_storage().unwrap();
+        let mut storage = InMemoryStorage::new();
         let mut db = TaskDb::new();
         let uuid1 = Uuid::new_v4();
         let uuid2 = Uuid::new_v4();
@@ -157,94 +159,72 @@ mod tests {
             old_value: Some("v2".into()),
             timestamp,
         });
-        let mut txn = storage.txn()?;
-        db.commit_operations(txn.as_mut(), ops, |_| false)?;
+        storage.txn(|txn| {
+            db.commit_operations(txn, ops, |_| false)?;
 
-        let db_state = db.sorted_tasks(txn.as_mut());
+            let db_state = db.sorted_tasks(txn);
 
-        let mut ops = Operations::new();
-        ops.push(Operation::UndoPoint);
-        ops.push(Operation::Delete {
-            uuid: uuid1,
-            old_task: [("prop".to_string(), "v1".to_string())].into(),
-        });
-        ops.push(Operation::Update {
-            uuid: uuid2,
-            property: "prop".into(),
-            value: None,
-            old_value: Some("v2".into()),
-            timestamp,
-        });
-        ops.push(Operation::Update {
-            uuid: uuid2,
-            property: "prop2".into(),
-            value: Some("new-value".into()),
-            old_value: Some("v3".into()),
-            timestamp,
-        });
-        db.commit_operations(txn.as_mut(), ops, |_| false)?;
+            let mut ops = Operations::new();
+            ops.push(Operation::UndoPoint);
+            ops.push(Operation::Delete {
+                uuid: uuid1,
+                old_task: [("prop".to_string(), "v1".to_string())].into(),
+            });
+            ops.push(Operation::Update {
+                uuid: uuid2,
+                property: "prop".into(),
+                value: None,
+                old_value: Some("v2".into()),
+                timestamp,
+            });
+            ops.push(Operation::Update {
+                uuid: uuid2,
+                property: "prop2".into(),
+                value: Some("new-value".into()),
+                old_value: Some("v3".into()),
+                timestamp,
+            });
+            db.commit_operations(txn, ops, |_| false)?;
 
-        assert_eq!(
-            db.operations(txn.as_mut()).len(),
-            9,
-            "{:#?}",
-            db.operations(txn.as_mut())
-        );
+            assert_eq!(db.operations(txn).len(), 9, "{:#?}", db.operations(txn));
 
-        let undo_ops = get_undo_operations(txn.as_mut())?;
-        assert_eq!(undo_ops.len(), 4, "{:#?}", undo_ops);
-        assert_eq!(&undo_ops[..], &db.operations(txn.as_mut())[5..]);
+            let undo_ops = get_undo_operations(txn)?;
+            assert_eq!(undo_ops.len(), 4, "{:#?}", undo_ops);
+            assert_eq!(&undo_ops[..], &db.operations(txn)[5..]);
 
-        // Try committing the wrong set of ops.
-        assert!(!commit_reversed_operations(
-            txn.as_mut(),
-            undo_ops[1..=2].to_vec(),
-        )?);
+            // Try committing the wrong set of ops.
+            assert!(!commit_reversed_operations(txn, undo_ops[1..=2].to_vec(),)?);
 
-        assert!(commit_reversed_operations(txn.as_mut(), undo_ops)?);
+            assert!(commit_reversed_operations(txn, undo_ops)?);
 
-        // Note that we've subtracted the length of undo_ops.
-        assert_eq!(
-            db.operations(txn.as_mut()).len(),
-            5,
-            "{:#?}",
-            db.operations(txn.as_mut())
-        );
-        assert_eq!(
-            db.sorted_tasks(txn.as_mut()),
-            db_state,
-            "{:#?}",
-            db.sorted_tasks(txn.as_mut())
-        );
+            // Note that we've subtracted the length of undo_ops.
+            assert_eq!(db.operations(txn).len(), 5, "{:#?}", db.operations(txn));
+            assert_eq!(
+                db.sorted_tasks(txn),
+                db_state,
+                "{:#?}",
+                db.sorted_tasks(txn)
+            );
 
-        // Note that the number of undo operations is equal to the number of operations in the
-        // database here because there are no UndoPoints.
-        let undo_ops = get_undo_operations(txn.as_mut())?;
-        assert_eq!(undo_ops.len(), 5, "{:#?}", undo_ops);
+            // Note that the number of undo operations is equal to the number of operations in the
+            // database here because there are no UndoPoints.
+            let undo_ops = get_undo_operations(txn)?;
+            assert_eq!(undo_ops.len(), 5, "{:#?}", undo_ops);
 
-        assert!(commit_reversed_operations(txn.as_mut(), undo_ops)?);
+            assert!(commit_reversed_operations(txn, undo_ops)?);
 
-        // empty db
-        assert_eq!(
-            db.operations(txn.as_mut()).len(),
-            0,
-            "{:#?}",
-            db.operations(txn.as_mut())
-        );
-        assert_eq!(
-            db.sorted_tasks(txn.as_mut()),
-            vec![],
-            "{:#?}",
-            db.sorted_tasks(txn.as_mut())
-        );
+            // empty db
+            assert_eq!(db.operations(txn).len(), 0, "{:#?}", db.operations(txn));
+            assert_eq!(db.sorted_tasks(txn), vec![], "{:#?}", db.sorted_tasks(txn));
 
-        let undo_ops = get_undo_operations(txn.as_mut())?;
-        assert_eq!(undo_ops.len(), 0, "{:#?}", undo_ops);
+            let undo_ops = get_undo_operations(txn)?;
+            assert_eq!(undo_ops.len(), 0, "{:#?}", undo_ops);
 
-        // nothing left to undo, so commit_undo_ops() returns false
-        assert!(!commit_reversed_operations(txn.as_mut(), undo_ops)?);
+            // nothing left to undo, so commit_undo_ops() returns false
+            assert!(!commit_reversed_operations(txn, undo_ops)?);
 
-        Ok(())
+            Ok(())
+        })
     }
 
     #[test]

--- a/src/taskdb/working_set.rs
+++ b/src/taskdb/working_set.rs
@@ -82,8 +82,10 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::storage::InMemoryStorage;
+    use crate::storage::Storage;
     use crate::taskdb::TaskDb;
-    use crate::{Operation, Operations, StorageConfig};
+    use crate::{Operation, Operations};
     use chrono::Utc;
     use uuid::Uuid;
 
@@ -98,7 +100,7 @@ mod test {
     }
 
     fn rebuild_working_set(renumber: bool) -> Result<()> {
-        let mut storage = StorageConfig::InMemory.into_storage().unwrap();
+        let mut storage = InMemoryStorage::new();
         let mut db = TaskDb::new();
         let mut uuids = vec![];
         uuids.push(Uuid::new_v4());
@@ -126,55 +128,56 @@ mod test {
                 timestamp: Utc::now(),
             });
         }
-        let mut txn = storage.txn()?;
-        db.commit_operations(txn.as_mut(), ops, |_| false)?;
+        storage.txn(|txn| {
+            db.commit_operations(txn, ops, |_| false)?;
 
-        // set the existing working_set as we want it
-        {
-            txn.clear_working_set()?;
+            // set the existing working_set as we want it
+            {
+                txn.clear_working_set()?;
 
-            for i in &[1usize, 3, 4] {
-                txn.add_to_working_set(uuids[*i])?;
+                for i in &[1usize, 3, 4] {
+                    txn.add_to_working_set(uuids[*i])?;
+                }
+
+                txn.commit()?;
             }
 
-            txn.commit()?;
-        }
+            assert_eq!(
+                db.working_set(txn)?,
+                vec![None, Some(uuids[1]), Some(uuids[3]), Some(uuids[4])]
+            );
 
-        assert_eq!(
-            db.working_set(txn.as_mut())?,
-            vec![None, Some(uuids[1]), Some(uuids[3]), Some(uuids[4])]
-        );
+            rebuild(
+                txn,
+                |t| {
+                    if let Some(status) = t.get("status") {
+                        status == "pending"
+                    } else {
+                        false
+                    }
+                },
+                renumber,
+            )?;
 
-        rebuild(
-            txn.as_mut(),
-            |t| {
-                if let Some(status) = t.get("status") {
-                    status == "pending"
-                } else {
-                    false
-                }
-            },
-            renumber,
-        )?;
+            let exp = if renumber {
+                // uuids[1] and uuids[4] are already in the working set, so are compressed
+                // to the top, and then uuids[0] is added.
+                vec![None, Some(uuids[1]), Some(uuids[4]), Some(uuids[0])]
+            } else {
+                // uuids[1] and uuids[4] are already in the working set, at indexes 1 and 3,
+                // and then uuids[0] is added.
+                vec![None, Some(uuids[1]), None, Some(uuids[4]), Some(uuids[0])]
+            };
 
-        let exp = if renumber {
-            // uuids[1] and uuids[4] are already in the working set, so are compressed
-            // to the top, and then uuids[0] is added.
-            vec![None, Some(uuids[1]), Some(uuids[4]), Some(uuids[0])]
-        } else {
-            // uuids[1] and uuids[4] are already in the working set, at indexes 1 and 3,
-            // and then uuids[0] is added.
-            vec![None, Some(uuids[1]), None, Some(uuids[4]), Some(uuids[0])]
-        };
+            assert_eq!(db.working_set(txn)?, exp);
 
-        assert_eq!(db.working_set(txn.as_mut())?, exp);
-
-        Ok(())
+            Ok(())
+        })
     }
 
     #[test]
     fn rebuild_working_set_no_change() -> Result<()> {
-        let mut storage = StorageConfig::InMemory.into_storage().unwrap();
+        let mut storage = InMemoryStorage::new();
         let mut db = TaskDb::new();
 
         let mut uuids = vec![];
@@ -197,41 +200,42 @@ mod test {
                 timestamp: Utc::now(),
             });
         }
-        let mut txn = storage.txn()?;
-        db.commit_operations(txn.as_mut(), ops, |_| false)?;
+        storage.txn(|txn| {
+            db.commit_operations(txn, ops, |_| false)?;
 
-        // set the existing working_set as we want it, containing UUIDs 0 and 1.
-        {
-            txn.clear_working_set()?;
+            // set the existing working_set as we want it, containing UUIDs 0 and 1.
+            {
+                txn.clear_working_set()?;
 
-            for i in &[0, 1] {
-                txn.add_to_working_set(uuids[*i])?;
-            }
-
-            txn.commit()?;
-        }
-        rebuild(
-            txn.as_mut(),
-            |t| {
-                if let Some(status) = t.get("status") {
-                    status == "pending"
-                } else {
-                    false
+                for i in &[0, 1] {
+                    txn.add_to_working_set(uuids[*i])?;
                 }
-            },
-            true,
-        )?;
 
-        assert_eq!(
-            db.working_set(txn.as_mut())?,
-            vec![None, Some(uuids[0]), Some(uuids[1]), Some(uuids[2])]
-        );
-        Ok(())
+                txn.commit()?;
+            }
+            rebuild(
+                txn,
+                |t| {
+                    if let Some(status) = t.get("status") {
+                        status == "pending"
+                    } else {
+                        false
+                    }
+                },
+                true,
+            )?;
+
+            assert_eq!(
+                db.working_set(txn)?,
+                vec![None, Some(uuids[0]), Some(uuids[1]), Some(uuids[2])]
+            );
+            Ok(())
+        })
     }
 
     #[test]
     fn rebuild_working_set_shrinks() -> Result<()> {
-        let mut storage = StorageConfig::InMemory.into_storage().unwrap();
+        let mut storage = InMemoryStorage::new();
         let mut db = TaskDb::new();
 
         let mut uuids = vec![];
@@ -254,32 +258,33 @@ mod test {
             old_value: None,
             timestamp: Utc::now(),
         });
-        let mut txn = storage.txn()?;
-        db.commit_operations(txn.as_mut(), ops, |_| false)?;
+        storage.txn(|txn| {
+            db.commit_operations(txn, ops, |_| false)?;
 
-        // set the existing working_set as we want it, containing all three UUIDs.
-        {
-            txn.clear_working_set()?;
+            // set the existing working_set as we want it, containing all three UUIDs.
+            {
+                txn.clear_working_set()?;
 
-            for uuid in &uuids {
-                txn.add_to_working_set(*uuid)?;
-            }
-
-            txn.commit()?;
-        }
-        rebuild(
-            txn.as_mut(),
-            |t| {
-                if let Some(status) = t.get("status") {
-                    status == "pending"
-                } else {
-                    false
+                for uuid in &uuids {
+                    txn.add_to_working_set(*uuid)?;
                 }
-            },
-            true,
-        )?;
 
-        assert_eq!(db.working_set(txn.as_mut())?, vec![None, Some(uuids[0])]);
-        Ok(())
+                txn.commit()?;
+            }
+            rebuild(
+                txn,
+                |t| {
+                    if let Some(status) = t.get("status") {
+                        status == "pending"
+                    } else {
+                        false
+                    }
+                },
+                true,
+            )?;
+
+            assert_eq!(db.working_set(txn)?, vec![None, Some(uuids[0])]);
+            Ok(())
+        })
     }
 }

--- a/tests/cross-sync.rs
+++ b/tests/cross-sync.rs
@@ -1,14 +1,14 @@
 use chrono::Utc;
 use pretty_assertions::assert_eq;
-use taskchampion::{Operations, Replica, ServerConfig, Status, StorageConfig, Uuid};
+use taskchampion::{storage::InMemoryStorage, Operations, Replica, ServerConfig, Status, Uuid};
 use tempfile::TempDir;
 
 #[test]
 #[cfg(feature = "server-local")]
 fn cross_sync() -> anyhow::Result<()> {
     // set up two replicas, and demonstrate replication between them
-    let mut rep1 = Replica::new(StorageConfig::InMemory.into_storage()?);
-    let mut rep2 = Replica::new(StorageConfig::InMemory.into_storage()?);
+    let mut rep1 = Replica::new(InMemoryStorage::new());
+    let mut rep2 = Replica::new(InMemoryStorage::new());
 
     let tmp_dir = TempDir::new().expect("TempDir failed");
     let server_config = ServerConfig::Local {

--- a/tests/syncing-proptest.rs
+++ b/tests/syncing-proptest.rs
@@ -1,7 +1,7 @@
 use pretty_assertions::assert_eq;
 use proptest::prelude::*;
 #[cfg(feature = "storage-sqlite")]
-use taskchampion::{Operations, Replica, ServerConfig, StorageConfig, TaskData, Uuid};
+use taskchampion::{storage::InMemoryStorage, Operations, Replica, ServerConfig, TaskData, Uuid};
 use tempfile::TempDir;
 
 #[derive(Debug, Clone)]
@@ -39,10 +39,10 @@ fn multi_replica_sync(action_sequence in actions()) {
         server_dir: tmp_dir.path().to_path_buf(),
     };
     let mut server = server_config.into_server()?;
-    let mut replicas = [
-        Replica::new(StorageConfig::InMemory.into_storage().unwrap()),
-        Replica::new(StorageConfig::InMemory.into_storage().unwrap()),
-        Replica::new(StorageConfig::InMemory.into_storage().unwrap()),
+    let mut replicas: [Replica<InMemoryStorage>; 3] = [
+        Replica::new(InMemoryStorage::new()),
+        Replica::new(InMemoryStorage::new()),
+        Replica::new(InMemoryStorage::new()),
     ];
 
     for (action, rep) in action_sequence {

--- a/tests/update-and-delete-sync.rs
+++ b/tests/update-and-delete-sync.rs
@@ -1,5 +1,5 @@
 use taskchampion::chrono::{TimeZone, Utc};
-use taskchampion::{Operations, Replica, ServerConfig, Status, StorageConfig, Uuid};
+use taskchampion::{storage::InMemoryStorage, Operations, Replica, ServerConfig, Status, Uuid};
 use tempfile::TempDir;
 
 #[test]
@@ -20,8 +20,8 @@ fn update_and_delete_sync_update_first() -> anyhow::Result<()> {
 #[cfg(feature = "server-local")]
 fn update_and_delete_sync(delete_first: bool) -> anyhow::Result<()> {
     // set up two replicas, and demonstrate replication between them
-    let mut rep1 = Replica::new(StorageConfig::InMemory.into_storage()?);
-    let mut rep2 = Replica::new(StorageConfig::InMemory.into_storage()?);
+    let mut rep1 = Replica::new(InMemoryStorage::new());
+    let mut rep2 = Replica::new(InMemoryStorage::new());
 
     let tmp_dir = TempDir::new().expect("TempDir failed");
     let mut server = ServerConfig::Local {


### PR DESCRIPTION
This pull request refactors the storage layer to use a new, closure-based transaction signature. The is to ultimately align our transaction handling with the what's required by the async database lib `tokio_rusqlite`, which is a step toward making this library async.

This PR depends on #600.