### PR TITLE
Refactor: Convert Replica and Storage layers to async

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy 0.8.26",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -77,9 +89,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.83"
+version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -704,6 +716,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crypto-bigint"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1137,6 +1164,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
@@ -1148,11 +1184,11 @@ dependencies = [
 
 [[package]]
 name = "hashlink"
-version = "0.10.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -1518,7 +1554,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.15.2",
 ]
 
 [[package]]
@@ -1583,9 +1619,9 @@ checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.35.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "133c182a6a2c87864fe97778797e46c7e999672690dc9fa3ee8e241aa4a9c13f"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
  "cc",
  "pkg-config",
@@ -1626,7 +1662,7 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.15.2",
 ]
 
 [[package]]
@@ -1851,7 +1887,7 @@ version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -2204,9 +2240,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.37.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "165ca6e57b20e1351573e3729b958bc62f0e48025386970b6e4d29e7a7e71f3f"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
 dependencies = [
  "bitflags",
  "fallible-iterator",
@@ -2667,6 +2703,7 @@ name = "taskchampion"
 version = "3.0.0-pre"
 dependencies = [
  "anyhow",
+ "async-trait",
  "aws-config",
  "aws-credential-types",
  "aws-sdk-s3",
@@ -2687,6 +2724,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.6",
  "tokio",
+ "tokio-rusqlite",
  "ureq",
  "url",
  "uuid",
@@ -2830,6 +2868,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-rusqlite"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b65501378eb676f400c57991f42cbd0986827ab5c5200c53f206d710fb32a945"
+dependencies = [
+ "crossbeam-channel",
+ "rusqlite",
+ "tokio",
 ]
 
 [[package]]
@@ -3374,7 +3423,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "byteorder",
- "zerocopy-derive",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
+dependencies = [
+ "zerocopy-derive 0.8.26",
 ]
 
 [[package]]
@@ -3382,6 +3440,17 @@ name = "zerocopy-derive"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,21 +25,21 @@ sync = ["server-sync", "server-gcp", "server-aws", "server-local"]
 # Support for sync to a server
 server-sync = ["encryption", "dep:ureq", "dep:url"]
 # Support for sync to GCP
-server-gcp = ["cloud", "encryption", "dep:google-cloud-storage", "dep:tokio"]
+server-gcp = ["cloud", "encryption", "dep:google-cloud-storage"]
 # Support for sync to AWS
-server-aws = ["cloud", "encryption", "dep:aws-sdk-s3", "dep:aws-config", "dep:aws-credential-types", "dep:tokio"]
+server-aws = ["cloud", "encryption", "dep:aws-sdk-s3", "dep:aws-config", "dep:aws-credential-types"]
 # Suppport for sync to another SQLite database on the same machine
 server-local = ["storage-sqlite"]
 # Support for all task storage backends
 storage = ["storage-sqlite"]
 # Support for SQLite task storage
-storage-sqlite = ["dep:rusqlite"]
+storage-sqlite = ["dep:rusqlite", "dep:tokio-rusqlite"]
 # (private) Support for sync protocol encryption
 encryption = ["dep:ring"]
 # (private) Generic support for cloud sync
 cloud = []
 # static bundling of dependencies
-bundled = ["rusqlite/bundled"]
+bundled = ["rusqlite/bundled", "tokio-rusqlite/bundled"]
 # use native CA roots, instead of bundled
 tls-native-roots = ["ureq/native-certs"]
 
@@ -57,16 +57,18 @@ flate2 = "1"
 google-cloud-storage = { version = "0.24.0", default-features = false, features = ["rustls-tls", "auth"], optional = true }
 log = "^0.4.17"
 ring = { version = "0.17", optional = true }
-rusqlite = { version = "0.37", optional = true}
+rusqlite = { version = "0.32", optional = true}
 serde_json = "^1.0"
 serde = { version = "^1.0.147", features = ["derive"] }
 strum = "0.27"
 strum_macros = "0.27"
-tokio = { version = "1", features = ["rt-multi-thread"], optional = true }
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 thiserror = "2.0"
 ureq = { version = "^2.12.1", features = ["tls"], optional = true }
 uuid = { version = "^1.16.0", features = ["serde", "v4"] }
 url = { version = "2", optional = true }
+async-trait = "0.1.89"
+tokio-rusqlite = { version = "0.6.0", optional = true }
 
 [dev-dependencies]
 proptest = "^1.7.0"

--- a/src/crate-doc.md
+++ b/src/crate-doc.md
@@ -37,7 +37,8 @@ Several server implementations are included, and users can define their own impl
 # {
 # use taskchampion::{storage::AccessMode, ServerConfig, Replica, storage::InMemoryStorage};
 # use tempfile::TempDir;
-# fn main() -> anyhow::Result<()> {
+# #[tokio::main]
+# async fn main() -> anyhow::Result<()> {
 # let taskdb_dir = TempDir::new()?;
 # let taskdb_dir = taskdb_dir.path().to_path_buf();
 # let server_dir = TempDir::new()?;
@@ -51,7 +52,7 @@ let server_config = ServerConfig::Local { server_dir };
 let mut server = server_config.into_server()?;
 
 // Sync to that server.
-replica.sync(&mut server, true)?;
+replica.sync(server, true).await?;
 #
 # Ok(())
 # }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -41,6 +41,8 @@ other_error!(serde_json::Error);
 other_error!(rusqlite::Error);
 #[cfg(feature = "storage-sqlite")]
 other_error!(crate::storage::sqlite::SqliteError);
+#[cfg(feature = "storage-sqlite")]
+other_error!(tokio_rusqlite::Error);
 
 #[cfg(feature = "server-gcp")]
 other_error!(google_cloud_storage::http::Error);

--- a/src/replica.rs
+++ b/src/replica.rs
@@ -13,7 +13,7 @@ use anyhow::Context;
 use chrono::{DateTime, Duration, Utc};
 use log::trace;
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use uuid::Uuid;
 
 /// A replica represents an instance of a user's task data, providing an easy interface
@@ -39,7 +39,8 @@ use uuid::Uuid;
 # use taskchampion::chrono::{TimeZone, Utc};
 # use taskchampion::{storage::AccessMode, Operations, Replica, Status, Uuid, storage::SqliteStorage};
 # use tempfile::TempDir;
-# fn main() -> anyhow::Result<()> {
+# #[tokio::main]
+# async fn main() -> anyhow::Result<()> {
 # let tmp_dir = TempDir::new()?;
 # let mut replica: Replica<SqliteStorage> = Replica::new(SqliteStorage::new(
 #   tmp_dir.path().to_path_buf(),
@@ -49,13 +50,13 @@ use uuid::Uuid;
 // Create a new task, recording the required operations.
 let mut ops = Operations::new();
 let uuid = Uuid::new_v4();
-let mut t = replica.create_task(uuid, &mut ops)?;
+let mut t = replica.create_task(uuid, &mut ops).await?;
 t.set_description("my first task".into(), &mut ops)?;
 t.set_status(Status::Pending, &mut ops)?;
 t.set_entry(Some(Utc::now()), &mut ops)?;
 
 // Commit those operations to storage.
-replica.commit_operations(ops)?;
+replica.commit_operations(ops).await?;
 #
 # Ok(())
 # }
@@ -74,8 +75,6 @@ replica.commit_operations(ops)?;
 pub struct Replica<S: Storage> {
     storage: S,
 
-    taskdb: TaskDb,
-
     /// If true, this replica has already added an undo point.
     added_undo_point: bool,
 
@@ -87,22 +86,16 @@ impl<S: Storage> Replica<S> {
     pub fn new(storage: S) -> Self {
         Self {
             storage,
-            taskdb: TaskDb::new(),
             added_undo_point: false,
             depmap: None,
         }
-    }
-
-    #[cfg(test)]
-    pub(crate) fn new_inmemory() -> Replica<InMemoryStorage> {
-        Replica::new(InMemoryStorage::new())
     }
 
     /// Update an existing task.  If the value is Some, the property is added or updated.  If the
     /// value is None, the property is deleted.  It is not an error to delete a nonexistent
     /// property.
     #[deprecated(since = "0.7.0", note = "please use TaskData instead")]
-    pub fn update_task<S1, S2>(
+    pub async fn update_task<S1, S2>(
         &mut self,
         uuid: Uuid,
         property: S1,
@@ -115,52 +108,56 @@ impl<S: Storage> Replica<S> {
         let value = value.map(|v| v.into());
         let property = property.into();
         let mut ops = self.make_operations();
-        let Some(mut task) = self.get_task_data(uuid)? else {
+        let Some(mut task) = self.get_task_data(uuid).await? else {
             return Err(Error::Database(format!("Task {} does not exist", uuid)));
         };
         task.update(property, value, &mut ops);
-        self.commit_operations(ops)?;
-        self.storage.txn(|txn| {
-            Ok(self
-                .taskdb
-                .get_task(txn, uuid)?
-                .expect("task should exist after an update"))
-        })
+        self.commit_operations(ops).await?;
+        self.storage
+            .txn(move |txn| {
+                Ok(TaskDb::get_task(txn, uuid)?.expect("task should exist after an update"))
+            })
+            .await
     }
 
     /// Get all tasks represented as a map keyed by UUID
-    pub fn all_tasks(&mut self) -> Result<HashMap<Uuid, Task>> {
-        let depmap = self.dependency_map(false)?;
-        self.storage.txn(|txn| {
-            let mut res = HashMap::new();
-            for (uuid, tm) in self.taskdb.all_tasks(txn)?.drain(..) {
-                res.insert(uuid, Task::new(TaskData::new(uuid, tm), depmap.clone()));
-            }
-            Ok(res)
-        })
+    pub async fn all_tasks(&mut self) -> Result<HashMap<Uuid, Task>> {
+        let depmap = self.dependency_map(false).await?;
+        self.storage
+            .txn(move |txn| {
+                let mut res = HashMap::new();
+                for (uuid, tm) in TaskDb::all_tasks(txn)?.drain(..) {
+                    res.insert(uuid, Task::new(TaskData::new(uuid, tm), depmap.clone()));
+                }
+                Ok(res)
+            })
+            .await
     }
 
     /// Get all task represented as a map of [`TaskData`] keyed by UUID
-    pub fn all_task_data(&mut self) -> Result<HashMap<Uuid, TaskData>> {
-        self.storage.txn(|txn| {
-            let mut res = HashMap::new();
-            for (uuid, tm) in self.taskdb.all_tasks(txn)?.drain(..) {
-                res.insert(uuid, TaskData::new(uuid, tm));
-            }
-            Ok(res)
-        })
+    pub async fn all_task_data(&mut self) -> Result<HashMap<Uuid, TaskData>> {
+        self.storage
+            .txn(move |txn| {
+                let mut res = HashMap::new();
+                for (uuid, tm) in TaskDb::all_tasks(txn)?.drain(..) {
+                    res.insert(uuid, TaskData::new(uuid, tm));
+                }
+                Ok(res)
+            })
+            .await
     }
 
     /// Get the UUIDs of all tasks
-    pub fn all_task_uuids(&mut self) -> Result<Vec<Uuid>> {
-        self.storage.txn(|txn| self.taskdb.all_task_uuids(txn))
+    pub async fn all_task_uuids(&mut self) -> Result<Vec<Uuid>> {
+        self.storage.txn(|txn| TaskDb::all_task_uuids(txn)).await
     }
 
     /// Get an array containing all pending tasks
-    pub fn pending_tasks(&mut self) -> Result<Vec<Task>> {
-        let depmap = self.dependency_map(false)?;
+    pub async fn pending_tasks(&mut self) -> Result<Vec<Task>> {
+        let depmap = self.dependency_map(false).await?;
         let res = self
-            .pending_task_data()?
+            .pending_task_data()
+            .await?
             .into_iter()
             .map(|taskdata| Task::new(taskdata, depmap.clone()))
             .collect();
@@ -168,28 +165,29 @@ impl<S: Storage> Replica<S> {
         Ok(res)
     }
 
-    pub fn pending_task_data(&mut self) -> Result<Vec<TaskData>> {
-        self.storage.txn(|txn| {
-            let res = self
-                .taskdb
-                .get_pending_tasks(txn)?
-                .into_iter()
-                .map(|(uuid, taskmap)| TaskData::new(uuid, taskmap))
-                .collect::<Vec<_>>();
+    pub async fn pending_task_data(&mut self) -> Result<Vec<TaskData>> {
+        self.storage
+            .txn(move |txn| {
+                let res = TaskDb::get_pending_tasks(txn)?
+                    .into_iter()
+                    .map(|(uuid, taskmap)| TaskData::new(uuid, taskmap))
+                    .collect::<Vec<_>>();
 
-            Ok(res)
-        })
+                Ok(res)
+            })
+            .await
     }
 
     /// Get the "working set" for this replica.  This is a snapshot of the current state,
     /// and it is up to the caller to decide how long to store this value.
-    pub fn working_set(&mut self) -> Result<WorkingSet> {
+    pub async fn working_set(&mut self) -> Result<WorkingSet> {
         self.storage
-            .txn(|txn| Replica::<S>::working_set_with_txn(&mut self.taskdb, txn))
+            .txn(|txn| Replica::<S>::working_set_with_txn(txn))
+            .await
     }
 
-    fn working_set_with_txn(taskdb: &mut TaskDb, txn: &mut dyn StorageTxn) -> Result<WorkingSet> {
-        Ok(WorkingSet::new(taskdb.working_set(txn)?))
+    fn working_set_with_txn(txn: &mut dyn StorageTxn) -> Result<WorkingSet> {
+        Ok(WorkingSet::new(TaskDb::working_set(txn)?))
     }
 
     /// Get the dependency map for all pending tasks.
@@ -206,22 +204,29 @@ impl<S: Storage> Replica<S> {
     ///
     /// Calculating this value requires a scan of the full working set and may not be performant.
     /// The [`TaskData`] API avoids generating this value.
-    pub fn dependency_map(&mut self, force: bool) -> Result<Arc<DependencyMap>> {
-        self.storage.txn(|txn| {
-            if force || self.depmap.is_none() {
+    pub async fn dependency_map(&mut self, force: bool) -> Result<Arc<DependencyMap>> {
+        if !force {
+            if let Some(depmap) = &self.depmap {
+                return Ok(depmap.clone());
+            }
+        }
+
+        let dm = self
+            .storage
+            .txn(|txn| {
                 // note: we can't use self.get_task here, as that depends on a
                 // DependencyMap
 
                 let mut dm = DependencyMap::new();
                 // temporary cache tracking whether tasks are considered Pending or not.
                 let mut is_pending_cache: HashMap<Uuid, bool> = HashMap::new();
-                let ws = Replica::<S>::working_set_with_txn(&mut self.taskdb, txn)?;
+                let ws = Replica::<S>::working_set_with_txn(txn)?;
                 // for each task in the working set
                 for i in 1..=ws.largest_index() {
                     // get the task UUID
                     if let Some(u) = ws.by_index(i) {
                         // get the task
-                        if let Some(taskmap) = self.taskdb.get_task(txn, u)? {
+                        if let Some(taskmap) = TaskDb::get_task(txn, u)? {
                             // search the task's keys
                             for p in taskmap.keys() {
                                 // for one matching `dep_..`
@@ -235,7 +240,7 @@ impl<S: Storage> Replica<S> {
                                                 *dep_pending
                                             } else if let Some(dep_taskmap) =
                                                 // or if we get the task
-                                                self.taskdb.get_task(txn, dep)?
+                                                TaskDb::get_task(txn, dep)?
                                             {
                                                 // and its status is "pending"
                                                 let dep_pending = matches!(
@@ -259,33 +264,31 @@ impl<S: Storage> Replica<S> {
                         }
                     }
                 }
-                self.depmap = Some(Arc::new(dm));
-            }
+                Ok(dm)
+            })
+            .await?;
 
-            // at this point self.depmap is guaranteed to be Some(_)
-            Ok(self.depmap.as_ref().unwrap().clone())
-        })
+        self.depmap = Some(Arc::new(dm));
+        // at this point self.depmap is guaranteed to be Some(_)
+        Ok(self.depmap.as_ref().unwrap().clone())
     }
 
     /// Get an existing task by its UUID
-    pub fn get_task(&mut self, uuid: Uuid) -> Result<Option<Task>> {
-        let depmap = self.dependency_map(false)?;
-        self.storage.txn(|txn| {
-            Ok(self
-                .taskdb
-                .get_task(txn, uuid)?
-                .map(move |tm| Task::new(TaskData::new(uuid, tm), depmap)))
-        })
+    pub async fn get_task(&mut self, uuid: Uuid) -> Result<Option<Task>> {
+        let depmap = self.dependency_map(false).await?;
+        self.storage
+            .txn(move |txn| {
+                Ok(TaskDb::get_task(txn, uuid)?
+                    .map(move |tm| Task::new(TaskData::new(uuid, tm), depmap)))
+            })
+            .await
     }
 
     /// Get an existing task by its UUID, as a [`TaskData`](crate::TaskData).
-    pub fn get_task_data(&mut self, uuid: Uuid) -> Result<Option<TaskData>> {
-        self.storage.txn(|txn| {
-            Ok(self
-                .taskdb
-                .get_task(txn, uuid)?
-                .map(move |tm| TaskData::new(uuid, tm)))
-        })
+    pub async fn get_task_data(&mut self, uuid: Uuid) -> Result<Option<TaskData>> {
+        self.storage
+            .txn(move |txn| Ok(TaskDb::get_task(txn, uuid)?.map(move |tm| TaskData::new(uuid, tm))))
+            .await
     }
 
     /// Get the operations that led to the given task.
@@ -298,9 +301,10 @@ impl<S: Storage> Replica<S> {
     /// conflicting operations were performed on different replicas. The "losing" operations in
     /// those conflicts may not appear on all replicas. In practice, conflicts are rare and the
     /// results of this function will be the same on all replicas for most tasks.
-    pub fn get_task_operations(&mut self, uuid: Uuid) -> Result<Operations> {
+    pub async fn get_task_operations(&mut self, uuid: Uuid) -> Result<Operations> {
         self.storage
-            .txn(|txn| self.taskdb.get_task_operations(txn, uuid))
+            .txn(move |txn| TaskDb::get_task_operations(txn, uuid))
+            .await
     }
 
     /// Create a new task, setting `modified`, `description`, `status`, and `entry`.
@@ -311,7 +315,7 @@ impl<S: Storage> Replica<S> {
         since = "0.7.0",
         note = "please use `create_task` and call `Task` methods `set_status`, `set_description`, and `set_entry`"
     )]
-    pub fn new_task(&mut self, status: Status, description: String) -> Result<Task> {
+    pub async fn new_task(&mut self, status: Status, description: String) -> Result<Task> {
         let uuid = Uuid::new_v4();
         let mut ops = self.make_operations();
         let now = format!("{}", Utc::now().timestamp());
@@ -320,10 +324,11 @@ impl<S: Storage> Replica<S> {
         task.update("description", Some(description), &mut ops);
         task.update("status", Some(status.to_taskmap().to_string()), &mut ops);
         task.update("entry", Some(now), &mut ops);
-        self.commit_operations(ops)?;
+        self.commit_operations(ops).await?;
         trace!("task {} created", uuid);
         Ok(self
-            .get_task(uuid)?
+            .get_task(uuid)
+            .await?
             .expect("Task should exist after creation"))
     }
 
@@ -331,11 +336,11 @@ impl<S: Storage> Replica<S> {
     ///
     /// Use [Uuid::new_v4] to invent a new task ID, if necessary. If the task already
     /// exists, it is returned.
-    pub fn create_task(&mut self, uuid: Uuid, ops: &mut Operations) -> Result<Task> {
-        if let Some(task) = self.get_task(uuid)? {
+    pub async fn create_task(&mut self, uuid: Uuid, ops: &mut Operations) -> Result<Task> {
+        if let Some(task) = self.get_task(uuid).await? {
             return Ok(task);
         }
-        let depmap = self.dependency_map(false)?;
+        let depmap = self.dependency_map(false).await?;
         Ok(Task::new(TaskData::create(uuid, ops), depmap))
     }
 
@@ -343,12 +348,13 @@ impl<S: Storage> Replica<S> {
     /// otherwise should be avoided in favor of `create_task`.  If the task already exists, this
     /// does nothing and returns the existing task.
     #[deprecated(since = "0.7.0", note = "please use TaskData instead")]
-    pub fn import_task_with_uuid(&mut self, uuid: Uuid) -> Result<Task> {
+    pub async fn import_task_with_uuid(&mut self, uuid: Uuid) -> Result<Task> {
         let mut ops = self.make_operations();
         TaskData::create(uuid, &mut ops);
-        self.commit_operations(ops)?;
+        self.commit_operations(ops).await?;
         Ok(self
-            .get_task(uuid)?
+            .get_task(uuid)
+            .await?
             .expect("Task should exist after creation"))
     }
 
@@ -360,13 +366,13 @@ impl<S: Storage> Replica<S> {
     /// after both replicas have fully synced, the resulting task will only have a `description`
     /// property.
     #[deprecated(since = "0.7.0", note = "please use TaskData::delete")]
-    pub fn delete_task(&mut self, uuid: Uuid) -> Result<()> {
-        let Some(mut task) = self.get_task_data(uuid)? else {
+    pub async fn delete_task(&mut self, uuid: Uuid) -> Result<()> {
+        let Some(mut task) = self.get_task_data(uuid).await? else {
             return Err(Error::Database(format!("Task {} does not exist", uuid)));
         };
         let mut ops = self.make_operations();
         task.delete(&mut ops);
-        self.commit_operations(ops)?;
+        self.commit_operations(ops).await?;
         trace!("task {} deleted", uuid);
         Ok(())
     }
@@ -375,41 +381,43 @@ impl<S: Storage> Replica<S> {
     ///
     /// All local state on the replica will be updated accordingly, including the working set and
     /// and temporarily cached data.
-    pub fn commit_operations(&mut self, operations: Operations) -> Result<()> {
-        self.storage.txn(|txn| {
-            if operations.is_empty() {
-                return Ok(());
-            }
+    pub async fn commit_operations(&mut self, operations: Operations) -> Result<()> {
+        if operations.is_empty() {
+            return Ok(());
+        }
 
-            // Add tasks to the working set when the status property is updated from anything other
-            // than pending or recurring to one of those two statuses.
-            let pending = Status::Pending.to_taskmap();
-            let recurring = Status::Recurring.to_taskmap();
-            let is_p_or_r = |val: &Option<String>| {
-                if let Some(val) = val {
-                    val == pending || val == recurring
-                } else {
-                    false
-                }
-            };
-            let add_to_working_set = |op: &Operation| match op {
-                Operation::Update {
-                    property,
-                    value,
-                    old_value,
-                    ..
-                } => property == "status" && !is_p_or_r(old_value) && is_p_or_r(value),
-                _ => false,
-            };
-            self.taskdb
-                .commit_operations(txn, operations, add_to_working_set)?;
+        self.storage
+            .txn(move |txn| {
+                // Add tasks to the working set when the status property is updated from anything other
+                // than pending or recurring to one of those two statuses.
+                let pending = Status::Pending.to_taskmap();
+                let recurring = Status::Recurring.to_taskmap();
+                let is_p_or_r = |val: &Option<String>| {
+                    if let Some(val) = val {
+                        val == pending || val == recurring
+                    } else {
+                        false
+                    }
+                };
+                let add_to_working_set = |op: &Operation| match op {
+                    Operation::Update {
+                        property,
+                        value,
+                        old_value,
+                        ..
+                    } => property == "status" && !is_p_or_r(old_value) && is_p_or_r(value),
+                    _ => false,
+                };
 
-            // The cached dependency map may now be invalid, do not retain it. Any existing Task values
-            // will continue to use the old map.
-            self.depmap = None;
+                TaskDb::commit_operations(txn, operations, add_to_working_set)
+            })
+            .await?;
 
-            Ok(())
-        })
+        // The cached dependency map may now be invalid, do not retain it. Any existing Task values
+        // will continue to use the old map.
+        self.depmap = None;
+
+        Ok(())
     }
 
     /// Synchronize this replica against the given server.  The working set is rebuilt after
@@ -422,14 +430,21 @@ impl<S: Storage> Replica<S> {
     ///
     /// Set this to true on systems more constrained in CPU, memory, or bandwidth than a typical desktop
     /// system
-    pub fn sync(&mut self, server: &mut Box<dyn Server>, avoid_snapshots: bool) -> Result<()> {
-        self.storage.txn(|txn| {
-            self.taskdb
-                .sync(txn, server, avoid_snapshots)
-                .context("Failed to synchronize with server")?;
-            Ok(())
-        })?;
+    pub async fn sync(
+        &mut self,
+        server: Arc<Mutex<dyn Server + Send>>,
+        avoid_snapshots: bool,
+    ) -> Result<()> {
+        self.storage
+            .txn(move |txn| {
+                let mut server_guard = server.lock().unwrap();
+                TaskDb::sync(txn, &mut *server_guard, avoid_snapshots)
+                    .context("Failed to synchronize with server")?;
+                Ok(())
+            })
+            .await?;
         self.rebuild_working_set(false)
+            .await
             .context("Failed to rebuild working set after sync")?;
         Ok(())
     }
@@ -439,8 +454,10 @@ impl<S: Storage> Replica<S> {
     ///
     /// The operations are returned in the order they were applied. Use
     /// [`Replica::commit_reversed_operations`] to "undo" them.
-    pub fn get_undo_operations(&mut self) -> Result<Operations> {
-        self.storage.txn(|txn| self.taskdb.get_undo_operations(txn))
+    pub async fn get_undo_operations(&mut self) -> Result<Operations> {
+        self.storage
+            .txn(|txn| TaskDb::get_undo_operations(txn))
+            .await
     }
 
     /// Commit the reverse of the given operations, beginning with the last operation in the given
@@ -448,10 +465,11 @@ impl<S: Storage> Replica<S> {
     ///
     /// This method only supports reversing operations if they precisely match local operations
     /// that have not yet been synchronized, and will return `false` if this is not the case.
-    pub fn commit_reversed_operations(&mut self, operations: Operations) -> Result<bool> {
+    pub async fn commit_reversed_operations(&mut self, operations: Operations) -> Result<bool> {
         let success = self
             .storage
-            .txn(|txn| self.taskdb.commit_reversed_operations(txn, operations))?;
+            .txn(|txn| TaskDb::commit_reversed_operations(txn, operations))
+            .await?;
         if !success {
             return Ok(false);
         }
@@ -459,6 +477,7 @@ impl<S: Storage> Replica<S> {
         // Both the dependency map and the working set are potentially now invalid.
         self.depmap = None;
         self.rebuild_working_set(false)
+            .await
             .context("Failed to rebuild working set after committing reversed operations")?;
 
         Ok(true)
@@ -468,23 +487,25 @@ impl<S: Storage> Replica<S> {
     /// `renumber` is true, then existing tasks may be moved to new working-set indices; in any
     /// case, on completion all pending and recurring tasks are in the working set and all tasks
     /// with other statuses are not.
-    pub fn rebuild_working_set(&mut self, renumber: bool) -> Result<()> {
-        self.storage.txn(|txn| {
-            let pending = String::from(Status::Pending.to_taskmap());
-            let recurring = String::from(Status::Recurring.to_taskmap());
-            self.taskdb.rebuild_working_set(
-                txn,
-                |t| {
-                    if let Some(st) = t.get("status") {
-                        st == &pending || st == &recurring
-                    } else {
-                        false
-                    }
-                },
-                renumber,
-            )?;
-            Ok(())
-        })
+    pub async fn rebuild_working_set(&mut self, renumber: bool) -> Result<()> {
+        self.storage
+            .txn(move |txn| {
+                let pending = String::from(Status::Pending.to_taskmap());
+                let recurring = String::from(Status::Recurring.to_taskmap());
+                TaskDb::rebuild_working_set(
+                    txn,
+                    |t| {
+                        if let Some(st) = t.get("status") {
+                            st == &pending || st == &recurring
+                        } else {
+                            false
+                        }
+                    },
+                    renumber,
+                )?;
+                Ok(())
+            })
+            .await
     }
 
     /// Expire old, deleted tasks.
@@ -494,11 +515,12 @@ impl<S: Storage> Replica<S> {
     ///
     /// Tasks are eligible for expiration when they have status Deleted and have not been modified
     /// for 180 days (about six months). Note that completed tasks are not eligible.
-    pub fn expire_tasks(&mut self) -> Result<()> {
+    pub async fn expire_tasks(&mut self) -> Result<()> {
         let six_mos_ago = Utc::now() - Duration::days(180);
         let mut ops = Operations::new();
         let deleted = Status::Deleted.to_taskmap();
-        self.all_task_data()?
+        self.all_task_data()
+            .await?
             .drain()
             .filter(|(_, t)| t.get("status") == Some(deleted))
             .filter(|(_, t)| {
@@ -509,7 +531,7 @@ impl<S: Storage> Replica<S> {
                 })
             })
             .for_each(|(_, mut t)| t.delete(&mut ops));
-        self.commit_operations(ops)
+        self.commit_operations(ops).await
     }
 
     /// Add an UndoPoint, if one has not already been added by this Replica.  This occurs
@@ -520,10 +542,10 @@ impl<S: Storage> Replica<S> {
         since = "0.7.0",
         note = "Push an `Operation::UndoPoint` onto your `Operations` instead."
     )]
-    pub fn add_undo_point(&mut self, force: bool) -> Result<()> {
+    pub async fn add_undo_point(&mut self, force: bool) -> Result<()> {
         if force || !self.added_undo_point {
             let ops = vec![Operation::UndoPoint];
-            self.commit_operations(ops)?;
+            self.commit_operations(ops).await?;
             self.added_undo_point = true;
         }
         Ok(())
@@ -541,13 +563,13 @@ impl<S: Storage> Replica<S> {
     }
 
     /// Get the number of operations local to this replica and not yet synchronized to the server.
-    pub fn num_local_operations(&mut self) -> Result<usize> {
-        self.storage.txn(|txn| self.taskdb.num_operations(txn))
+    pub async fn num_local_operations(&mut self) -> Result<usize> {
+        self.storage.txn(|txn| TaskDb::num_operations(txn)).await
     }
 
     /// Get the number of undo points available (number of times `undo` will succeed).
-    pub fn num_undo_points(&mut self) -> Result<usize> {
-        self.storage.txn(|txn| self.taskdb.num_undo_points(txn))
+    pub async fn num_undo_points(&mut self) -> Result<usize> {
+        self.storage.txn(|txn| TaskDb::num_undo_points(txn)).await
     }
 }
 
@@ -592,24 +614,30 @@ mod tests {
         }
     }
 
-    #[test]
-    fn new_task() {
-        let mut rep = Replica::<InMemoryStorage>::new_inmemory();
+    #[tokio::test]
+    async fn new_task() {
+        let mut rep = Replica::new(InMemoryStorage::new());
 
         #[allow(deprecated)]
-        let t = rep.new_task(Status::Pending, "a task".into()).unwrap();
+        let t = rep
+            .new_task(Status::Pending, "a task".into())
+            .await
+            .unwrap();
         assert_eq!(t.get_description(), String::from("a task"));
         assert_eq!(t.get_status(), Status::Pending);
         assert!(t.get_modified().is_some());
     }
 
-    #[test]
-    fn modify_task() -> Result<()> {
-        let mut rep = Replica::<InMemoryStorage>::new_inmemory();
+    #[tokio::test]
+    async fn modify_task() -> Result<()> {
+        let mut rep = Replica::new(InMemoryStorage::new());
 
         // Further test the deprecated `new_task` method.
         #[allow(deprecated)]
-        let mut t = rep.new_task(Status::Pending, "a task".into()).unwrap();
+        let mut t = rep
+            .new_task(Status::Pending, "a task".into())
+            .await
+            .unwrap();
 
         let mut ops = Operations::new();
         t.set_description(String::from("past tense"), &mut ops)
@@ -620,138 +648,139 @@ mod tests {
         assert_eq!(t.get_status(), Status::Completed);
 
         // check that values have not changed in storage, yet
-        let t = rep.get_task(t.get_uuid()).unwrap().unwrap();
+        let t = rep.get_task(t.get_uuid()).await.unwrap().unwrap();
         assert_eq!(t.get_description(), "a task");
         assert_eq!(t.get_status(), Status::Pending);
 
         // check that values have changed in storage after commit
-        rep.commit_operations(ops).unwrap();
-        let t = rep.get_task(t.get_uuid()).unwrap().unwrap();
+        rep.commit_operations(ops).await.unwrap();
+        let t = rep.get_task(t.get_uuid()).await.unwrap().unwrap();
         assert_eq!(t.get_description(), "past tense");
         assert_eq!(t.get_status(), Status::Completed);
 
-        rep.storage.txn(|txn| {
-            // and check for the corresponding operations, cleaning out the timestamps
-            // and modified properties as these are based on the current time
-            assert_eq!(
-                rep.taskdb
-                    .operations(txn)
-                    .drain(..)
-                    .map(clean_op)
-                    .collect::<Vec<_>>(),
-                vec![
-                    Operation::UndoPoint,
-                    Operation::Create { uuid: t.get_uuid() },
-                    Operation::Update {
-                        uuid: t.get_uuid(),
-                        property: "modified".into(),
-                        old_value: None,
-                        value: Some("just-now".into()),
-                        timestamp: JUST_NOW.unwrap(),
-                    },
-                    Operation::Update {
-                        uuid: t.get_uuid(),
-                        property: "description".into(),
-                        old_value: None,
-                        value: Some("a task".into()),
-                        timestamp: JUST_NOW.unwrap(),
-                    },
-                    Operation::Update {
-                        uuid: t.get_uuid(),
-                        property: "status".into(),
-                        old_value: None,
-                        value: Some("pending".into()),
-                        timestamp: JUST_NOW.unwrap(),
-                    },
-                    Operation::Update {
-                        uuid: t.get_uuid(),
-                        property: "entry".into(),
-                        old_value: None,
-                        value: Some("just-now".into()),
-                        timestamp: JUST_NOW.unwrap(),
-                    },
-                    Operation::Update {
-                        uuid: t.get_uuid(),
-                        property: "modified".into(),
-                        old_value: Some("just-now".into()),
-                        value: Some("just-now".into()),
-                        timestamp: JUST_NOW.unwrap(),
-                    },
-                    Operation::Update {
-                        uuid: t.get_uuid(),
-                        property: "description".into(),
-                        old_value: Some("a task".into()),
-                        value: Some("past tense".into()),
-                        timestamp: JUST_NOW.unwrap(),
-                    },
-                    Operation::Update {
-                        uuid: t.get_uuid(),
-                        property: "end".into(),
-                        old_value: None,
-                        value: Some("just-now".into()),
-                        timestamp: JUST_NOW.unwrap(),
-                    },
-                    Operation::Update {
-                        uuid: t.get_uuid(),
-                        property: "status".into(),
-                        old_value: Some("pending".into()),
-                        value: Some("completed".into()),
-                        timestamp: JUST_NOW.unwrap(),
-                    },
-                ]
-            );
-            Ok(())
-        })?;
+        rep.storage
+            .txn(move |txn| {
+                // and check for the corresponding operations, cleaning out the timestamps
+                // and modified properties as these are based on the current time
+                assert_eq!(
+                    TaskDb::operations(txn)
+                        .drain(..)
+                        .map(clean_op)
+                        .collect::<Vec<_>>(),
+                    vec![
+                        Operation::UndoPoint,
+                        Operation::Create { uuid: t.get_uuid() },
+                        Operation::Update {
+                            uuid: t.get_uuid(),
+                            property: "modified".into(),
+                            old_value: None,
+                            value: Some("just-now".into()),
+                            timestamp: JUST_NOW.unwrap(),
+                        },
+                        Operation::Update {
+                            uuid: t.get_uuid(),
+                            property: "description".into(),
+                            old_value: None,
+                            value: Some("a task".into()),
+                            timestamp: JUST_NOW.unwrap(),
+                        },
+                        Operation::Update {
+                            uuid: t.get_uuid(),
+                            property: "status".into(),
+                            old_value: None,
+                            value: Some("pending".into()),
+                            timestamp: JUST_NOW.unwrap(),
+                        },
+                        Operation::Update {
+                            uuid: t.get_uuid(),
+                            property: "entry".into(),
+                            old_value: None,
+                            value: Some("just-now".into()),
+                            timestamp: JUST_NOW.unwrap(),
+                        },
+                        Operation::Update {
+                            uuid: t.get_uuid(),
+                            property: "modified".into(),
+                            old_value: Some("just-now".into()),
+                            value: Some("just-now".into()),
+                            timestamp: JUST_NOW.unwrap(),
+                        },
+                        Operation::Update {
+                            uuid: t.get_uuid(),
+                            property: "description".into(),
+                            old_value: Some("a task".into()),
+                            value: Some("past tense".into()),
+                            timestamp: JUST_NOW.unwrap(),
+                        },
+                        Operation::Update {
+                            uuid: t.get_uuid(),
+                            property: "end".into(),
+                            old_value: None,
+                            value: Some("just-now".into()),
+                            timestamp: JUST_NOW.unwrap(),
+                        },
+                        Operation::Update {
+                            uuid: t.get_uuid(),
+                            property: "status".into(),
+                            old_value: Some("pending".into()),
+                            value: Some("completed".into()),
+                            timestamp: JUST_NOW.unwrap(),
+                        },
+                    ]
+                );
+                Ok(())
+            })
+            .await?;
 
         // num_local_operations includes all but the undo point
-        assert_eq!(rep.num_local_operations().unwrap(), 9);
+        assert_eq!(rep.num_local_operations().await.unwrap(), 9);
 
         // num_undo_points includes only the undo point
-        assert_eq!(rep.num_undo_points().unwrap(), 1);
+        assert_eq!(rep.num_undo_points().await.unwrap(), 1);
 
         // A second undo point is counted.
         let ops = vec![Operation::UndoPoint];
-        rep.commit_operations(ops).unwrap();
-        assert_eq!(rep.num_undo_points().unwrap(), 2);
+        rep.commit_operations(ops).await.unwrap();
+        assert_eq!(rep.num_undo_points().await.unwrap(), 2);
 
         Ok(())
     }
 
-    #[test]
-    fn delete_task() {
-        let mut rep = Replica::<InMemoryStorage>::new_inmemory();
+    #[tokio::test]
+    async fn delete_task() {
+        let mut rep = Replica::new(InMemoryStorage::new());
 
         let uuid = Uuid::new_v4();
         let mut ops = Operations::new();
-        rep.create_task(uuid, &mut ops).unwrap();
-        rep.commit_operations(ops).unwrap();
+        rep.create_task(uuid, &mut ops).await.unwrap();
+        rep.commit_operations(ops).await.unwrap();
 
         #[allow(deprecated)]
-        rep.delete_task(uuid).unwrap();
-        assert_eq!(rep.get_task(uuid).unwrap(), None);
+        rep.delete_task(uuid).await.unwrap();
+        assert_eq!(rep.get_task(uuid).await.unwrap(), None);
     }
 
-    #[test]
-    fn all_tasks() {
-        let mut rep = Replica::<InMemoryStorage>::new_inmemory();
+    #[tokio::test]
+    async fn all_tasks() {
+        let mut rep = Replica::new(InMemoryStorage::new());
 
         let (uuid1, uuid2) = (Uuid::new_v4(), Uuid::new_v4());
         let mut ops = Operations::new();
-        rep.create_task(uuid1, &mut ops).unwrap();
-        rep.create_task(uuid2, &mut ops).unwrap();
-        rep.commit_operations(ops).unwrap();
+        rep.create_task(uuid1, &mut ops).await.unwrap();
+        rep.create_task(uuid2, &mut ops).await.unwrap();
+        rep.commit_operations(ops).await.unwrap();
 
-        let all_tasks = rep.all_tasks().unwrap();
+        let all_tasks = rep.all_tasks().await.unwrap();
         assert_eq!(all_tasks.len(), 2);
         assert_eq!(all_tasks.get(&uuid1).unwrap().get_uuid(), uuid1);
         assert_eq!(all_tasks.get(&uuid2).unwrap().get_uuid(), uuid2);
 
-        let all_tasks = rep.all_task_data().unwrap();
+        let all_tasks = rep.all_task_data().await.unwrap();
         assert_eq!(all_tasks.len(), 2);
         assert_eq!(all_tasks.get(&uuid1).unwrap().get_uuid(), uuid1);
         assert_eq!(all_tasks.get(&uuid2).unwrap().get_uuid(), uuid2);
 
-        let mut all_uuids = rep.all_task_uuids().unwrap();
+        let mut all_uuids = rep.all_task_uuids().await.unwrap();
         all_uuids.sort();
         let mut exp_uuids = vec![uuid1, uuid2];
         exp_uuids.sort();
@@ -759,43 +788,43 @@ mod tests {
         assert_eq!(all_uuids, exp_uuids);
     }
 
-    #[test]
-    fn pending_tasks() {
-        let mut rep = Replica::<InMemoryStorage>::new_inmemory();
+    #[tokio::test]
+    async fn pending_tasks() {
+        let mut rep = Replica::new(InMemoryStorage::new());
 
         let (uuid1, uuid2, uuid3) = (Uuid::new_v4(), Uuid::new_v4(), Uuid::new_v4());
         let mut ops = Operations::new();
 
-        let mut t1 = rep.create_task(uuid1, &mut ops).unwrap();
+        let mut t1 = rep.create_task(uuid1, &mut ops).await.unwrap();
         t1.set_status(Status::Pending, &mut ops).unwrap();
 
-        let mut t2 = rep.create_task(uuid2, &mut ops).unwrap();
+        let mut t2 = rep.create_task(uuid2, &mut ops).await.unwrap();
         t2.set_status(Status::Pending, &mut ops).unwrap();
 
-        let mut t3 = rep.create_task(uuid3, &mut ops).unwrap();
+        let mut t3 = rep.create_task(uuid3, &mut ops).await.unwrap();
         t3.set_status(Status::Completed, &mut ops).unwrap();
 
-        rep.commit_operations(ops).unwrap();
+        rep.commit_operations(ops).await.unwrap();
 
-        let pending_tasks = rep.pending_tasks().unwrap();
+        let pending_tasks = rep.pending_tasks().await.unwrap();
         assert_eq!(pending_tasks.len(), 2);
         assert_eq!(pending_tasks.first().unwrap().get_uuid(), uuid1);
         assert_eq!(pending_tasks.get(1).unwrap().get_uuid(), uuid2);
     }
 
-    #[test]
-    fn commit_operations() -> Result<()> {
+    #[tokio::test]
+    async fn commit_operations() -> Result<()> {
         // This mostly tests the working-set callback, as `TaskDB::commit_operations` has
         // tests for the remaining functionality.
-        let mut rep = Replica::<InMemoryStorage>::new_inmemory();
+        let mut rep = Replica::new(InMemoryStorage::new());
 
         // Generate the depmap so later assertions can verify it is reset.
-        rep.dependency_map(true).unwrap();
+        rep.dependency_map(true).await.unwrap();
         assert!(rep.depmap.is_some());
 
         let mut ops = Operations::new();
         let uuid1 = Uuid::new_v4();
-        let mut t = rep.create_task(uuid1, &mut ops).unwrap();
+        let mut t = rep.create_task(uuid1, &mut ops).await.unwrap();
         t.set_status(Status::Pending, &mut ops).unwrap();
 
         // uuid2 is created and deleted, but this does not affect the
@@ -882,9 +911,9 @@ mod tests {
         let uuid12 = Uuid::new_v4();
         ops.push(update_op(uuid12, "status", Some("pending"), None));
 
-        rep.commit_operations(ops)?;
+        rep.commit_operations(ops).await?;
 
-        let ws = rep.working_set()?;
+        let ws = rep.working_set().await?;
         assert!(ws.by_uuid(uuid1).is_some());
         assert!(ws.by_uuid(uuid2).is_none());
         assert!(ws.by_uuid(uuid3).is_none());
@@ -904,85 +933,86 @@ mod tests {
         Ok(())
     }
 
-    #[test]
-    fn commit_reversed_operations() -> Result<()> {
+    #[tokio::test]
+    async fn commit_reversed_operations() -> Result<()> {
         let uuid1 = Uuid::new_v4();
         let uuid2 = Uuid::new_v4();
         let uuid3 = Uuid::new_v4();
 
-        let mut rep = Replica::<InMemoryStorage>::new_inmemory();
+        let mut rep = Replica::new(InMemoryStorage::new());
 
         let mut ops = Operations::new();
         ops.push(Operation::UndoPoint);
-        rep.create_task(uuid1, &mut ops).unwrap();
+        rep.create_task(uuid1, &mut ops).await.unwrap();
         ops.push(Operation::UndoPoint);
-        rep.create_task(uuid2, &mut ops).unwrap();
-        rep.commit_operations(ops)?;
-        assert_eq!(rep.num_undo_points().unwrap(), 2);
+        rep.create_task(uuid2, &mut ops).await.unwrap();
+        rep.commit_operations(ops).await?;
+        assert_eq!(rep.num_undo_points().await.unwrap(), 2);
 
         // Trying to reverse-commit the wrong operations fails.
         let ops = vec![Operation::Delete {
             uuid: uuid3,
             old_task: TaskMap::new(),
         }];
-        assert!(!rep.commit_reversed_operations(ops)?);
+        assert!(!rep.commit_reversed_operations(ops).await?);
 
         // Commiting the correct operations succeeds
-        let ops = rep.get_undo_operations()?;
-        assert!(rep.commit_reversed_operations(ops)?);
-        assert_eq!(rep.num_undo_points().unwrap(), 1);
+        let ops = rep.get_undo_operations().await?;
+        assert!(rep.commit_reversed_operations(ops).await?);
+        assert_eq!(rep.num_undo_points().await.unwrap(), 1);
 
         Ok(())
     }
 
-    #[test]
-    fn get_and_modify() {
-        let mut rep = Replica::<InMemoryStorage>::new_inmemory();
+    #[tokio::test]
+    async fn get_and_modify() {
+        let mut rep = Replica::new(InMemoryStorage::new());
 
         let mut ops = Operations::new();
         let uuid = Uuid::new_v4();
-        let mut t = rep.create_task(uuid, &mut ops).unwrap();
+        let mut t = rep.create_task(uuid, &mut ops).await.unwrap();
         t.set_status(Status::Pending, &mut ops).unwrap();
         t.set_description("another task".into(), &mut ops).unwrap();
-        rep.commit_operations(ops).unwrap();
+        rep.commit_operations(ops).await.unwrap();
 
-        let mut t = rep.get_task(uuid).unwrap().unwrap();
+        let mut t = rep.get_task(uuid).await.unwrap().unwrap();
         assert_eq!(t.get_description(), String::from("another task"));
 
         let mut ops = Operations::new();
         t.set_status(Status::Deleted, &mut ops).unwrap();
         t.set_description("gone".into(), &mut ops).unwrap();
-        rep.commit_operations(ops).unwrap();
+        rep.commit_operations(ops).await.unwrap();
 
-        let t = rep.get_task(uuid).unwrap().unwrap();
+        let t = rep.get_task(uuid).await.unwrap().unwrap();
         assert_eq!(t.get_status(), Status::Deleted);
         assert_eq!(t.get_description(), "gone");
 
-        rep.rebuild_working_set(true).unwrap();
+        rep.rebuild_working_set(true).await.unwrap();
 
-        let ws = rep.working_set().unwrap();
+        let ws = rep.working_set().await.unwrap();
         assert!(ws.by_uuid(t.get_uuid()).is_none());
     }
 
-    #[test]
-    fn get_task_data_and_operations() {
-        let mut rep = Replica::<InMemoryStorage>::new_inmemory();
+    #[tokio::test]
+    async fn get_task_data_and_operations() {
+        let mut rep = Replica::new(InMemoryStorage::new());
 
         let uuid1 = Uuid::new_v4();
         let uuid2 = Uuid::new_v4();
         let mut ops = Operations::new();
-        let mut t = rep.create_task(uuid1, &mut ops).unwrap();
+        let mut t = rep.create_task(uuid1, &mut ops).await.unwrap();
         t.set_description("another task".into(), &mut ops).unwrap();
-        let mut t2 = rep.create_task(uuid2, &mut ops).unwrap();
+        let mut t2 = rep.create_task(uuid2, &mut ops).await.unwrap();
         t2.set_description("a distraction!".into(), &mut ops)
             .unwrap();
-        rep.commit_operations(ops).unwrap();
+        rep.commit_operations(ops).await.unwrap();
 
-        let t = rep.get_task_data(uuid1).unwrap().unwrap();
+        let t = rep.get_task_data(uuid1).await.unwrap().unwrap();
         assert_eq!(t.get_uuid(), uuid1);
         assert_eq!(t.get("description"), Some("another task"));
         assert_eq!(
             rep.get_task_operations(uuid1)
+                .await
                 .unwrap()
                 .into_iter()
                 .map(clean_op)
@@ -1006,84 +1036,87 @@ mod tests {
             ]
         );
 
-        assert!(rep.get_task_data(Uuid::new_v4()).unwrap().is_none());
-        assert_eq!(rep.get_task_operations(Uuid::new_v4()).unwrap(), vec![]);
+        assert!(rep.get_task_data(Uuid::new_v4()).await.unwrap().is_none());
+        assert_eq!(
+            rep.get_task_operations(Uuid::new_v4()).await.unwrap(),
+            vec![]
+        );
     }
 
-    #[test]
-    fn rebuild_working_set_includes_recurring() {
-        let mut rep = Replica::<InMemoryStorage>::new_inmemory();
+    #[tokio::test]
+    async fn rebuild_working_set_includes_recurring() {
+        let mut rep = Replica::new(InMemoryStorage::new());
 
         let uuid = Uuid::new_v4();
         let mut ops = Operations::new();
-        let mut t = rep.create_task(uuid, &mut ops).unwrap();
+        let mut t = rep.create_task(uuid, &mut ops).await.unwrap();
         t.set_status(Status::Completed, &mut ops).unwrap();
-        rep.commit_operations(ops).unwrap();
+        rep.commit_operations(ops).await.unwrap();
 
-        let mut t = rep.get_task(uuid).unwrap().unwrap();
+        let mut t = rep.get_task(uuid).await.unwrap().unwrap();
         let mut ops = Operations::new();
         t.set_status(Status::Recurring, &mut ops).unwrap();
-        rep.commit_operations(ops).unwrap();
+        rep.commit_operations(ops).await.unwrap();
 
-        rep.rebuild_working_set(true).unwrap();
+        rep.rebuild_working_set(true).await.unwrap();
 
-        let ws = rep.working_set().unwrap();
+        let ws = rep.working_set().await.unwrap();
         assert!(ws.by_uuid(uuid).is_some());
     }
 
-    #[test]
-    fn new_pending_adds_to_working_set() {
-        let mut rep = Replica::<InMemoryStorage>::new_inmemory();
+    #[tokio::test]
+    async fn new_pending_adds_to_working_set() {
+        let mut rep = Replica::new(InMemoryStorage::new());
 
         let uuid = Uuid::new_v4();
         let mut ops = Operations::new();
-        let mut t = rep.create_task(uuid, &mut ops).unwrap();
+        let mut t = rep.create_task(uuid, &mut ops).await.unwrap();
         t.set_status(Status::Pending, &mut ops).unwrap();
-        rep.commit_operations(ops).unwrap();
+        rep.commit_operations(ops).await.unwrap();
 
-        let ws = rep.working_set().unwrap();
+        let ws = rep.working_set().await.unwrap();
         assert_eq!(ws.len(), 1); // only one non-none value
         assert!(ws.by_index(0).is_none());
         assert_eq!(ws.by_index(1), Some(uuid));
 
-        let ws = rep.working_set().unwrap();
+        let ws = rep.working_set().await.unwrap();
         assert_eq!(ws.by_uuid(t.get_uuid()), Some(1));
     }
 
-    #[test]
-    fn new_recurring_adds_to_working_set() {
-        let mut rep = Replica::<InMemoryStorage>::new_inmemory();
+    #[tokio::test]
+    async fn new_recurring_adds_to_working_set() {
+        let mut rep = Replica::new(InMemoryStorage::new());
 
         let uuid = Uuid::new_v4();
         let mut ops = Operations::new();
-        let mut t = rep.create_task(uuid, &mut ops).unwrap();
+        let mut t = rep.create_task(uuid, &mut ops).await.unwrap();
         t.set_status(Status::Recurring, &mut ops).unwrap();
-        rep.commit_operations(ops).unwrap();
+        rep.commit_operations(ops).await.unwrap();
 
-        let ws = rep.working_set().unwrap();
+        let ws = rep.working_set().await.unwrap();
         assert_eq!(ws.len(), 1); // only one non-none value
         assert!(ws.by_index(0).is_none());
         assert_eq!(ws.by_index(1), Some(uuid));
 
-        let ws = rep.working_set().unwrap();
+        let ws = rep.working_set().await.unwrap();
         assert_eq!(ws.by_uuid(t.get_uuid()), Some(1));
     }
 
-    #[test]
-    fn get_does_not_exist() {
-        let mut rep = Replica::<InMemoryStorage>::new_inmemory();
+    #[tokio::test]
+    async fn get_does_not_exist() {
+        let mut rep = Replica::new(InMemoryStorage::new());
         let uuid = Uuid::new_v4();
-        assert_eq!(rep.get_task(uuid).unwrap(), None);
+        assert_eq!(rep.get_task(uuid).await.unwrap(), None);
     }
 
-    #[test]
-    fn expire() {
-        let mut rep = Replica::<InMemoryStorage>::new_inmemory();
+    #[tokio::test]
+    async fn expire() {
+        let mut rep = Replica::new(InMemoryStorage::new());
         let mut ops = Operations::new();
 
         // uuid1 is old but pending, so is not expired.
         let keeper_uuid1 = Uuid::new_v4();
-        let mut t = rep.create_task(keeper_uuid1, &mut ops).unwrap();
+        let mut t = rep.create_task(keeper_uuid1, &mut ops).await.unwrap();
         t.set_description("keeper 1".into(), &mut ops).unwrap();
         t.set_modified(Utc.with_ymd_and_hms(1980, 1, 1, 0, 0, 0).unwrap(), &mut ops)
             .unwrap();
@@ -1091,7 +1124,7 @@ mod tests {
 
         // uuid2 is old but completed, so is not expired.
         let keeper_uuid2 = Uuid::new_v4();
-        let mut t = rep.create_task(keeper_uuid2, &mut ops).unwrap();
+        let mut t = rep.create_task(keeper_uuid2, &mut ops).await.unwrap();
         t.set_description("keeper 2".into(), &mut ops).unwrap();
         t.set_modified(Utc.with_ymd_and_hms(1980, 1, 1, 0, 0, 0).unwrap(), &mut ops)
             .unwrap();
@@ -1099,7 +1132,7 @@ mod tests {
 
         // uuid3 is deleted but recently modified, so is not expired.
         let keeper_uuid3 = Uuid::new_v4();
-        let mut t = rep.create_task(keeper_uuid3, &mut ops).unwrap();
+        let mut t = rep.create_task(keeper_uuid3, &mut ops).await.unwrap();
         t.set_description("keeper 3".into(), &mut ops).unwrap();
         t.set_status(Status::Deleted, &mut ops).unwrap();
         t.set_modified(Utc::now(), &mut ops).unwrap();
@@ -1107,29 +1140,29 @@ mod tests {
 
         // uuid4 was deleted long ago, so it is expired.
         let goner_uuid4 = Uuid::new_v4();
-        let mut t = rep.create_task(goner_uuid4, &mut ops).unwrap();
+        let mut t = rep.create_task(goner_uuid4, &mut ops).await.unwrap();
         t.set_description("goner".into(), &mut ops).unwrap();
         t.set_status(Status::Deleted, &mut ops).unwrap();
         t.set_modified(Utc.with_ymd_and_hms(1980, 1, 1, 0, 0, 0).unwrap(), &mut ops)
             .unwrap();
-        rep.commit_operations(ops).unwrap();
+        rep.commit_operations(ops).await.unwrap();
 
-        rep.expire_tasks().unwrap();
+        rep.expire_tasks().await.unwrap();
 
-        assert!(rep.get_task_data(keeper_uuid1).unwrap().is_some());
-        assert!(rep.get_task_data(keeper_uuid2).unwrap().is_some());
-        assert!(rep.get_task_data(keeper_uuid3).unwrap().is_some());
-        assert!(rep.get_task_data(goner_uuid4).unwrap().is_none());
+        assert!(rep.get_task_data(keeper_uuid1).await.unwrap().is_some());
+        assert!(rep.get_task_data(keeper_uuid2).await.unwrap().is_some());
+        assert!(rep.get_task_data(keeper_uuid3).await.unwrap().is_some());
+        assert!(rep.get_task_data(goner_uuid4).await.unwrap().is_none());
     }
 
-    #[test]
-    fn dependency_map() {
-        let mut rep = Replica::<InMemoryStorage>::new_inmemory();
+    #[tokio::test]
+    async fn dependency_map() {
+        let mut rep = Replica::new(InMemoryStorage::new());
 
         let mut tasks = vec![];
         let mut ops = Operations::new();
         for _ in 0..4 {
-            let mut t = rep.create_task(Uuid::new_v4(), &mut ops).unwrap();
+            let mut t = rep.create_task(Uuid::new_v4(), &mut ops).await.unwrap();
             t.set_status(Status::Pending, &mut ops).unwrap();
             tasks.push(t);
         }
@@ -1148,11 +1181,11 @@ mod tests {
         let mut t = tasks.pop().unwrap();
         t.add_dependency(uuids[0], &mut ops).unwrap();
 
-        rep.commit_operations(ops).unwrap();
+        rep.commit_operations(ops).await.unwrap();
 
         // generate the dependency map, forcing an update based on the newly-added dependencies.
         // This need not be forced since the `commit_operations` invalidated the cached value.
-        let dm = rep.dependency_map(false).unwrap();
+        let dm = rep.dependency_map(false).await.unwrap();
 
         assert_eq!(
             dm.dependencies(uuids[3]).collect::<HashSet<_>>(),
@@ -1191,12 +1224,13 @@ mod tests {
         // mark t[0] as done, removing it from the working set
         let mut ops = Operations::new();
         rep.get_task(uuids[0])
+            .await
             .unwrap()
             .unwrap()
             .done(&mut ops)
             .unwrap();
-        rep.commit_operations(ops).unwrap();
-        let dm = rep.dependency_map(false).unwrap();
+        rep.commit_operations(ops).await.unwrap();
+        let dm = rep.dependency_map(false).await.unwrap();
 
         assert_eq!(
             dm.dependencies(uuids[3]).collect::<HashSet<_>>(),

--- a/src/server/op.rs
+++ b/src/server/op.rs
@@ -257,7 +257,7 @@ mod test {
         Ok(())
     }
 
-    fn test_transform(
+    async fn test_transform(
         setup: Option<SyncOp>,
         o1: SyncOp,
         o2: SyncOp,
@@ -269,8 +269,7 @@ mod test {
 
         // check that the two operation sequences have the same effect, enforcing the invariant of
         // the transform function.
-        let mut storage1 = InMemoryStorage::new();
-        let mut db = TaskDb::new();
+        let storage1 = InMemoryStorage::new();
         let mut ops1 = Operations::new();
         if let Some(o) = setup.clone() {
             ops1.push(o.into_op());
@@ -280,10 +279,11 @@ mod test {
             ops1.push(o.into_op());
         }
         storage1
-            .txn(|txn| db.commit_operations(txn, ops1, |_| false))
+            .txn(|txn| TaskDb::commit_operations(txn, ops1, |_| false))
+            .await
             .unwrap();
 
-        let mut storage2 = InMemoryStorage::new();
+        let storage2 = InMemoryStorage::new();
         let mut ops2 = Operations::new();
         if let Some(o) = setup {
             ops2.push(o.into_op());
@@ -293,18 +293,19 @@ mod test {
             ops2.push(o.into_op());
         }
         storage2
-            .txn(|txn| db.commit_operations(txn, ops2, |_| false))
+            .txn(|txn| TaskDb::commit_operations(txn, ops2, |_| false))
+            .await
             .unwrap();
 
-        let tasks1 = storage1.txn(|txn| Ok(db.sorted_tasks(txn)))?;
-        let tasks2 = storage2.txn(|txn| Ok(db.sorted_tasks(txn)))?;
+        let tasks1 = storage1.txn(|txn| Ok(TaskDb::sorted_tasks(txn))).await?;
+        let tasks2 = storage2.txn(|txn| Ok(TaskDb::sorted_tasks(txn))).await?;
         assert_eq!(tasks1, tasks2);
 
         Ok(())
     }
 
-    #[test]
-    fn test_unrelated_create() -> Result<()> {
+    #[tokio::test]
+    async fn test_unrelated_create() -> Result<()> {
         let uuid1 = Uuid::new_v4();
         let uuid2 = Uuid::new_v4();
 
@@ -315,10 +316,11 @@ mod test {
             Some(Create { uuid: uuid1 }),
             Some(Create { uuid: uuid2 }),
         )
+        .await
     }
 
-    #[test]
-    fn test_related_updates_different_props() -> Result<()> {
+    #[tokio::test]
+    async fn test_related_updates_different_props() -> Result<()> {
         let uuid = Uuid::new_v4();
         let timestamp = Utc::now();
 
@@ -349,10 +351,11 @@ mod test {
                 timestamp,
             }),
         )
+        .await
     }
 
-    #[test]
-    fn test_related_updates_same_prop() -> Result<()> {
+    #[tokio::test]
+    async fn test_related_updates_same_prop() -> Result<()> {
         let uuid = Uuid::new_v4();
         let timestamp1 = Utc::now();
         let timestamp2 = timestamp1 + Duration::seconds(10);
@@ -379,10 +382,11 @@ mod test {
                 timestamp: timestamp2,
             }),
         )
+        .await
     }
 
-    #[test]
-    fn test_related_updates_same_prop_same_time() -> Result<()> {
+    #[tokio::test]
+    async fn test_related_updates_same_prop_same_time() -> Result<()> {
         let uuid = Uuid::new_v4();
         let timestamp = Utc::now();
 
@@ -408,6 +412,7 @@ mod test {
             }),
             None,
         )
+        .await
     }
 
     fn uuid_strategy() -> impl Strategy<Value = Uuid> {
@@ -442,41 +447,42 @@ mod test {
         /// Check that, given two operations, their transform produces the same result, as
         /// required by the invariant.
         fn transform_invariant_holds(o1 in operation_strategy(), o2 in operation_strategy()) {
-            let (o1p, o2p) = SyncOp::transform(o1.clone(), o2.clone());
+            tokio::runtime::Runtime::new().unwrap().block_on(async {
+                let (o1p, o2p) = SyncOp::transform(o1.clone(), o2.clone());
 
             let mut ops1 = Operations::new();
             let mut ops2 = Operations::new();
-            let mut storage1 = InMemoryStorage::new();
-            let mut storage2 = InMemoryStorage::new();
-            let mut db = TaskDb::new();
+            let storage1 = InMemoryStorage::new();
+            let storage2 = InMemoryStorage::new();
 
-            // Ensure that any expected tasks already exist
-            for o in [&o1, &o2] {
-                match o {
-                    Update { uuid, .. } | Delete { uuid } => {
-                        ops1.push(Operation::Create { uuid: *uuid });
-                        ops2.push(Operation::Create { uuid: *uuid });
+                // Ensure that any expected tasks already exist
+                for o in [&o1, &o2] {
+                    match o {
+                        SyncOp::Update { uuid, .. } | SyncOp::Delete { uuid } => {
+                            ops1.push(Operation::Create { uuid: *uuid });
+                            ops2.push(Operation::Create { uuid: *uuid });
+                        }
+                        _ => {},
                     }
-                    _ => {},
                 }
-            }
 
-            ops1.push(o1.into_op());
-            ops2.push(o2.into_op());
+                ops1.push(o1.into_op());
+                ops2.push(o2.into_op());
 
-            if let Some(o2p) = o2p {
-                ops1.push(o2p.into_op());
-            }
-            if let Some(o1p) = o1p {
-                ops2.push(o1p.into_op());
-            }
+                if let Some(o2p) = o2p {
+                    ops1.push(o2p.into_op());
+                }
+                if let Some(o1p) = o1p {
+                    ops2.push(o1p.into_op());
+                }
 
-            storage1.txn(|txn| db.commit_operations(txn, ops1, |_| false)).unwrap();
-            storage2.txn(|txn| db.commit_operations(txn, ops2, |_| false)).unwrap();
+                storage1.txn(|txn| TaskDb::commit_operations(txn, ops1, |_| false)).await.unwrap();
+                storage2.txn(|txn| TaskDb::commit_operations(txn, ops2, |_| false)).await.unwrap();
 
-            let tasks1 = storage1.txn(|txn| Ok(db.sorted_tasks(txn))).unwrap();
-            let tasks2 = storage2.txn(|txn| Ok(db.sorted_tasks(txn))).unwrap();
-            assert_eq!(tasks1, tasks2);
+                let tasks1 = storage1.txn(|txn| Ok(TaskDb::sorted_tasks(txn))).await.unwrap();
+                let tasks2 = storage2.txn(|txn| Ok(TaskDb::sorted_tasks(txn))).await.unwrap();
+                assert_eq!(tasks1, tasks2);
+            });
         }
     }
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -10,6 +10,7 @@ traits defined here and pass the result to [`Replica`](crate::Replica).
 
 use crate::errors::Result;
 use crate::operation::Operation;
+use async_trait::async_trait;
 use std::collections::HashMap;
 use uuid::Uuid;
 
@@ -153,9 +154,23 @@ pub trait StorageTxn {
 
 /// A trait for objects able to act as task storage.  Most of the interesting behavior is in the
 /// [`crate::storage::StorageTxn`] trait.
-pub trait Storage {
-    /// Begin a transaction
-    fn txn<F, R>(&mut self, f: F) -> Result<R>
+///
+/// ## Concurrency
+///
+/// The [`Storage::txn`] method is `async` but takes a **synchronous** closure `f`. This allows
+/// the use of database drivers with blocking APIs (like `rusqlite`) without stalling
+/// the async runtime.
+///
+/// Implementations of this trait must execute the closure on a separate thread, for
+/// example by using `tokio::task::spawn_blocking`.
+#[async_trait]
+pub trait Storage: Send + Sync {
+    /// Begins an async transaction.
+    ///
+    /// The provided closure `f` is synchronous and will be executed by the storage
+    /// backend on a blocking-safe thread.
+    async fn txn<F, R>(&self, f: F) -> Result<R>
     where
-        F: for<'a> FnOnce(&'a mut (dyn StorageTxn + 'a)) -> Result<R>;
+        F: for<'a> FnOnce(&'a mut (dyn StorageTxn + 'a)) -> Result<R> + Send + 'static,
+        R: Send + 'static;
 }

--- a/src/storage/test.rs
+++ b/src/storage/test.rs
@@ -13,655 +13,765 @@ use uuid::Uuid;
 /// Define a collection of storage tests that apply to all storage implementations.
 macro_rules! storage_tests {
     ($storage:expr) => {
-        #[test]
-        fn get_working_set_empty() -> $crate::errors::Result<()> {
-            $crate::storage::test::get_working_set_empty($storage)
+        #[tokio::test]
+        async fn get_working_set_empty() -> $crate::errors::Result<()> {
+            $crate::storage::test::get_working_set_empty($storage).await
         }
 
-        #[test]
-        fn add_to_working_set() -> $crate::errors::Result<()> {
-            $crate::storage::test::add_to_working_set($storage)
+        #[tokio::test]
+        async fn add_to_working_set() -> $crate::errors::Result<()> {
+            $crate::storage::test::add_to_working_set($storage).await
         }
 
-        #[test]
-        fn clear_working_set() -> $crate::errors::Result<()> {
-            $crate::storage::test::clear_working_set($storage)
+        #[tokio::test]
+        async fn clear_working_set() -> $crate::errors::Result<()> {
+            $crate::storage::test::clear_working_set($storage).await
         }
 
-        #[test]
-        fn drop_transaction() -> $crate::errors::Result<()> {
-            $crate::storage::test::drop_transaction($storage)
+        #[tokio::test]
+        async fn drop_transaction() -> $crate::errors::Result<()> {
+            $crate::storage::test::drop_transaction($storage).await
         }
 
-        #[test]
-        fn create() -> $crate::errors::Result<()> {
-            $crate::storage::test::create($storage)
+        #[tokio::test]
+        async fn create() -> $crate::errors::Result<()> {
+            $crate::storage::test::create($storage).await
         }
 
-        #[test]
-        fn create_exists() -> $crate::errors::Result<()> {
-            $crate::storage::test::create_exists($storage)
+        #[tokio::test]
+        async fn create_exists() -> $crate::errors::Result<()> {
+            $crate::storage::test::create_exists($storage).await
         }
 
-        #[test]
-        fn get_missing() -> $crate::errors::Result<()> {
-            $crate::storage::test::get_missing($storage)
+        #[tokio::test]
+        async fn get_missing() -> $crate::errors::Result<()> {
+            $crate::storage::test::get_missing($storage).await
         }
 
-        #[test]
-        fn set_task() -> $crate::errors::Result<()> {
-            $crate::storage::test::set_task($storage)
+        #[tokio::test]
+        async fn set_task() -> $crate::errors::Result<()> {
+            $crate::storage::test::set_task($storage).await
         }
 
-        #[test]
-        fn delete_task_missing() -> $crate::errors::Result<()> {
-            $crate::storage::test::delete_task_missing($storage)
+        #[tokio::test]
+        async fn delete_task_missing() -> $crate::errors::Result<()> {
+            $crate::storage::test::delete_task_missing($storage).await
         }
 
-        #[test]
-        fn delete_task_exists() -> $crate::errors::Result<()> {
-            $crate::storage::test::delete_task_exists($storage)
+        #[tokio::test]
+        async fn delete_task_exists() -> $crate::errors::Result<()> {
+            $crate::storage::test::delete_task_exists($storage).await
         }
 
-        #[test]
-        fn all_tasks_empty() -> $crate::errors::Result<()> {
-            $crate::storage::test::all_tasks_empty($storage)
+        #[tokio::test]
+        async fn all_tasks_empty() -> $crate::errors::Result<()> {
+            $crate::storage::test::all_tasks_empty($storage).await
         }
 
-        #[test]
-        fn all_tasks_and_uuids() -> $crate::errors::Result<()> {
-            $crate::storage::test::all_tasks_and_uuids($storage)
+        #[tokio::test]
+        async fn all_tasks_and_uuids() -> $crate::errors::Result<()> {
+            $crate::storage::test::all_tasks_and_uuids($storage).await
         }
 
-        #[test]
-        fn base_version_default() -> Result<()> {
-            $crate::storage::test::base_version_default($storage)
+        #[tokio::test]
+        async fn base_version_default() -> Result<()> {
+            $crate::storage::test::base_version_default($storage).await
         }
 
-        #[test]
-        fn base_version_setting() -> Result<()> {
-            $crate::storage::test::base_version_setting($storage)
+        #[tokio::test]
+        async fn base_version_setting() -> Result<()> {
+            $crate::storage::test::base_version_setting($storage).await
         }
 
-        #[test]
-        fn unsynced_operations() -> Result<()> {
-            $crate::storage::test::unsynced_operations($storage)
+        #[tokio::test]
+        async fn unsynced_operations() -> Result<()> {
+            $crate::storage::test::unsynced_operations($storage).await
         }
 
-        #[test]
-        fn remove_operations() -> Result<()> {
-            $crate::storage::test::remove_operations($storage)
+        #[tokio::test]
+        async fn remove_operations() -> Result<()> {
+            $crate::storage::test::remove_operations($storage).await
         }
 
-        #[test]
-        fn task_operations() -> Result<()> {
-            $crate::storage::test::task_operations($storage)
+        #[tokio::test]
+        async fn task_operations() -> Result<()> {
+            $crate::storage::test::task_operations($storage).await
         }
 
-        #[test]
-        fn sync_complete() -> Result<()> {
-            $crate::storage::test::sync_complete($storage)
+        #[tokio::test]
+        async fn sync_complete() -> Result<()> {
+            $crate::storage::test::sync_complete($storage).await
         }
 
-        #[test]
-        fn set_working_set_item() -> Result<()> {
-            $crate::storage::test::set_working_set_item($storage)
+        #[tokio::test]
+        async fn set_working_set_item() -> Result<()> {
+            $crate::storage::test::set_working_set_item($storage).await
         }
     };
 }
 pub(crate) use storage_tests;
 
-pub(super) fn get_working_set_empty(mut storage: impl Storage) -> Result<()> {
-    storage.txn(|txn| {
-        let ws = txn.get_working_set()?;
-        assert_eq!(ws, vec![None]);
-        Ok(())
-    })
+pub(super) async fn get_working_set_empty(storage: impl Storage) -> Result<()> {
+    storage
+        .txn(move |txn| {
+            let ws = txn.get_working_set()?;
+            assert_eq!(ws, vec![None]);
+            Ok(())
+        })
+        .await
 }
 
-pub(super) fn add_to_working_set(mut storage: impl Storage) -> Result<()> {
+pub(super) async fn add_to_working_set(storage: impl Storage) -> Result<()> {
     let uuid1 = Uuid::new_v4();
     let uuid2 = Uuid::new_v4();
 
-    storage.txn(|txn| {
-        txn.add_to_working_set(uuid1)?;
-        txn.add_to_working_set(uuid2)?;
-        txn.commit()
-    })?;
+    storage
+        .txn(move |txn| {
+            txn.add_to_working_set(uuid1)?;
+            txn.add_to_working_set(uuid2)?;
+            txn.commit()
+        })
+        .await?;
 
-    storage.txn(|txn| {
-        let ws = txn.get_working_set()?;
-        assert_eq!(ws, vec![None, Some(uuid1), Some(uuid2)]);
-        Ok(())
-    })
+    storage
+        .txn(move |txn| {
+            let ws = txn.get_working_set()?;
+            assert_eq!(ws, vec![None, Some(uuid1), Some(uuid2)]);
+            Ok(())
+        })
+        .await
 }
 
-pub(super) fn clear_working_set(mut storage: impl Storage) -> Result<()> {
+pub(super) async fn clear_working_set(storage: impl Storage) -> Result<()> {
     let uuid1 = Uuid::new_v4();
     let uuid2 = Uuid::new_v4();
 
-    storage.txn(|txn| {
-        txn.add_to_working_set(uuid1)?;
-        txn.add_to_working_set(uuid2)?;
-        txn.commit()
-    })?;
+    storage
+        .txn(move |txn| {
+            txn.add_to_working_set(uuid1)?;
+            txn.add_to_working_set(uuid2)?;
+            txn.commit()
+        })
+        .await?;
 
-    storage.txn(|txn| {
-        txn.clear_working_set()?;
-        txn.add_to_working_set(uuid2)?;
-        txn.add_to_working_set(uuid1)?;
-        txn.commit()
-    })?;
+    storage
+        .txn(move |txn| {
+            txn.clear_working_set()?;
+            txn.add_to_working_set(uuid2)?;
+            txn.add_to_working_set(uuid1)?;
+            txn.commit()
+        })
+        .await?;
 
-    storage.txn(|txn| {
-        let ws = txn.get_working_set()?;
-        assert_eq!(ws, vec![None, Some(uuid2), Some(uuid1)]);
-        Ok(())
-    })
+    storage
+        .txn(move |txn| {
+            let ws = txn.get_working_set()?;
+            assert_eq!(ws, vec![None, Some(uuid2), Some(uuid1)]);
+            Ok(())
+        })
+        .await
 }
 
-pub(super) fn drop_transaction(mut storage: impl Storage) -> Result<()> {
+pub(super) async fn drop_transaction(storage: impl Storage) -> Result<()> {
     let uuid1 = Uuid::new_v4();
     let uuid2 = Uuid::new_v4();
 
-    storage.txn(|txn| {
-        assert!(txn.create_task(uuid1)?);
-        txn.commit()
-    })?;
+    storage
+        .txn(move |txn| {
+            assert!(txn.create_task(uuid1)?);
+            txn.commit()
+        })
+        .await?;
 
-    let result: Result<()> = storage.txn(|txn| {
-        assert!(txn.create_task(uuid2)?);
-        Err(Error::Other(anyhow!("Intentional error")))
-    });
+    let result: Result<()> = storage
+        .txn(move |txn| {
+            assert!(txn.create_task(uuid2)?);
+            Err(Error::Other(anyhow!("Intentional error")))
+        })
+        .await;
 
     assert!(result.is_err());
 
-    storage.txn(|txn| {
-        let uuids = txn.all_task_uuids()?;
-        assert_eq!(uuids, [uuid1]);
-        Ok(())
-    })
+    storage
+        .txn(move |txn| {
+            let uuids = txn.all_task_uuids()?;
+            assert_eq!(uuids, [uuid1]);
+            Ok(())
+        })
+        .await
 }
 
-pub(super) fn create(mut storage: impl Storage) -> Result<()> {
+pub(super) async fn create(storage: impl Storage) -> Result<()> {
     let uuid = Uuid::new_v4();
 
-    storage.txn(|txn| {
-        assert!(txn.create_task(uuid)?);
-        txn.commit()
-    })?;
+    storage
+        .txn(move |txn| {
+            assert!(txn.create_task(uuid)?);
+            txn.commit()
+        })
+        .await?;
 
-    storage.txn(|txn| {
-        let task = txn.get_task(uuid)?;
-        assert_eq!(task, Some(taskmap_with(vec![])));
-        Ok(())
-    })
+    storage
+        .txn(move |txn| {
+            let task = txn.get_task(uuid)?;
+            assert_eq!(task, Some(taskmap_with(vec![])));
+            Ok(())
+        })
+        .await
 }
 
-pub(super) fn create_exists(mut storage: impl Storage) -> Result<()> {
+pub(super) async fn create_exists(storage: impl Storage) -> Result<()> {
     let uuid = Uuid::new_v4();
 
-    storage.txn(|txn| {
-        assert!(txn.create_task(uuid)?);
-        txn.commit()
-    })?;
+    storage
+        .txn(move |txn| {
+            assert!(txn.create_task(uuid)?);
+            txn.commit()
+        })
+        .await?;
 
-    storage.txn(|txn| {
-        assert!(!txn.create_task(uuid)?);
-        txn.commit()
-    })
+    storage
+        .txn(move |txn| {
+            assert!(!txn.create_task(uuid)?);
+            txn.commit()
+        })
+        .await
 }
 
-pub(super) fn get_missing(mut storage: impl Storage) -> Result<()> {
+pub(super) async fn get_missing(storage: impl Storage) -> Result<()> {
     let uuid = Uuid::new_v4();
-    storage.txn(|txn| {
-        let task = txn.get_task(uuid)?;
-        assert_eq!(task, None);
-        Ok(())
-    })
+    storage
+        .txn(move |txn| {
+            let task = txn.get_task(uuid)?;
+            assert_eq!(task, None);
+            Ok(())
+        })
+        .await
 }
 
-pub(super) fn set_task(mut storage: impl Storage) -> Result<()> {
+pub(super) async fn set_task(storage: impl Storage) -> Result<()> {
     let uuid = Uuid::new_v4();
-    storage.txn(|txn| {
-        txn.set_task(uuid, taskmap_with(vec![("k".to_string(), "v".to_string())]))?;
-        txn.commit()
-    })?;
+    storage
+        .txn(move |txn| {
+            txn.set_task(uuid, taskmap_with(vec![("k".to_string(), "v".to_string())]))?;
+            txn.commit()
+        })
+        .await?;
 
-    storage.txn(|txn| {
-        let task = txn.get_task(uuid)?;
-        assert_eq!(
-            task,
-            Some(taskmap_with(vec![("k".to_string(), "v".to_string())]))
-        );
-        Ok(())
-    })
+    storage
+        .txn(move |txn| {
+            let task = txn.get_task(uuid)?;
+            assert_eq!(
+                task,
+                Some(taskmap_with(vec![("k".to_string(), "v".to_string())]))
+            );
+            Ok(())
+        })
+        .await
 }
 
-pub(super) fn delete_task_missing(mut storage: impl Storage) -> Result<()> {
+pub(super) async fn delete_task_missing(storage: impl Storage) -> Result<()> {
     let uuid = Uuid::new_v4();
-    storage.txn(|txn| {
-        assert!(!txn.delete_task(uuid)?);
-        Ok(())
-    })
+    storage
+        .txn(move |txn| {
+            assert!(!txn.delete_task(uuid)?);
+            Ok(())
+        })
+        .await
 }
 
-pub(super) fn delete_task_exists(mut storage: impl Storage) -> Result<()> {
+pub(super) async fn delete_task_exists(storage: impl Storage) -> Result<()> {
     let uuid = Uuid::new_v4();
-    storage.txn(|txn| {
-        assert!(txn.create_task(uuid)?);
-        txn.commit()
-    })?;
+    storage
+        .txn(move |txn| {
+            assert!(txn.create_task(uuid)?);
+            txn.commit()
+        })
+        .await?;
 
-    storage.txn(|txn| {
-        assert!(txn.delete_task(uuid)?);
-        txn.commit()
-    })
+    storage
+        .txn(move |txn| {
+            assert!(txn.delete_task(uuid)?);
+            txn.commit()
+        })
+        .await
 }
 
-pub(super) fn all_tasks_empty(mut storage: impl Storage) -> Result<()> {
-    storage.txn(|txn| {
-        let tasks = txn.all_tasks()?;
-        assert_eq!(tasks, vec![]);
-        Ok(())
-    })
+pub(super) async fn all_tasks_empty(storage: impl Storage) -> Result<()> {
+    storage
+        .txn(move |txn| {
+            let tasks = txn.all_tasks()?;
+            assert_eq!(tasks, vec![]);
+            Ok(())
+        })
+        .await
 }
 
-pub(super) fn all_tasks_and_uuids(mut storage: impl Storage) -> Result<()> {
+pub(super) async fn all_tasks_and_uuids(storage: impl Storage) -> Result<()> {
     let uuid1 = Uuid::new_v4();
     let uuid2 = Uuid::new_v4();
-    storage.txn(|txn| {
-        assert!(txn.create_task(uuid1)?);
-        txn.set_task(
-            uuid1,
-            taskmap_with(vec![("num".to_string(), "1".to_string())]),
-        )?;
-        assert!(txn.create_task(uuid2)?);
-        txn.set_task(
-            uuid2,
-            taskmap_with(vec![("num".to_string(), "2".to_string())]),
-        )?;
-        txn.commit()
-    })?;
-
-    storage.txn(|txn| {
-        let mut tasks = txn.all_tasks()?;
-
-        // order is nondeterministic, so sort by uuid
-        tasks.sort_by(|a, b| a.0.cmp(&b.0));
-
-        let mut exp = vec![
-            (
+    storage
+        .txn(move |txn| {
+            assert!(txn.create_task(uuid1)?);
+            txn.set_task(
                 uuid1,
                 taskmap_with(vec![("num".to_string(), "1".to_string())]),
-            ),
-            (
+            )?;
+            assert!(txn.create_task(uuid2)?);
+            txn.set_task(
                 uuid2,
                 taskmap_with(vec![("num".to_string(), "2".to_string())]),
-            ),
-        ];
-        exp.sort_by(|a, b| a.0.cmp(&b.0));
+            )?;
+            txn.commit()
+        })
+        .await?;
 
-        assert_eq!(tasks, exp);
-        Ok(())
-    })?;
+    storage
+        .txn(move |txn| {
+            let mut tasks = txn.all_tasks()?;
 
-    storage.txn(|txn| {
-        let mut uuids = txn.all_task_uuids()?;
-        uuids.sort();
+            // order is nondeterministic, so sort by uuid
+            tasks.sort_by(|a, b| a.0.cmp(&b.0));
 
-        let mut exp = vec![uuid1, uuid2];
-        exp.sort();
+            let mut exp = vec![
+                (
+                    uuid1,
+                    taskmap_with(vec![("num".to_string(), "1".to_string())]),
+                ),
+                (
+                    uuid2,
+                    taskmap_with(vec![("num".to_string(), "2".to_string())]),
+                ),
+            ];
+            exp.sort_by(|a, b| a.0.cmp(&b.0));
 
-        assert_eq!(uuids, exp);
-        Ok(())
-    })
+            assert_eq!(tasks, exp);
+            Ok(())
+        })
+        .await?;
+
+    storage
+        .txn(move |txn| {
+            let mut uuids = txn.all_task_uuids()?;
+            uuids.sort();
+
+            let mut exp = vec![uuid1, uuid2];
+            exp.sort();
+
+            assert_eq!(uuids, exp);
+            Ok(())
+        })
+        .await
 }
 
-pub(super) fn base_version_default(mut storage: impl Storage) -> Result<()> {
-    storage.txn(|txn| {
-        assert_eq!(txn.base_version()?, DEFAULT_BASE_VERSION);
-        Ok(())
-    })
+pub(super) async fn base_version_default(storage: impl Storage) -> Result<()> {
+    storage
+        .txn(move |txn| {
+            assert_eq!(txn.base_version()?, DEFAULT_BASE_VERSION);
+            Ok(())
+        })
+        .await
 }
 
-pub(super) fn base_version_setting(mut storage: impl Storage) -> Result<()> {
+pub(super) async fn base_version_setting(storage: impl Storage) -> Result<()> {
     let u = Uuid::new_v4();
-    storage.txn(|txn| {
-        txn.set_base_version(u)?;
-        txn.commit()
-    })?;
+    storage
+        .txn(move |txn| {
+            txn.set_base_version(u)?;
+            txn.commit()
+        })
+        .await?;
 
-    storage.txn(|txn| {
-        assert_eq!(txn.base_version()?, u);
-        Ok(())
-    })
+    storage
+        .txn(move |txn| {
+            assert_eq!(txn.base_version()?, u);
+            Ok(())
+        })
+        .await
 }
 
-pub(super) fn unsynced_operations(mut storage: impl Storage) -> Result<()> {
+pub(super) async fn unsynced_operations(storage: impl Storage) -> Result<()> {
     let uuid1 = Uuid::new_v4();
     let uuid2 = Uuid::new_v4();
     let uuid3 = Uuid::new_v4();
 
     // create some operations
-    storage.txn(|txn| {
-        txn.add_operation(Operation::Create { uuid: uuid1 })?;
-        txn.add_operation(Operation::Create { uuid: uuid2 })?;
-        txn.commit()
-    })?;
+    storage
+        .txn(move |txn| {
+            txn.add_operation(Operation::Create { uuid: uuid1 })?;
+            txn.add_operation(Operation::Create { uuid: uuid2 })?;
+            txn.commit()
+        })
+        .await?;
 
     // read them back
-    storage.txn(|txn| {
-        let ops = txn.unsynced_operations()?;
-        assert_eq!(
-            ops,
-            vec![
-                Operation::Create { uuid: uuid1 },
-                Operation::Create { uuid: uuid2 },
-            ]
-        );
+    storage
+        .txn(move |txn| {
+            let ops = txn.unsynced_operations()?;
+            assert_eq!(
+                ops,
+                vec![
+                    Operation::Create { uuid: uuid1 },
+                    Operation::Create { uuid: uuid2 },
+                ]
+            );
 
-        assert_eq!(txn.num_unsynced_operations()?, 2);
-        Ok(())
-    })?;
+            assert_eq!(txn.num_unsynced_operations()?, 2);
+            Ok(())
+        })
+        .await?;
 
     // Sync them.
-    storage.txn(|txn| {
-        txn.sync_complete()?;
-        txn.commit()
-    })?;
+    storage
+        .txn(move |txn| {
+            txn.sync_complete()?;
+            txn.commit()
+        })
+        .await?;
 
     // create some more operations (to test adding operations after sync)
-    storage.txn(|txn| {
-        txn.add_operation(Operation::Create { uuid: uuid3 })?;
-        txn.add_operation(Operation::Delete {
-            uuid: uuid3,
-            old_task: TaskMap::new(),
-        })?;
-        txn.commit()
-    })?;
+    storage
+        .txn(move |txn| {
+            txn.add_operation(Operation::Create { uuid: uuid3 })?;
+            txn.add_operation(Operation::Delete {
+                uuid: uuid3,
+                old_task: TaskMap::new(),
+            })?;
+            txn.commit()
+        })
+        .await?;
 
     // read them back
-    storage.txn(|txn| {
-        let ops = txn.unsynced_operations()?;
-        assert_eq!(
-            ops,
-            vec![
-                Operation::Create { uuid: uuid3 },
-                Operation::Delete {
-                    uuid: uuid3,
-                    old_task: TaskMap::new()
-                },
-            ]
-        );
-        assert_eq!(txn.num_unsynced_operations()?, 2);
-        Ok(())
-    })?;
+    storage
+        .txn(move |txn| {
+            let ops = txn.unsynced_operations()?;
+            assert_eq!(
+                ops,
+                vec![
+                    Operation::Create { uuid: uuid3 },
+                    Operation::Delete {
+                        uuid: uuid3,
+                        old_task: TaskMap::new()
+                    },
+                ]
+            );
+            assert_eq!(txn.num_unsynced_operations()?, 2);
+            Ok(())
+        })
+        .await?;
 
     // Remove the right one
-    storage.txn(|txn| {
-        txn.remove_operation(Operation::Delete {
-            uuid: uuid3,
-            old_task: TaskMap::new(),
-        })?;
-        txn.commit()
-    })?;
+    storage
+        .txn(move |txn| {
+            txn.remove_operation(Operation::Delete {
+                uuid: uuid3,
+                old_task: TaskMap::new(),
+            })?;
+            txn.commit()
+        })
+        .await?;
 
     // read the remaining op back
-    storage.txn(|txn| {
-        let ops = txn.unsynced_operations()?;
-        assert_eq!(ops, vec![Operation::Create { uuid: uuid3 },]);
-        assert_eq!(txn.num_unsynced_operations()?, 1);
-        Ok(())
-    })
+    storage
+        .txn(move |txn| {
+            let ops = txn.unsynced_operations()?;
+            assert_eq!(ops, vec![Operation::Create { uuid: uuid3 },]);
+            assert_eq!(txn.num_unsynced_operations()?, 1);
+            Ok(())
+        })
+        .await
 }
 
-pub(super) fn remove_operations(mut storage: impl Storage) -> Result<()> {
+pub(super) async fn remove_operations(storage: impl Storage) -> Result<()> {
     let uuid1 = Uuid::new_v4();
     let uuid2 = Uuid::new_v4();
     let uuid3 = Uuid::new_v4();
     let uuid4 = Uuid::new_v4();
 
     // Create some tasks and operations.
-    storage.txn(|txn| {
-        txn.create_task(uuid1)?;
-        txn.create_task(uuid2)?;
-        txn.create_task(uuid3)?;
+    storage
+        .txn(move |txn| {
+            txn.create_task(uuid1)?;
+            txn.create_task(uuid2)?;
+            txn.create_task(uuid3)?;
 
-        txn.add_operation(Operation::Create { uuid: uuid1 })?;
-        txn.add_operation(Operation::Create { uuid: uuid2 })?;
-        txn.add_operation(Operation::Create { uuid: uuid3 })?;
-        txn.commit()
-    })?;
+            txn.add_operation(Operation::Create { uuid: uuid1 })?;
+            txn.add_operation(Operation::Create { uuid: uuid2 })?;
+            txn.add_operation(Operation::Create { uuid: uuid3 })?;
+            txn.commit()
+        })
+        .await?;
 
     // Remove the uuid3 operation.
-    storage.txn(|txn| {
-        txn.remove_operation(Operation::Create { uuid: uuid3 })?;
-        assert_eq!(txn.num_unsynced_operations()?, 2);
-        txn.commit()
-    })?;
+    storage
+        .txn(move |txn| {
+            txn.remove_operation(Operation::Create { uuid: uuid3 })?;
+            assert_eq!(txn.num_unsynced_operations()?, 2);
+            txn.commit()
+        })
+        .await?;
 
     // Remove a nonexistent operation
-    storage.txn(|txn| {
-        assert!(txn
-            .remove_operation(Operation::Create { uuid: uuid4 })
-            .is_err());
-        Ok(())
-    })?;
+    storage
+        .txn(move |txn| {
+            assert!(txn
+                .remove_operation(Operation::Create { uuid: uuid4 })
+                .is_err());
+            Ok(())
+        })
+        .await?;
 
     // Remove an operation that is not most recent.
-    storage.txn(|txn| {
-        assert!(txn
-            .remove_operation(Operation::Create { uuid: uuid1 })
-            .is_err());
-        Ok(())
-    })?;
+    storage
+        .txn(move |txn| {
+            assert!(txn
+                .remove_operation(Operation::Create { uuid: uuid1 })
+                .is_err());
+            Ok(())
+        })
+        .await?;
 
     // Mark operations as synced.
-    storage.txn(|txn| {
-        txn.sync_complete()?;
-        txn.commit()
-    })?;
+    storage
+        .txn(move |txn| {
+            txn.sync_complete()?;
+            txn.commit()
+        })
+        .await?;
 
     // Try to remove the synced operation.
-    storage.txn(|txn| {
-        assert!(txn
-            .remove_operation(Operation::Create { uuid: uuid2 })
-            .is_err());
-        Ok(())
-    })
+    storage
+        .txn(move |txn| {
+            assert!(txn
+                .remove_operation(Operation::Create { uuid: uuid2 })
+                .is_err());
+            Ok(())
+        })
+        .await
 }
 
-pub(super) fn task_operations(mut storage: impl Storage) -> Result<()> {
+pub(super) async fn task_operations(storage: impl Storage) -> Result<()> {
     let uuid1 = Uuid::new_v4();
     let uuid2 = Uuid::new_v4();
     let uuid3 = Uuid::new_v4();
     let now = Utc::now();
 
     // Create some tasks and operations.
-    storage.txn(|txn| {
-        txn.create_task(uuid1)?;
-        txn.create_task(uuid2)?;
-        txn.create_task(uuid3)?;
+    storage
+        .txn(move |txn| {
+            txn.create_task(uuid1)?;
+            txn.create_task(uuid2)?;
+            txn.create_task(uuid3)?;
 
-        txn.add_operation(Operation::UndoPoint)?;
-        txn.add_operation(Operation::Create { uuid: uuid1 })?;
-        txn.add_operation(Operation::Create { uuid: uuid1 })?;
-        txn.add_operation(Operation::UndoPoint)?;
-        txn.add_operation(Operation::Delete {
-            uuid: uuid2,
-            old_task: TaskMap::new(),
-        })?;
-        txn.add_operation(Operation::Update {
-            uuid: uuid3,
-            property: "p".into(),
-            old_value: None,
-            value: Some("P".into()),
-            timestamp: now,
-        })?;
-        txn.add_operation(Operation::Delete {
-            uuid: uuid3,
-            old_task: TaskMap::new(),
-        })?;
-
-        txn.commit()
-    })?;
-
-    // remove the last operation to verify it doesn't appear
-    storage.txn(|txn| {
-        txn.remove_operation(Operation::Delete {
-            uuid: uuid3,
-            old_task: TaskMap::new(),
-        })?;
-        txn.commit()
-    })?;
-
-    // read them back
-    storage.txn(|txn| {
-        let ops = txn.get_task_operations(uuid1)?;
-        assert_eq!(
-            ops,
-            vec![
-                Operation::Create { uuid: uuid1 },
-                Operation::Create { uuid: uuid1 },
-            ]
-        );
-        let ops = txn.get_task_operations(uuid2)?;
-        assert_eq!(
-            ops,
-            vec![Operation::Delete {
+            txn.add_operation(Operation::UndoPoint)?;
+            txn.add_operation(Operation::Create { uuid: uuid1 })?;
+            txn.add_operation(Operation::Create { uuid: uuid1 })?;
+            txn.add_operation(Operation::UndoPoint)?;
+            txn.add_operation(Operation::Delete {
                 uuid: uuid2,
-                old_task: TaskMap::new()
-            }]
-        );
-        let ops = txn.get_task_operations(uuid3)?;
-        assert_eq!(
-            ops,
-            vec![Operation::Update {
+                old_task: TaskMap::new(),
+            })?;
+            txn.add_operation(Operation::Update {
                 uuid: uuid3,
                 property: "p".into(),
                 old_value: None,
                 value: Some("P".into()),
                 timestamp: now,
-            }]
-        );
-        Ok(())
-    })?;
+            })?;
+            txn.add_operation(Operation::Delete {
+                uuid: uuid3,
+                old_task: TaskMap::new(),
+            })?;
+
+            txn.commit()
+        })
+        .await?;
+
+    // remove the last operation to verify it doesn't appear
+    storage
+        .txn(move |txn| {
+            txn.remove_operation(Operation::Delete {
+                uuid: uuid3,
+                old_task: TaskMap::new(),
+            })?;
+            txn.commit()
+        })
+        .await?;
+
+    // read them back
+    storage
+        .txn(move |txn| {
+            let ops = txn.get_task_operations(uuid1)?;
+            assert_eq!(
+                ops,
+                vec![
+                    Operation::Create { uuid: uuid1 },
+                    Operation::Create { uuid: uuid1 },
+                ]
+            );
+            let ops = txn.get_task_operations(uuid2)?;
+            assert_eq!(
+                ops,
+                vec![Operation::Delete {
+                    uuid: uuid2,
+                    old_task: TaskMap::new()
+                }]
+            );
+            let ops = txn.get_task_operations(uuid3)?;
+            assert_eq!(
+                ops,
+                vec![Operation::Update {
+                    uuid: uuid3,
+                    property: "p".into(),
+                    old_value: None,
+                    value: Some("P".into()),
+                    timestamp: now,
+                }]
+            );
+            Ok(())
+        })
+        .await?;
 
     // Sync and verify the task operations still exist.
-    storage.txn(|txn| {
-        txn.sync_complete()?;
+    storage
+        .txn(move |txn| {
+            txn.sync_complete()?;
 
-        let ops = txn.get_task_operations(uuid1)?;
-        assert_eq!(ops.len(), 2);
-        let ops = txn.get_task_operations(uuid2)?;
-        assert_eq!(ops.len(), 1);
-        let ops = txn.get_task_operations(uuid3)?;
-        assert_eq!(ops.len(), 1);
-        Ok(())
-    })
+            let ops = txn.get_task_operations(uuid1)?;
+            assert_eq!(ops.len(), 2);
+            let ops = txn.get_task_operations(uuid2)?;
+            assert_eq!(ops.len(), 1);
+            let ops = txn.get_task_operations(uuid3)?;
+            assert_eq!(ops.len(), 1);
+            Ok(())
+        })
+        .await
 }
 
-pub(super) fn sync_complete(mut storage: impl Storage) -> Result<()> {
+pub(super) async fn sync_complete(storage: impl Storage) -> Result<()> {
     let uuid1 = Uuid::new_v4();
     let uuid2 = Uuid::new_v4();
 
     // Create some tasks and operations.
-    storage.txn(|txn| {
-        txn.create_task(uuid1)?;
-        txn.create_task(uuid2)?;
+    storage
+        .txn(move |txn| {
+            txn.create_task(uuid1)?;
+            txn.create_task(uuid2)?;
 
-        txn.add_operation(Operation::Create { uuid: uuid1 })?;
-        txn.add_operation(Operation::Create { uuid: uuid2 })?;
+            txn.add_operation(Operation::Create { uuid: uuid1 })?;
+            txn.add_operation(Operation::Create { uuid: uuid2 })?;
 
-        txn.commit()
-    })?;
+            txn.commit()
+        })
+        .await?;
 
     // Sync and verify the task operations still exist.
-    storage.txn(|txn| {
-        txn.sync_complete()?;
+    storage
+        .txn(move |txn| {
+            txn.sync_complete()?;
 
-        let ops = txn.get_task_operations(uuid1)?;
-        assert_eq!(ops.len(), 1);
-        let ops = txn.get_task_operations(uuid2)?;
-        assert_eq!(ops.len(), 1);
-        Ok(())
-    })?;
+            let ops = txn.get_task_operations(uuid1)?;
+            assert_eq!(ops.len(), 1);
+            let ops = txn.get_task_operations(uuid2)?;
+            assert_eq!(ops.len(), 1);
+            Ok(())
+        })
+        .await?;
 
     // Delete uuid2.
-    storage.txn(|txn| {
-        txn.delete_task(uuid2)?;
-        txn.add_operation(Operation::Delete {
-            uuid: uuid2,
-            old_task: TaskMap::new(),
-        })?;
+    storage
+        .txn(move |txn| {
+            txn.delete_task(uuid2)?;
+            txn.add_operation(Operation::Delete {
+                uuid: uuid2,
+                old_task: TaskMap::new(),
+            })?;
 
-        txn.commit()
-    })?;
+            txn.commit()
+        })
+        .await?;
 
     // Sync and verify that uuid1's operations still exist, but uuid2's do not.
-    storage.txn(|txn| {
-        txn.sync_complete()?;
+    storage
+        .txn(move |txn| {
+            txn.sync_complete()?;
 
-        let ops = txn.get_task_operations(uuid1)?;
-        assert_eq!(ops.len(), 1);
-        let ops = txn.get_task_operations(uuid2)?;
-        assert_eq!(ops.len(), 0);
-        Ok(())
-    })
+            let ops = txn.get_task_operations(uuid1)?;
+            assert_eq!(ops.len(), 1);
+            let ops = txn.get_task_operations(uuid2)?;
+            assert_eq!(ops.len(), 0);
+            Ok(())
+        })
+        .await
 }
 
-pub(super) fn set_working_set_item(mut storage: impl Storage) -> Result<()> {
+pub(super) async fn set_working_set_item(storage: impl Storage) -> Result<()> {
     let uuid1 = Uuid::new_v4();
     let uuid2 = Uuid::new_v4();
 
-    storage.txn(|txn| {
-        txn.add_to_working_set(uuid1)?;
-        txn.add_to_working_set(uuid2)?;
-        txn.commit()
-    })?;
+    storage
+        .txn(move |txn| {
+            txn.add_to_working_set(uuid1)?;
+            txn.add_to_working_set(uuid2)?;
+            txn.commit()
+        })
+        .await?;
 
-    storage.txn(|txn| {
-        let ws = txn.get_working_set()?;
-        assert_eq!(ws, vec![None, Some(uuid1), Some(uuid2)]);
-        Ok(())
-    })?;
+    storage
+        .txn(move |txn| {
+            let ws = txn.get_working_set()?;
+            assert_eq!(ws, vec![None, Some(uuid1), Some(uuid2)]);
+            Ok(())
+        })
+        .await?;
 
     // Clear one item
-    storage.txn(|txn| {
-        txn.set_working_set_item(1, None)?;
-        txn.commit()
-    })?;
+    storage
+        .txn(move |txn| {
+            txn.set_working_set_item(1, None)?;
+            txn.commit()
+        })
+        .await?;
 
-    storage.txn(|txn| {
-        let ws = txn.get_working_set()?;
-        assert_eq!(ws, vec![None, None, Some(uuid2)]);
-        Ok(())
-    })?;
+    storage
+        .txn(move |txn| {
+            let ws = txn.get_working_set()?;
+            assert_eq!(ws, vec![None, None, Some(uuid2)]);
+            Ok(())
+        })
+        .await?;
 
     // Override item
-    storage.txn(|txn| {
-        txn.set_working_set_item(2, Some(uuid1))?;
-        txn.commit()
-    })?;
+    storage
+        .txn(move |txn| {
+            txn.set_working_set_item(2, Some(uuid1))?;
+            txn.commit()
+        })
+        .await?;
 
-    storage.txn(|txn| {
-        let ws = txn.get_working_set()?;
-        assert_eq!(ws, vec![None, None, Some(uuid1)]);
-        Ok(())
-    })?;
+    storage
+        .txn(move |txn| {
+            let ws = txn.get_working_set()?;
+            assert_eq!(ws, vec![None, None, Some(uuid1)]);
+            Ok(())
+        })
+        .await?;
 
     // Set the last item to None
-    storage.txn(|txn| {
-        txn.set_working_set_item(1, Some(uuid1))?;
-        txn.set_working_set_item(2, None)?;
-        txn.commit()
-    })?;
+    storage
+        .txn(move |txn| {
+            txn.set_working_set_item(1, Some(uuid1))?;
+            txn.set_working_set_item(2, None)?;
+            txn.commit()
+        })
+        .await?;
 
-    storage.txn(|txn| {
-        let ws = txn.get_working_set()?;
-        // Note no trailing `None`.
-        assert_eq!(ws, vec![None, Some(uuid1)]);
-        Ok(())
-    })
+    storage
+        .txn(move |txn| {
+            let ws = txn.get_working_set()?;
+            // Note no trailing `None`.
+            assert_eq!(ws, vec![None, Some(uuid1)]);
+            Ok(())
+        })
+        .await
 }

--- a/src/task/task.rs
+++ b/src/task/task.rs
@@ -595,14 +595,14 @@ mod test {
     // Test task mutation by modifying a task and checking the assertions both on the
     // modified task and on a re-loaded task after the operations are committed. Then,
     // apply the same operations again and check that the result is the same.
-    fn with_mut_task<MODIFY: Fn(&mut Task, &mut Operations), ASSERT: Fn(&Task)>(
+    async fn with_mut_task<MODIFY: Fn(&mut Task, &mut Operations), ASSERT: Fn(&Task)>(
         modify: MODIFY,
         assert: ASSERT,
     ) {
-        let mut replica = Replica::<InMemoryStorage>::new_inmemory();
+        let mut replica = Replica::new(InMemoryStorage::new());
         let mut ops = Operations::new();
         let uuid = Uuid::new_v4();
-        let mut task = replica.create_task(uuid, &mut ops).unwrap();
+        let mut task = replica.create_task(uuid, &mut ops).await.unwrap();
 
         // Modify the task
         modify(&mut task, &mut ops);
@@ -610,10 +610,10 @@ mod test {
         // Check assertions about the task before committing it.
         assert(&task);
         println!("commiting operations from first call to modify function");
-        replica.commit_operations(ops).unwrap();
+        replica.commit_operations(ops).await.unwrap();
 
         // Check assertions on task loaded from storage
-        let mut task = replica.get_task(uuid).unwrap().unwrap();
+        let mut task = replica.get_task(uuid).await.unwrap().unwrap();
         assert(&task);
 
         // Apply the operations again, checking that they do not fail.
@@ -623,10 +623,10 @@ mod test {
         // Changes should still be as expected before commit.
         assert(&task);
         println!("commiting operations from second call to modify function");
-        replica.commit_operations(ops).unwrap();
+        replica.commit_operations(ops).await.unwrap();
 
         // Changes should still be as expected when loaded from storage.
-        let task = replica.get_task(uuid).unwrap().unwrap();
+        let task = replica.get_task(uuid).await.unwrap().unwrap();
         assert(&task);
     }
 
@@ -640,14 +640,14 @@ mod test {
         Tag::from_inner(TagInner::Synthetic(synth))
     }
 
-    #[test]
-    fn test_is_active_never_started() {
+    #[tokio::test]
+    async fn test_is_active_never_started() {
         let task = Task::new(TaskData::new(Uuid::new_v4(), TaskMap::new()), dm());
         assert!(!task.is_active());
     }
 
-    #[test]
-    fn test_is_active_active() {
+    #[tokio::test]
+    async fn test_is_active_active() {
         let task = Task::new(
             TaskData::new(
                 Uuid::new_v4(),
@@ -661,20 +661,20 @@ mod test {
         assert!(task.is_active());
     }
 
-    #[test]
-    fn test_is_active_inactive() {
+    #[tokio::test]
+    async fn test_is_active_inactive() {
         let task = Task::new(TaskData::new(Uuid::new_v4(), Default::default()), dm());
         assert!(!task.is_active());
     }
 
-    #[test]
-    fn test_entry_not_set() {
+    #[tokio::test]
+    async fn test_entry_not_set() {
         let task = Task::new(TaskData::new(Uuid::new_v4(), TaskMap::new()), dm());
         assert_eq!(task.get_entry(), None);
     }
 
-    #[test]
-    fn test_entry_set() {
+    #[tokio::test]
+    async fn test_entry_set() {
         let ts = Utc.with_ymd_and_hms(1980, 1, 1, 0, 0, 0).unwrap();
         let task = Task::new(
             TaskData::new(
@@ -688,16 +688,16 @@ mod test {
         assert_eq!(task.get_entry(), Some(ts));
     }
 
-    #[test]
-    fn test_wait_not_set() {
+    #[tokio::test]
+    async fn test_wait_not_set() {
         let task = Task::new(TaskData::new(Uuid::new_v4(), TaskMap::new()), dm());
 
         assert!(!task.is_waiting());
         assert_eq!(task.get_wait(), None);
     }
 
-    #[test]
-    fn test_wait_in_past() {
+    #[tokio::test]
+    async fn test_wait_in_past() {
         let ts = Utc.with_ymd_and_hms(1970, 1, 1, 0, 0, 0).unwrap();
         let task = Task::new(
             TaskData::new(
@@ -713,8 +713,8 @@ mod test {
         assert_eq!(task.get_wait(), Some(ts));
     }
 
-    #[test]
-    fn test_wait_in_future() {
+    #[tokio::test]
+    async fn test_wait_in_future() {
         let ts = Utc.with_ymd_and_hms(3000, 1, 1, 0, 0, 0).unwrap();
         let task = Task::new(
             TaskData::new(
@@ -730,8 +730,8 @@ mod test {
         assert_eq!(task.get_wait(), Some(ts));
     }
 
-    #[test]
-    fn test_has_tag() {
+    #[tokio::test]
+    async fn test_has_tag() {
         let task = Task::new(
             TaskData::new(
                 Uuid::new_v4(),
@@ -752,8 +752,8 @@ mod test {
         assert!(!task.has_tag(&stag(SyntheticTag::Waiting)));
     }
 
-    #[test]
-    fn test_get_tags() {
+    #[tokio::test]
+    async fn test_get_tags() {
         let task = Task::new(
             TaskData::new(
                 Uuid::new_v4(),
@@ -780,8 +780,8 @@ mod test {
         assert_eq!(tags, exp);
     }
 
-    #[test]
-    fn test_get_tags_invalid_tags() {
+    #[tokio::test]
+    async fn test_get_tags_invalid_tags() {
         let task = Task::new(
             TaskData::new(
                 Uuid::new_v4(),
@@ -809,8 +809,8 @@ mod test {
         );
     }
 
-    #[test]
-    fn test_get_due() {
+    #[tokio::test]
+    async fn test_get_due() {
         let test_time = Utc.with_ymd_and_hms(2033, 1, 1, 0, 0, 0).unwrap();
         let task = Task::new(
             TaskData::new(
@@ -824,8 +824,8 @@ mod test {
         assert_eq!(task.get_due(), Some(test_time))
     }
 
-    #[test]
-    fn test_get_invalid_due() {
+    #[tokio::test]
+    async fn test_get_invalid_due() {
         let task = Task::new(
             TaskData::new(
                 Uuid::new_v4(),
@@ -838,24 +838,25 @@ mod test {
         assert_eq!(task.get_due(), None);
     }
 
-    #[test]
-    fn test_due_new_task() {
-        with_mut_task(|_task, _ops| {}, |task| assert_eq!(task.get_due(), None));
+    #[tokio::test]
+    async fn test_due_new_task() {
+        with_mut_task(|_task, _ops| {}, |task| assert_eq!(task.get_due(), None)).await;
     }
 
-    #[test]
-    fn test_add_due() {
+    #[tokio::test]
+    async fn test_add_due() {
         let test_time = Utc.with_ymd_and_hms(2033, 1, 1, 0, 0, 0).unwrap();
         with_mut_task(
             |task, ops| {
                 task.set_due(Some(test_time), ops).unwrap();
             },
             |task| assert_eq!(task.get_due(), Some(test_time)),
-        );
+        )
+        .await;
     }
 
-    #[test]
-    fn test_remove_due() {
+    #[tokio::test]
+    async fn test_remove_due() {
         with_mut_task(
             |task, ops| {
                 task.data.update("due", Some("some-time".into()), ops);
@@ -865,17 +866,18 @@ mod test {
             |task| {
                 assert!(!task.data.has("due"));
             },
-        );
+        )
+        .await;
     }
 
-    #[test]
-    fn test_get_priority_default() {
+    #[tokio::test]
+    async fn test_get_priority_default() {
         let task = Task::new(TaskData::new(Uuid::new_v4(), TaskMap::new()), dm());
         assert_eq!(task.get_priority(), "");
     }
 
-    #[test]
-    fn test_get_annotations() {
+    #[tokio::test]
+    async fn test_get_annotations() {
         let task = Task::new(
             TaskData::new(
                 Uuid::new_v4(),
@@ -914,8 +916,8 @@ mod test {
         );
     }
 
-    #[test]
-    fn test_add_annotation() {
+    #[tokio::test]
+    async fn test_add_annotation() {
         with_mut_task(
             |task, ops| {
                 task.add_annotation(
@@ -931,11 +933,12 @@ mod test {
                 let k = "annotation_1635301900";
                 assert_eq!(task.data.get(k).unwrap(), "right message".to_owned());
             },
-        );
+        )
+        .await;
     }
 
-    #[test]
-    fn test_add_annotation_overwrite() {
+    #[tokio::test]
+    async fn test_add_annotation_overwrite() {
         with_mut_task(
             |task, ops| {
                 task.add_annotation(
@@ -959,11 +962,12 @@ mod test {
                 let k = "annotation_1635301900";
                 assert_eq!(task.data.get(k).unwrap(), "right message 2".to_owned());
             },
-        );
+        )
+        .await;
     }
 
-    #[test]
-    fn test_remove_annotation() {
+    #[tokio::test]
+    async fn test_remove_annotation() {
         with_mut_task(
             |task, ops| {
                 task.data
@@ -983,11 +987,12 @@ mod test {
                 anns.sort();
                 assert_eq!(anns, vec![]);
             },
-        );
+        )
+        .await;
     }
 
-    #[test]
-    fn test_set_get_priority() {
+    #[tokio::test]
+    async fn test_set_get_priority() {
         with_mut_task(
             |task, ops| {
                 task.set_priority("H".into(), ops).unwrap();
@@ -995,21 +1000,23 @@ mod test {
             |task| {
                 assert_eq!(task.get_priority(), "H");
             },
-        );
+        )
+        .await;
     }
 
-    #[test]
-    fn test_get_priority_new_task() {
+    #[tokio::test]
+    async fn test_get_priority_new_task() {
         with_mut_task(
             |_task, _ops| {},
             |task| {
                 assert_eq!(task.get_priority(), "");
             },
-        );
+        )
+        .await;
     }
 
-    #[test]
-    fn test_set_status_pending() {
+    #[tokio::test]
+    async fn test_set_status_pending() {
         with_mut_task(
             |task, ops| {
                 task.data.update("status", Some("completed".into()), ops);
@@ -1023,11 +1030,12 @@ mod test {
                 assert!(task.has_tag(&stag(SyntheticTag::Pending)));
                 assert!(!task.has_tag(&stag(SyntheticTag::Completed)));
             },
-        );
+        )
+        .await;
     }
 
-    #[test]
-    fn test_set_status_recurring() {
+    #[tokio::test]
+    async fn test_set_status_recurring() {
         with_mut_task(
             |task, ops| {
                 task.data.update("status", Some("completed".into()), ops);
@@ -1040,11 +1048,12 @@ mod test {
                 assert!(!task.has_tag(&stag(SyntheticTag::Pending))); // recurring is not +PENDING
                 assert!(!task.has_tag(&stag(SyntheticTag::Completed)));
             },
-        );
+        )
+        .await;
     }
 
-    #[test]
-    fn test_set_status_completed() {
+    #[tokio::test]
+    async fn test_set_status_completed() {
         with_mut_task(
             |task, ops| {
                 task.set_status(Status::Completed, ops).unwrap();
@@ -1055,11 +1064,12 @@ mod test {
                 assert!(!task.has_tag(&stag(SyntheticTag::Pending)));
                 assert!(task.has_tag(&stag(SyntheticTag::Completed)));
             },
-        );
+        )
+        .await;
     }
 
-    #[test]
-    fn test_set_status_deleted() {
+    #[tokio::test]
+    async fn test_set_status_deleted() {
         with_mut_task(
             |task, ops| {
                 task.set_status(Status::Deleted, ops).unwrap();
@@ -1070,11 +1080,12 @@ mod test {
                 assert!(!task.has_tag(&stag(SyntheticTag::Pending)));
                 assert!(!task.has_tag(&stag(SyntheticTag::Completed)));
             },
-        );
+        )
+        .await;
     }
 
-    #[test]
-    fn test_set_get_value() {
+    #[tokio::test]
+    async fn test_set_get_value() {
         let property = "property-name";
         with_mut_task(
             |task, ops| {
@@ -1083,11 +1094,12 @@ mod test {
             |task| {
                 assert_eq!(task.get_value(property), Some("value"));
             },
-        );
+        )
+        .await;
     }
 
-    #[test]
-    fn test_set_get_value_none() {
+    #[tokio::test]
+    async fn test_set_get_value_none() {
         let property = "property-name";
         with_mut_task(
             |task, ops| {
@@ -1097,11 +1109,12 @@ mod test {
             |task| {
                 assert_eq!(task.get_value(property), None);
             },
-        );
+        )
+        .await;
     }
 
-    #[test]
-    fn test_start() {
+    #[tokio::test]
+    async fn test_start() {
         with_mut_task(
             |task, ops| {
                 task.start(ops).unwrap();
@@ -1109,11 +1122,12 @@ mod test {
             |task| {
                 assert!(task.data.has("start"));
             },
-        );
+        )
+        .await;
     }
 
-    #[test]
-    fn test_stop() {
+    #[tokio::test]
+    async fn test_stop() {
         with_mut_task(
             |task, ops| {
                 task.data.update("start", Some("right now".into()), ops);
@@ -1122,11 +1136,12 @@ mod test {
             |task| {
                 assert!(!task.data.has("start"));
             },
-        );
+        )
+        .await;
     }
 
-    #[test]
-    fn test_done() {
+    #[tokio::test]
+    async fn test_done() {
         with_mut_task(
             |task, ops| {
                 task.done(ops).unwrap();
@@ -1136,11 +1151,12 @@ mod test {
                 assert!(task.data.has("end"));
                 assert!(task.has_tag(&stag(SyntheticTag::Completed)));
             },
-        );
+        )
+        .await;
     }
 
-    #[test]
-    fn test_delete() {
+    #[tokio::test]
+    async fn test_delete() {
         with_mut_task(
             |task, ops| {
                 #[allow(deprecated)]
@@ -1151,11 +1167,12 @@ mod test {
                 assert!(task.data.has("end"));
                 assert!(!task.has_tag(&stag(SyntheticTag::Completed)));
             },
-        );
+        )
+        .await;
     }
 
-    #[test]
-    fn test_add_tags() {
+    #[tokio::test]
+    async fn test_add_tags() {
         with_mut_task(
             |task, ops| {
                 task.add_tag(&utag("abc"), ops).unwrap();
@@ -1164,11 +1181,12 @@ mod test {
                 assert!(task.data.has("tag_abc"));
                 assert!(task.has_tag(&utag("abc")));
             },
-        );
+        )
+        .await;
     }
 
-    #[test]
-    fn test_remove_tags() {
+    #[tokio::test]
+    async fn test_remove_tags() {
         with_mut_task(
             |task, ops| {
                 task.data.update("tag_abc", Some("x".into()), ops);
@@ -1177,11 +1195,12 @@ mod test {
             |task| {
                 assert!(!task.data.has("tag_abc"));
             },
-        );
+        )
+        .await;
     }
 
-    #[test]
-    fn test_get_udas() {
+    #[tokio::test]
+    async fn test_get_udas() {
         let task = Task::new(
             TaskData::new(
                 Uuid::new_v4(),
@@ -1212,8 +1231,8 @@ mod test {
         );
     }
 
-    #[test]
-    fn test_get_uda() {
+    #[tokio::test]
+    async fn test_get_uda() {
         let task = Task::new(
             TaskData::new(
                 Uuid::new_v4(),
@@ -1234,8 +1253,8 @@ mod test {
         assert_eq!(task.get_uda("bugzilla", "url"), None);
     }
 
-    #[test]
-    fn test_get_legacy_uda() {
+    #[tokio::test]
+    async fn test_get_legacy_uda() {
         let task = Task::new(
             TaskData::new(
                 Uuid::new_v4(),
@@ -1258,8 +1277,8 @@ mod test {
         assert_eq!(task.get_legacy_uda("bugzilla.url"), None);
     }
 
-    #[test]
-    fn test_get_user_defined_attribute() {
+    #[tokio::test]
+    async fn test_get_user_defined_attribute() {
         let task = Task::new(
             TaskData::new(
                 Uuid::new_v4(),
@@ -1282,8 +1301,8 @@ mod test {
         assert_eq!(task.get_user_defined_attribute("bugzilla.url"), None);
     }
 
-    #[test]
-    fn test_set_uda() {
+    #[tokio::test]
+    async fn test_set_uda() {
         with_mut_task(
             |task, ops| {
                 task.set_uda("jira", "url", "h://y", ops).unwrap();
@@ -1298,10 +1317,11 @@ mod test {
                 );
             },
         )
+        .await
     }
 
-    #[test]
-    fn test_set_legacy_uda() {
+    #[tokio::test]
+    async fn test_set_legacy_uda() {
         with_mut_task(
             |task, ops| {
                 task.set_legacy_uda("jira.url", "h://y", ops).unwrap();
@@ -1316,10 +1336,11 @@ mod test {
                 );
             },
         )
+        .await
     }
 
-    #[test]
-    fn test_set_user_defined_attribute() {
+    #[tokio::test]
+    async fn test_set_user_defined_attribute() {
         with_mut_task(
             |task, ops| {
                 task.set_user_defined_attribute("jira.url", "h://y", ops)
@@ -1336,10 +1357,11 @@ mod test {
                 );
             },
         )
+        .await
     }
 
-    #[test]
-    fn test_set_uda_invalid() {
+    #[tokio::test]
+    async fn test_set_uda_invalid() {
         with_mut_task(
             |task, ops| {
                 assert!(task.set_uda("", "modified", "123", ops).is_err());
@@ -1355,10 +1377,11 @@ mod test {
             },
             |_task| {},
         )
+        .await
     }
 
-    #[test]
-    fn test_remove_uda() {
+    #[tokio::test]
+    async fn test_remove_uda() {
         with_mut_task(
             |task, ops| {
                 task.data.update("github.id", Some("123".into()), ops);
@@ -1369,10 +1392,11 @@ mod test {
                 assert_eq!(udas, vec![]);
             },
         )
+        .await
     }
 
-    #[test]
-    fn test_remove_legacy_uda() {
+    #[tokio::test]
+    async fn test_remove_legacy_uda() {
         with_mut_task(
             |task, ops| {
                 task.data.update("githubid", Some("123".into()), ops);
@@ -1383,10 +1407,11 @@ mod test {
                 assert_eq!(udas, vec![]);
             },
         )
+        .await
     }
 
-    #[test]
-    fn test_remove_user_defined_attribute() {
+    #[tokio::test]
+    async fn test_remove_user_defined_attribute() {
         with_mut_task(
             |task, ops| {
                 task.data.update("githubid", Some("123".into()), ops);
@@ -1397,10 +1422,11 @@ mod test {
                 assert_eq!(udas, vec![]);
             },
         )
+        .await
     }
 
-    #[test]
-    fn test_remove_uda_invalid() {
+    #[tokio::test]
+    async fn test_remove_uda_invalid() {
         with_mut_task(
             |task, ops| {
                 assert!(task.remove_uda("", "modified", ops).is_err());
@@ -1412,10 +1438,11 @@ mod test {
             },
             |_task| {},
         )
+        .await
     }
 
-    #[test]
-    fn test_dependencies_one() {
+    #[tokio::test]
+    async fn test_dependencies_one() {
         let dep1 = Uuid::new_v4();
         with_mut_task(
             |task, ops| {
@@ -1426,10 +1453,11 @@ mod test {
                 assert!(deps.contains(&dep1));
             },
         )
+        .await
     }
 
-    #[test]
-    fn test_dependencies_two() {
+    #[tokio::test]
+    async fn test_dependencies_two() {
         let dep1 = Uuid::new_v4();
         let dep2 = Uuid::new_v4();
         with_mut_task(
@@ -1443,10 +1471,11 @@ mod test {
                 assert!(deps.contains(&dep2));
             },
         )
+        .await
     }
 
-    #[test]
-    fn test_dependencies_removed() {
+    #[tokio::test]
+    async fn test_dependencies_removed() {
         let dep1 = Uuid::new_v4();
         let dep2 = Uuid::new_v4();
         with_mut_task(
@@ -1461,28 +1490,29 @@ mod test {
                 assert!(!deps.contains(&dep2));
             },
         )
+        .await
     }
 
-    #[test]
-    fn dependencies_tags() {
-        let mut rep = Replica::<InMemoryStorage>::new_inmemory();
+    #[tokio::test]
+    async fn dependencies_tags() {
+        let mut rep = Replica::new(InMemoryStorage::new());
         let mut ops = Operations::new();
         let (uuid1, uuid2) = (Uuid::new_v4(), Uuid::new_v4());
 
-        let mut t1 = rep.create_task(uuid1, &mut ops).unwrap();
+        let mut t1 = rep.create_task(uuid1, &mut ops).await.unwrap();
         t1.set_status(Status::Pending, &mut ops).unwrap();
         t1.add_dependency(uuid2, &mut ops).unwrap();
 
-        let mut t2 = rep.create_task(uuid2, &mut ops).unwrap();
+        let mut t2 = rep.create_task(uuid2, &mut ops).await.unwrap();
         t2.set_status(Status::Pending, &mut ops).unwrap();
 
-        rep.commit_operations(ops).unwrap();
+        rep.commit_operations(ops).await.unwrap();
 
         // force-refresh depmap
-        rep.dependency_map(true).unwrap();
+        rep.dependency_map(true).await.unwrap();
 
-        let t1 = rep.get_task(uuid1).unwrap().unwrap();
-        let t2 = rep.get_task(uuid2).unwrap().unwrap();
+        let t1 = rep.get_task(uuid1).await.unwrap().unwrap();
+        let t2 = rep.get_task(uuid2).await.unwrap().unwrap();
         assert!(t1.has_tag(&stag(SyntheticTag::Blocked)));
         assert!(!t1.has_tag(&stag(SyntheticTag::Unblocked)));
         assert!(!t1.has_tag(&stag(SyntheticTag::Blocking)));
@@ -1491,8 +1521,8 @@ mod test {
         assert!(t2.has_tag(&stag(SyntheticTag::Blocking)));
     }
 
-    #[test]
-    fn set_value_modified() {
+    #[tokio::test]
+    async fn set_value_modified() {
         with_mut_task(
             |task, ops| {
                 // set the modified property to something in the past..
@@ -1506,5 +1536,6 @@ mod test {
                 assert_eq!(task.get_value("modified").unwrap(), "1671820000")
             },
         )
+        .await
     }
 }

--- a/src/taskdb/sync.rs
+++ b/src/taskdb/sync.rs
@@ -14,7 +14,7 @@ struct Version {
 
 /// Sync to the given server, pulling remote changes and pushing local changes.
 pub(super) fn sync(
-    server: &mut Box<dyn Server>,
+    server: &mut dyn Server,
     txn: &mut dyn StorageTxn,
     avoid_snapshots: bool,
 ) -> Result<()> {
@@ -235,16 +235,33 @@ mod test {
         assert_eq!(got, exp);
     }
 
-    #[test]
-    fn test_sync() -> Result<()> {
-        let mut db = TaskDb::new();
-        let mut server: Box<dyn Server> = TestServer::new().server();
+    #[tokio::test]
+    async fn test_sync() -> Result<()> {
+        let server = TestServer::new();
 
-        let mut storage1 = InMemoryStorage::new();
-        storage1.txn(|txn| sync(&mut server, txn, false)).unwrap();
+        let storage1 = InMemoryStorage::new();
+        storage1
+            .txn({
+                let server = server.clone();
+                move |txn| {
+                    let mut server_guard = server.lock().unwrap();
+                    sync(&mut *server_guard, txn, false)
+                }
+            })
+            .await
+            .unwrap();
 
-        let mut storage2 = InMemoryStorage::new();
-        storage2.txn(|txn| sync(&mut server, txn, false)).unwrap();
+        let storage2 = InMemoryStorage::new();
+        storage2
+            .txn({
+                let server = server.clone();
+                move |txn| {
+                    let mut server_guard = server.lock().unwrap();
+                    sync(&mut *server_guard, txn, false)
+                }
+            })
+            .await
+            .unwrap();
 
         // make some changes in parallel to db1 and db2..
         let uuid1 = Uuid::new_v4();
@@ -268,14 +285,47 @@ mod test {
             old_value: None,
             timestamp: now1,
         });
-        storage1.txn(|txn| db.commit_operations(txn, ops, |_| false))?;
+        storage1
+            .txn(move |txn| TaskDb::commit_operations(txn, ops, |_| false))
+            .await?;
 
         // and synchronize those around
-        storage1.txn(|txn| sync(&mut server, txn, false)).unwrap();
-        storage2.txn(|txn| sync(&mut server, txn, false)).unwrap();
-        storage1.txn(|txn| sync(&mut server, txn, false)).unwrap();
-        let tasks1 = storage1.txn(|txn| Ok(db.sorted_tasks(txn)))?;
-        let tasks2 = storage2.txn(|txn| Ok(db.sorted_tasks(txn)))?;
+        storage1
+            .txn({
+                let server = server.clone();
+                move |txn| {
+                    let mut server_guard = server.lock().unwrap();
+                    sync(&mut *server_guard, txn, false)
+                }
+            })
+            .await
+            .unwrap();
+        storage2
+            .txn({
+                let server = server.clone();
+                move |txn| {
+                    let mut server_guard = server.lock().unwrap();
+                    sync(&mut *server_guard, txn, false)
+                }
+            })
+            .await
+            .unwrap();
+        storage1
+            .txn({
+                let server = server.clone();
+                move |txn| {
+                    let mut server_guard = server.lock().unwrap();
+                    sync(&mut *server_guard, txn, false)
+                }
+            })
+            .await
+            .unwrap();
+        let tasks1 = storage1
+            .txn(move |txn| Ok(TaskDb::sorted_tasks(txn)))
+            .await?;
+        let tasks2 = storage2
+            .txn(move |txn| Ok(TaskDb::sorted_tasks(txn)))
+            .await?;
         assert_eq!(tasks1, tasks2);
 
         // now make updates to the same task on both sides
@@ -288,7 +338,9 @@ mod test {
             old_value: None,
             timestamp: now2,
         });
-        storage1.txn(|txn| db.commit_operations(txn, ops, |_| false))?;
+        storage1
+            .txn(move |txn| TaskDb::commit_operations(txn, ops, |_| false))
+            .await?;
 
         let mut ops = Operations::new();
         let now3 = now2 + chrono::Duration::seconds(1);
@@ -299,20 +351,55 @@ mod test {
             old_value: None,
             timestamp: now3,
         });
-        storage1.txn(|txn| db.commit_operations(txn, ops, |_| false))?;
+        storage1
+            .txn(move |txn| TaskDb::commit_operations(txn, ops, |_| false))
+            .await?;
 
         // and synchronize those around
-        storage1.txn(|txn| sync(&mut server, txn, false)).unwrap();
-        storage2.txn(|txn| sync(&mut server, txn, false)).unwrap();
-        storage1.txn(|txn| sync(&mut server, txn, false)).unwrap();
-        let tasks1 = storage1.txn(|txn| Ok(db.sorted_tasks(txn)))?;
-        let tasks2 = storage2.txn(|txn| Ok(db.sorted_tasks(txn)))?;
+        storage1
+            .txn({
+                let server = server.clone();
+                move |txn| {
+                    let mut server_guard = server.lock().unwrap();
+                    sync(&mut *server_guard, txn, false)
+                }
+            })
+            .await
+            .unwrap();
+        storage2
+            .txn({
+                let server = server.clone();
+                move |txn| {
+                    let mut server_guard = server.lock().unwrap();
+                    sync(&mut *server_guard, txn, false)
+                }
+            })
+            .await
+            .unwrap();
+        storage1
+            .txn({
+                let server = server.clone();
+                move |txn| {
+                    let mut server_guard = server.lock().unwrap();
+                    sync(&mut *server_guard, txn, false)
+                }
+            })
+            .await
+            .unwrap();
+        let tasks1 = storage1
+            .txn(move |txn| Ok(TaskDb::sorted_tasks(txn)))
+            .await?;
+        let tasks2 = storage2
+            .txn(move |txn| Ok(TaskDb::sorted_tasks(txn)))
+            .await?;
         assert_eq!(tasks1, tasks2);
 
-        for (dbnum, storage) in [(1, &mut storage1), (2, &mut storage2)] {
+        for (dbnum, storage) in [(1, &storage1), (2, &storage2)] {
             eprintln!("checking db{dbnum}");
             expect_operations(
-                storage.txn(|txn| db.get_task_operations(txn, uuid1))?,
+                storage
+                    .txn(move |txn| TaskDb::get_task_operations(txn, uuid1))
+                    .await?,
                 vec![
                     Operation::Create { uuid: uuid1 },
                     Operation::Update {
@@ -325,7 +412,9 @@ mod test {
                 ],
             );
             expect_operations(
-                storage.txn(|txn| db.get_task_operations(txn, uuid2))?,
+                storage
+                    .txn(move |txn| TaskDb::get_task_operations(txn, uuid2))
+                    .await?,
                 vec![
                     Operation::Create { uuid: uuid2 },
                     Operation::Update {
@@ -356,16 +445,33 @@ mod test {
         Ok(())
     }
 
-    #[test]
-    fn test_sync_create_delete() -> Result<()> {
-        let mut db = TaskDb::new();
-        let mut server: Box<dyn Server> = TestServer::new().server();
+    #[tokio::test]
+    async fn test_sync_create_delete() -> Result<()> {
+        let server = TestServer::new();
 
-        let mut storage1 = InMemoryStorage::new();
-        storage1.txn(|txn| sync(&mut server, txn, false)).unwrap();
+        let storage1 = InMemoryStorage::new();
+        storage1
+            .txn({
+                let server = server.clone();
+                move |txn| {
+                    let mut server_guard = server.lock().unwrap();
+                    sync(&mut *server_guard, txn, false)
+                }
+            })
+            .await
+            .unwrap();
 
-        let mut storage2 = InMemoryStorage::new();
-        storage2.txn(|txn| sync(&mut server, txn, false)).unwrap();
+        let storage2 = InMemoryStorage::new();
+        storage2
+            .txn({
+                let server = server.clone();
+                move |txn| {
+                    let mut server_guard = server.lock().unwrap();
+                    sync(&mut *server_guard, txn, false)
+                }
+            })
+            .await
+            .unwrap();
 
         // create and update a task..
         let uuid = Uuid::new_v4();
@@ -379,14 +485,47 @@ mod test {
             old_value: None,
             timestamp: now1,
         });
-        storage1.txn(|txn| db.commit_operations(txn, ops, |_| false))?;
+        storage1
+            .txn(move |txn| TaskDb::commit_operations(txn, ops, |_| false))
+            .await?;
 
         // and synchronize those around
-        storage1.txn(|txn| sync(&mut server, txn, false)).unwrap();
-        storage2.txn(|txn| sync(&mut server, txn, false)).unwrap();
-        storage1.txn(|txn| sync(&mut server, txn, false)).unwrap();
-        let tasks1 = storage1.txn(|txn| Ok(db.sorted_tasks(txn)))?;
-        let tasks2 = storage2.txn(|txn| Ok(db.sorted_tasks(txn)))?;
+        storage1
+            .txn({
+                let server = server.clone();
+                move |txn| {
+                    let mut server_guard = server.lock().unwrap();
+                    sync(&mut *server_guard, txn, false)
+                }
+            })
+            .await
+            .unwrap();
+        storage2
+            .txn({
+                let server = server.clone();
+                move |txn| {
+                    let mut server_guard = server.lock().unwrap();
+                    sync(&mut *server_guard, txn, false)
+                }
+            })
+            .await
+            .unwrap();
+        storage1
+            .txn({
+                let server = server.clone();
+                move |txn| {
+                    let mut server_guard = server.lock().unwrap();
+                    sync(&mut *server_guard, txn, false)
+                }
+            })
+            .await
+            .unwrap();
+        let tasks1 = storage1
+            .txn(move |txn| Ok(TaskDb::sorted_tasks(txn)))
+            .await?;
+        let tasks2 = storage2
+            .txn(move |txn| Ok(TaskDb::sorted_tasks(txn)))
+            .await?;
         assert_eq!(tasks1, tasks2);
 
         // delete and re-create the task on db1
@@ -404,7 +543,9 @@ mod test {
             old_value: None,
             timestamp: now2,
         });
-        storage1.txn(|txn| db.commit_operations(txn, ops, |_| false))?;
+        storage1
+            .txn(move |txn| TaskDb::commit_operations(txn, ops, |_| false))
+            .await?;
 
         // and on db2, update a property of the task
         let mut ops = Operations::new();
@@ -416,19 +557,54 @@ mod test {
             old_value: None,
             timestamp: now3,
         });
-        storage2.txn(|txn| db.commit_operations(txn, ops, |_| false))?;
+        storage2
+            .txn(move |txn| TaskDb::commit_operations(txn, ops, |_| false))
+            .await?;
 
-        storage1.txn(|txn| sync(&mut server, txn, false)).unwrap();
-        storage2.txn(|txn| sync(&mut server, txn, false)).unwrap();
-        storage1.txn(|txn| sync(&mut server, txn, false)).unwrap();
-        let tasks1 = storage1.txn(|txn| Ok(db.sorted_tasks(txn)))?;
-        let tasks2 = storage2.txn(|txn| Ok(db.sorted_tasks(txn)))?;
+        storage1
+            .txn({
+                let server = server.clone();
+                move |txn| {
+                    let mut server_guard = server.lock().unwrap();
+                    sync(&mut *server_guard, txn, false)
+                }
+            })
+            .await
+            .unwrap();
+        storage2
+            .txn({
+                let server = server.clone();
+                move |txn| {
+                    let mut server_guard = server.lock().unwrap();
+                    sync(&mut *server_guard, txn, false)
+                }
+            })
+            .await
+            .unwrap();
+        storage1
+            .txn({
+                let server = server.clone();
+                move |txn| {
+                    let mut server_guard = server.lock().unwrap();
+                    sync(&mut *server_guard, txn, false)
+                }
+            })
+            .await
+            .unwrap();
+        let tasks1 = storage1
+            .txn(move |txn| Ok(TaskDb::sorted_tasks(txn)))
+            .await?;
+        let tasks2 = storage2
+            .txn(move |txn| Ok(TaskDb::sorted_tasks(txn)))
+            .await?;
         assert_eq!(tasks1, tasks2);
 
         // This is a case where the task operations appear different on the replicas,
         // because the update to "project" on db2 loses to the delete.
         expect_operations(
-            storage1.txn(|txn| db.get_task_operations(txn, uuid))?,
+            storage1
+                .txn(move |txn| TaskDb::get_task_operations(txn, uuid))
+                .await?,
             vec![
                 Operation::Create { uuid },
                 Operation::Create { uuid },
@@ -453,7 +629,9 @@ mod test {
             ],
         );
         expect_operations(
-            storage2.txn(|txn| db.get_task_operations(txn, uuid))?,
+            storage2
+                .txn(move |txn| TaskDb::get_task_operations(txn, uuid))
+                .await?,
             vec![
                 Operation::Create { uuid },
                 Operation::Create { uuid },
@@ -489,16 +667,33 @@ mod test {
         Ok(())
     }
 
-    #[test]
-    fn test_sync_conflicting_updates() -> Result<()> {
-        let mut db = TaskDb::new();
-        let mut server: Box<dyn Server> = TestServer::new().server();
+    #[tokio::test]
+    async fn test_sync_conflicting_updates() -> Result<()> {
+        let server = TestServer::new();
 
-        let mut storage1 = InMemoryStorage::new();
-        storage1.txn(|txn| sync(&mut server, txn, false)).unwrap();
+        let storage1 = InMemoryStorage::new();
+        storage1
+            .txn({
+                let server = server.clone();
+                move |txn| {
+                    let mut server_guard = server.lock().unwrap();
+                    sync(&mut *server_guard, txn, false)
+                }
+            })
+            .await
+            .unwrap();
 
-        let mut storage2 = InMemoryStorage::new();
-        storage2.txn(|txn| sync(&mut server, txn, false)).unwrap();
+        let storage2 = InMemoryStorage::new();
+        storage2
+            .txn({
+                let server = server.clone();
+                move |txn| {
+                    let mut server_guard = server.lock().unwrap();
+                    sync(&mut *server_guard, txn, false)
+                }
+            })
+            .await
+            .unwrap();
 
         // create and update a task..
         let uuid = Uuid::new_v4();
@@ -512,14 +707,47 @@ mod test {
             old_value: None,
             timestamp: now1,
         });
-        storage1.txn(|txn| db.commit_operations(txn, ops, |_| false))?;
+        storage1
+            .txn(move |txn| TaskDb::commit_operations(txn, ops, |_| false))
+            .await?;
 
         // and synchronize those around
-        storage1.txn(|txn| sync(&mut server, txn, false)).unwrap();
-        storage2.txn(|txn| sync(&mut server, txn, false)).unwrap();
-        storage1.txn(|txn| sync(&mut server, txn, false)).unwrap();
-        let tasks1 = storage1.txn(|txn| Ok(db.sorted_tasks(txn)))?;
-        let tasks2 = storage2.txn(|txn| Ok(db.sorted_tasks(txn)))?;
+        storage1
+            .txn({
+                let server = server.clone();
+                move |txn| {
+                    let mut server_guard = server.lock().unwrap();
+                    sync(&mut *server_guard, txn, false)
+                }
+            })
+            .await
+            .unwrap();
+        storage2
+            .txn({
+                let server = server.clone();
+                move |txn| {
+                    let mut server_guard = server.lock().unwrap();
+                    sync(&mut *server_guard, txn, false)
+                }
+            })
+            .await
+            .unwrap();
+        storage1
+            .txn({
+                let server = server.clone();
+                move |txn| {
+                    let mut server_guard = server.lock().unwrap();
+                    sync(&mut *server_guard, txn, false)
+                }
+            })
+            .await
+            .unwrap();
+        let tasks1 = storage1
+            .txn(move |txn| Ok(TaskDb::sorted_tasks(txn)))
+            .await?;
+        let tasks2 = storage2
+            .txn(move |txn| Ok(TaskDb::sorted_tasks(txn)))
+            .await?;
         assert_eq!(tasks1, tasks2);
 
         // add different updates on db1 and db2
@@ -532,7 +760,9 @@ mod test {
             old_value: None,
             timestamp: now2,
         });
-        storage1.txn(|txn| db.commit_operations(txn, ops, |_| false))?;
+        storage1
+            .txn(move |txn| TaskDb::commit_operations(txn, ops, |_| false))
+            .await?;
 
         // and on db2, update a property of the task
         let mut ops = Operations::new();
@@ -544,17 +774,52 @@ mod test {
             old_value: None,
             timestamp: now3,
         });
-        storage2.txn(|txn| db.commit_operations(txn, ops, |_| false))?;
+        storage2
+            .txn(move |txn| TaskDb::commit_operations(txn, ops, |_| false))
+            .await?;
 
-        storage1.txn(|txn| sync(&mut server, txn, false)).unwrap();
-        storage2.txn(|txn| sync(&mut server, txn, false)).unwrap();
-        storage1.txn(|txn| sync(&mut server, txn, false)).unwrap();
-        let tasks1 = storage1.txn(|txn| Ok(db.sorted_tasks(txn)))?;
-        let tasks2 = storage2.txn(|txn| Ok(db.sorted_tasks(txn)))?;
+        storage1
+            .txn({
+                let server = server.clone();
+                move |txn| {
+                    let mut server_guard = server.lock().unwrap();
+                    sync(&mut *server_guard, txn, false)
+                }
+            })
+            .await
+            .unwrap();
+        storage2
+            .txn({
+                let server = server.clone();
+                move |txn| {
+                    let mut server_guard = server.lock().unwrap();
+                    sync(&mut *server_guard, txn, false)
+                }
+            })
+            .await
+            .unwrap();
+        storage1
+            .txn({
+                let server = server.clone();
+                move |txn| {
+                    let mut server_guard = server.lock().unwrap();
+                    sync(&mut *server_guard, txn, false)
+                }
+            })
+            .await
+            .unwrap();
+        let tasks1 = storage1
+            .txn(move |txn| Ok(TaskDb::sorted_tasks(txn)))
+            .await?;
+        let tasks2 = storage2
+            .txn(move |txn| Ok(TaskDb::sorted_tasks(txn)))
+            .await?;
         assert_eq!(tasks1, tasks2);
 
         expect_operations(
-            storage1.txn(|txn| db.get_task_operations(txn, uuid))?,
+            storage1
+                .txn(move |txn| TaskDb::get_task_operations(txn, uuid))
+                .await?,
             vec![
                 Operation::Create { uuid },
                 Operation::Update {
@@ -583,7 +848,9 @@ mod test {
             ],
         );
         expect_operations(
-            storage2.txn(|txn| db.get_task_operations(txn, uuid))?,
+            storage2
+                .txn(move |txn| TaskDb::get_task_operations(txn, uuid))
+                .await?,
             vec![
                 Operation::Create { uuid },
                 Operation::Update {
@@ -605,13 +872,10 @@ mod test {
         Ok(())
     }
 
-    #[test]
-    fn test_sync_add_snapshot_start_with_snapshot() -> Result<()> {
-        let mut test_server = TestServer::new();
-
-        let mut server: Box<dyn Server> = test_server.server();
-        let mut storage1 = InMemoryStorage::new();
-        let mut db = TaskDb::new();
+    #[tokio::test]
+    async fn test_sync_add_snapshot_start_with_snapshot() -> Result<()> {
+        let server = TestServer::new();
+        let storage1 = InMemoryStorage::new();
 
         let uuid = Uuid::new_v4();
         let mut ops = Operations::new();
@@ -623,14 +887,29 @@ mod test {
             old_value: None,
             timestamp: Utc::now(),
         });
-        storage1.txn(|txn| db.commit_operations(txn, ops, |_| false))?;
+        storage1
+            .txn(move |txn| TaskDb::commit_operations(txn, ops, |_| false))
+            .await?;
 
-        test_server.set_snapshot_urgency(SnapshotUrgency::High);
-        storage1.txn(|txn| sync(&mut server, txn, false))?;
+        server
+            .lock()
+            .unwrap()
+            .set_snapshot_urgency(SnapshotUrgency::High);
+        storage1
+            .txn({
+                let server = server.clone();
+                move |txn| {
+                    let mut server_guard = server.lock().unwrap();
+                    sync(&mut *server_guard, txn, false)
+                }
+            })
+            .await?;
 
         // assert that a snapshot was added
-        let base_version = storage1.txn(|txn| txn.base_version())?;
-        let (v, s) = test_server
+        let base_version = storage1.txn(move |txn| txn.base_version()).await?;
+        let (v, s) = server
+            .lock()
+            .unwrap()
             .snapshot()
             .ok_or_else(|| anyhow::anyhow!("no snapshot"))?;
         assert_eq!(v, base_version);
@@ -647,55 +926,93 @@ mod test {
             old_value: None,
             timestamp: Utc::now(),
         });
-        storage1.txn(|txn| db.commit_operations(txn, ops, |_| false))?;
-        storage1.txn(|txn| sync(&mut server, txn, false))?;
+        storage1
+            .txn(move |txn| TaskDb::commit_operations(txn, ops, |_| false))
+            .await?;
+        storage1
+            .txn({
+                let server = server.clone();
+                move |txn| {
+                    let mut server_guard = server.lock().unwrap();
+                    sync(&mut *server_guard, txn, false)
+                }
+            })
+            .await?;
 
         // delete the first version, so that db2 *must* initialize from
         // the snapshot
-        test_server.delete_version(Uuid::nil());
+        server.lock().unwrap().delete_version(Uuid::nil());
 
         // sync to a new DB and check that we got the expected results
-        let mut storage2 = InMemoryStorage::new();
-        storage2.txn(|txn| sync(&mut server, txn, false))?;
+        let storage2 = InMemoryStorage::new();
+        storage2
+            .txn({
+                let server = server.clone();
+                move |txn| {
+                    let mut server_guard = server.lock().unwrap();
+                    sync(&mut *server_guard, txn, false)
+                }
+            })
+            .await?;
 
-        let task = storage2.txn(|txn| db.get_task(txn, uuid))?.unwrap();
+        let task = storage2
+            .txn(move |txn| TaskDb::get_task(txn, uuid))
+            .await?
+            .unwrap();
         assert_eq!(task.get("title").unwrap(), "my first task, updated");
 
         Ok(())
     }
 
-    #[test]
-    fn test_sync_avoids_snapshot() -> Result<()> {
-        let mut storage = InMemoryStorage::new();
-        let mut db = TaskDb::new();
-
-        let test_server = TestServer::new();
-        let mut server: Box<dyn Server> = test_server.server();
+    #[tokio::test]
+    async fn test_sync_avoids_snapshot() -> Result<()> {
+        let storage = InMemoryStorage::new();
+        let server = TestServer::new();
 
         let uuid = Uuid::new_v4();
         let mut ops = Operations::new();
         ops.push(Operation::Create { uuid });
-        storage.txn(|txn| db.commit_operations(txn, ops, |_| false))?;
+        storage
+            .txn(move |txn| TaskDb::commit_operations(txn, ops, |_| false))
+            .await?;
 
-        test_server.set_snapshot_urgency(SnapshotUrgency::Low);
-        storage.txn(|txn| sync(&mut server, txn, true)).unwrap();
+        server
+            .lock()
+            .unwrap()
+            .set_snapshot_urgency(SnapshotUrgency::Low);
+        storage
+            .txn({
+                let server = server.clone();
+                move |txn| {
+                    let mut server_guard = server.lock().unwrap();
+                    sync(&mut *server_guard, txn, true)
+                }
+            })
+            .await
+            .unwrap();
 
         // assert that a snapshot was not added, because we indicated
         // we wanted to avoid snapshots and it was only low urgency
-        assert_eq!(test_server.snapshot(), None);
+        assert_eq!(server.lock().unwrap().snapshot(), None);
 
         Ok(())
     }
 
-    #[test]
-    fn test_sync_batched() -> Result<()> {
-        let test_server = TestServer::new();
-        let mut storage = InMemoryStorage::new();
+    #[tokio::test]
+    async fn test_sync_batched() -> Result<()> {
+        let server = TestServer::new();
+        let storage = InMemoryStorage::new();
 
-        let mut server: Box<dyn Server> = test_server.server();
-
-        let mut db = TaskDb::new();
-        storage.txn(|txn| sync(&mut server, txn, false)).unwrap();
+        storage
+            .txn({
+                let server = server.clone();
+                move |txn| {
+                    let mut server_guard = server.lock().unwrap();
+                    sync(&mut *server_guard, txn, false)
+                }
+            })
+            .await
+            .unwrap();
 
         // add a task to db
         let uuid1 = Uuid::new_v4();
@@ -708,10 +1025,21 @@ mod test {
             old_value: None,
             timestamp: Utc::now(),
         });
-        storage.txn(|txn| db.commit_operations(txn, ops, |_| false))?;
+        storage
+            .txn(move |txn| TaskDb::commit_operations(txn, ops, |_| false))
+            .await?;
 
-        storage.txn(|txn| sync(&mut server, txn, true)).unwrap();
-        assert_eq!(test_server.versions_len(), 1);
+        storage
+            .txn({
+                let server = server.clone();
+                move |txn| {
+                    let mut server_guard = server.lock().unwrap();
+                    sync(&mut *server_guard, txn, true)
+                }
+            })
+            .await
+            .unwrap();
+        assert_eq!(server.lock().unwrap().versions_len(), 1);
 
         // chars are four bytes, but they're only one when converted to a String
         let data = vec!['a'; 400000];
@@ -727,24 +1055,40 @@ mod test {
                 timestamp: Utc::now(),
             });
         }
-        storage.txn(|txn| db.commit_operations(txn, ops, |_| false))?;
+        storage
+            .txn(move |txn| TaskDb::commit_operations(txn, ops, |_| false))
+            .await?;
 
         // this sync batches the operations into two versions.
-        storage.txn(|txn| sync(&mut server, txn, true)).unwrap();
-        assert_eq!(test_server.versions_len(), 3);
+        storage
+            .txn({
+                let server = server.clone();
+                move |txn| {
+                    let mut server_guard = server.lock().unwrap();
+                    sync(&mut *server_guard, txn, true)
+                }
+            })
+            .await
+            .unwrap();
+        assert_eq!(server.lock().unwrap().versions_len(), 3);
 
         Ok(())
     }
 
-    #[test]
-    fn test_sync_batches_at_least_one_op() -> Result<()> {
-        let test_server = TestServer::new();
-
-        let mut server: Box<dyn Server> = test_server.server();
-
-        let mut storage = InMemoryStorage::new();
-        let mut db = TaskDb::new();
-        storage.txn(|txn| sync(&mut server, txn, false)).unwrap();
+    #[tokio::test]
+    async fn test_sync_batches_at_least_one_op() -> Result<()> {
+        let server = TestServer::new();
+        let storage = InMemoryStorage::new();
+        storage
+            .txn({
+                let server = server.clone();
+                move |txn| {
+                    let mut server_guard = server.lock().unwrap();
+                    sync(&mut *server_guard, txn, false)
+                }
+            })
+            .await
+            .unwrap();
 
         // add a task to db
         let uuid1 = Uuid::new_v4();
@@ -757,10 +1101,21 @@ mod test {
             old_value: None,
             timestamp: Utc::now(),
         });
-        storage.txn(|txn| db.commit_operations(txn, ops, |_| false))?;
+        storage
+            .txn(move |txn| TaskDb::commit_operations(txn, ops, |_| false))
+            .await?;
 
-        storage.txn(|txn| sync(&mut server, txn, true)).unwrap();
-        assert_eq!(test_server.versions_len(), 1);
+        storage
+            .txn({
+                let server = server.clone();
+                move |txn| {
+                    let mut server_guard = server.lock().unwrap();
+                    sync(&mut *server_guard, txn, true)
+                }
+            })
+            .await
+            .unwrap();
+        assert_eq!(server.lock().unwrap().versions_len(), 1);
 
         // add an operation greater than the batch limit
         let data = vec!['a'; 1000001];
@@ -772,10 +1127,21 @@ mod test {
             old_value: None,
             timestamp: Utc::now(),
         });
-        storage.txn(|txn| db.commit_operations(txn, ops, |_| false))?;
+        storage
+            .txn(move |txn| TaskDb::commit_operations(txn, ops, |_| false))
+            .await?;
 
-        storage.txn(|txn| sync(&mut server, txn, true)).unwrap();
-        assert_eq!(test_server.versions_len(), 2);
+        storage
+            .txn({
+                let server = server.clone();
+                move |txn| {
+                    let mut server_guard = server.lock().unwrap();
+                    sync(&mut *server_guard, txn, true)
+                }
+            })
+            .await
+            .unwrap();
+        assert_eq!(server.lock().unwrap().versions_len(), 2);
 
         Ok(())
     }

--- a/src/taskdb/working_set.rs
+++ b/src/taskdb/working_set.rs
@@ -89,19 +89,18 @@ mod test {
     use chrono::Utc;
     use uuid::Uuid;
 
-    #[test]
-    fn rebuild_working_set_renumber() -> Result<()> {
-        rebuild_working_set(true)
+    #[tokio::test]
+    async fn rebuild_working_set_renumber() -> Result<()> {
+        rebuild_working_set(true).await
     }
 
-    #[test]
-    fn rebuild_working_set_no_renumber() -> Result<()> {
-        rebuild_working_set(false)
+    #[tokio::test]
+    async fn rebuild_working_set_no_renumber() -> Result<()> {
+        rebuild_working_set(false).await
     }
 
-    fn rebuild_working_set(renumber: bool) -> Result<()> {
-        let mut storage = InMemoryStorage::new();
-        let mut db = TaskDb::new();
+    async fn rebuild_working_set(renumber: bool) -> Result<()> {
+        let storage = InMemoryStorage::new();
         let mut uuids = vec![];
         uuids.push(Uuid::new_v4());
         println!("uuids[0]: {:?} - pending, not in working set", uuids[0]);
@@ -128,57 +127,58 @@ mod test {
                 timestamp: Utc::now(),
             });
         }
-        storage.txn(|txn| {
-            db.commit_operations(txn, ops, |_| false)?;
+        storage
+            .txn(move |txn| {
+                TaskDb::commit_operations(txn, ops, |_| false)?;
 
-            // set the existing working_set as we want it
-            {
-                txn.clear_working_set()?;
+                // set the existing working_set as we want it
+                {
+                    txn.clear_working_set()?;
 
-                for i in &[1usize, 3, 4] {
-                    txn.add_to_working_set(uuids[*i])?;
+                    for i in &[1usize, 3, 4] {
+                        txn.add_to_working_set(uuids[*i])?;
+                    }
+
+                    txn.commit()?;
                 }
 
-                txn.commit()?;
-            }
+                assert_eq!(
+                    TaskDb::working_set(txn)?,
+                    vec![None, Some(uuids[1]), Some(uuids[3]), Some(uuids[4])]
+                );
 
-            assert_eq!(
-                db.working_set(txn)?,
-                vec![None, Some(uuids[1]), Some(uuids[3]), Some(uuids[4])]
-            );
+                rebuild(
+                    txn,
+                    |t| {
+                        if let Some(status) = t.get("status") {
+                            status == "pending"
+                        } else {
+                            false
+                        }
+                    },
+                    renumber,
+                )?;
 
-            rebuild(
-                txn,
-                |t| {
-                    if let Some(status) = t.get("status") {
-                        status == "pending"
-                    } else {
-                        false
-                    }
-                },
-                renumber,
-            )?;
+                let exp = if renumber {
+                    // uuids[1] and uuids[4] are already in the working set, so are compressed
+                    // to the top, and then uuids[0] is added.
+                    vec![None, Some(uuids[1]), Some(uuids[4]), Some(uuids[0])]
+                } else {
+                    // uuids[1] and uuids[4] are already in the working set, at indexes 1 and 3,
+                    // and then uuids[0] is added.
+                    vec![None, Some(uuids[1]), None, Some(uuids[4]), Some(uuids[0])]
+                };
 
-            let exp = if renumber {
-                // uuids[1] and uuids[4] are already in the working set, so are compressed
-                // to the top, and then uuids[0] is added.
-                vec![None, Some(uuids[1]), Some(uuids[4]), Some(uuids[0])]
-            } else {
-                // uuids[1] and uuids[4] are already in the working set, at indexes 1 and 3,
-                // and then uuids[0] is added.
-                vec![None, Some(uuids[1]), None, Some(uuids[4]), Some(uuids[0])]
-            };
+                assert_eq!(TaskDb::working_set(txn)?, exp);
 
-            assert_eq!(db.working_set(txn)?, exp);
-
-            Ok(())
-        })
+                Ok(())
+            })
+            .await
     }
 
-    #[test]
-    fn rebuild_working_set_no_change() -> Result<()> {
-        let mut storage = InMemoryStorage::new();
-        let mut db = TaskDb::new();
+    #[tokio::test]
+    async fn rebuild_working_set_no_change() -> Result<()> {
+        let storage = InMemoryStorage::new();
 
         let mut uuids = vec![];
         uuids.push(Uuid::new_v4());
@@ -200,43 +200,44 @@ mod test {
                 timestamp: Utc::now(),
             });
         }
-        storage.txn(|txn| {
-            db.commit_operations(txn, ops, |_| false)?;
+        storage
+            .txn(move |txn| {
+                TaskDb::commit_operations(txn, ops, |_| false)?;
 
-            // set the existing working_set as we want it, containing UUIDs 0 and 1.
-            {
-                txn.clear_working_set()?;
+                // set the existing working_set as we want it, containing UUIDs 0 and 1.
+                {
+                    txn.clear_working_set()?;
 
-                for i in &[0, 1] {
-                    txn.add_to_working_set(uuids[*i])?;
-                }
-
-                txn.commit()?;
-            }
-            rebuild(
-                txn,
-                |t| {
-                    if let Some(status) = t.get("status") {
-                        status == "pending"
-                    } else {
-                        false
+                    for i in &[0, 1] {
+                        txn.add_to_working_set(uuids[*i])?;
                     }
-                },
-                true,
-            )?;
 
-            assert_eq!(
-                db.working_set(txn)?,
-                vec![None, Some(uuids[0]), Some(uuids[1]), Some(uuids[2])]
-            );
-            Ok(())
-        })
+                    txn.commit()?;
+                }
+                rebuild(
+                    txn,
+                    |t| {
+                        if let Some(status) = t.get("status") {
+                            status == "pending"
+                        } else {
+                            false
+                        }
+                    },
+                    true,
+                )?;
+
+                assert_eq!(
+                    TaskDb::working_set(txn)?,
+                    vec![None, Some(uuids[0]), Some(uuids[1]), Some(uuids[2])]
+                );
+                Ok(())
+            })
+            .await
     }
 
-    #[test]
-    fn rebuild_working_set_shrinks() -> Result<()> {
-        let mut storage = InMemoryStorage::new();
-        let mut db = TaskDb::new();
+    #[tokio::test]
+    async fn rebuild_working_set_shrinks() -> Result<()> {
+        let storage = InMemoryStorage::new();
 
         let mut uuids = vec![];
         uuids.push(Uuid::new_v4());
@@ -258,33 +259,35 @@ mod test {
             old_value: None,
             timestamp: Utc::now(),
         });
-        storage.txn(|txn| {
-            db.commit_operations(txn, ops, |_| false)?;
+        storage
+            .txn(move |txn| {
+                TaskDb::commit_operations(txn, ops, |_| false)?;
 
-            // set the existing working_set as we want it, containing all three UUIDs.
-            {
-                txn.clear_working_set()?;
+                // set the existing working_set as we want it, containing all three UUIDs.
+                {
+                    txn.clear_working_set()?;
 
-                for uuid in &uuids {
-                    txn.add_to_working_set(*uuid)?;
-                }
-
-                txn.commit()?;
-            }
-            rebuild(
-                txn,
-                |t| {
-                    if let Some(status) = t.get("status") {
-                        status == "pending"
-                    } else {
-                        false
+                    for uuid in &uuids {
+                        txn.add_to_working_set(*uuid)?;
                     }
-                },
-                true,
-            )?;
 
-            assert_eq!(db.working_set(txn)?, vec![None, Some(uuids[0])]);
-            Ok(())
-        })
+                    txn.commit()?;
+                }
+                rebuild(
+                    txn,
+                    |t| {
+                        if let Some(status) = t.get("status") {
+                            status == "pending"
+                        } else {
+                            false
+                        }
+                    },
+                    true,
+                )?;
+
+                assert_eq!(TaskDb::working_set(txn)?, vec![None, Some(uuids[0])]);
+                Ok(())
+            })
+            .await
     }
 }

--- a/tests/cross-sync.rs
+++ b/tests/cross-sync.rs
@@ -3,9 +3,9 @@ use pretty_assertions::assert_eq;
 use taskchampion::{storage::InMemoryStorage, Operations, Replica, ServerConfig, Status, Uuid};
 use tempfile::TempDir;
 
-#[test]
+#[tokio::test]
 #[cfg(feature = "server-local")]
-fn cross_sync() -> anyhow::Result<()> {
+async fn cross_sync() -> anyhow::Result<()> {
     // set up two replicas, and demonstrate replication between them
     let mut rep1 = Replica::new(InMemoryStorage::new());
     let mut rep2 = Replica::new(InMemoryStorage::new());
@@ -14,17 +14,17 @@ fn cross_sync() -> anyhow::Result<()> {
     let server_config = ServerConfig::Local {
         server_dir: tmp_dir.path().to_path_buf(),
     };
-    let mut server = server_config.into_server()?;
+    let server = server_config.into_server()?;
 
     let (uuid1, uuid2) = (Uuid::new_v4(), Uuid::new_v4());
     let mut ops = Operations::new();
 
     // add some tasks on rep1
-    let mut t1 = rep1.create_task(uuid1, &mut ops)?;
+    let mut t1 = rep1.create_task(uuid1, &mut ops).await?;
     t1.set_description("test 1".into(), &mut ops)?;
     t1.set_status(Status::Pending, &mut ops)?;
     t1.set_entry(Some(Utc::now()), &mut ops)?;
-    let mut t2 = rep1.create_task(uuid2, &mut ops)?;
+    let mut t2 = rep1.create_task(uuid2, &mut ops).await?;
     t2.set_description("test 2".into(), &mut ops)?;
     t2.set_status(Status::Pending, &mut ops)?;
     t2.set_entry(Some(Utc::now()), &mut ops)?;
@@ -32,14 +32,20 @@ fn cross_sync() -> anyhow::Result<()> {
     // modify t1
     t1.start(&mut ops)?;
 
-    rep1.commit_operations(ops)?;
+    rep1.commit_operations(ops).await?;
 
-    rep1.sync(&mut server, false)?;
-    rep2.sync(&mut server, false)?;
+    rep1.sync(server.clone(), false).await?;
+    rep2.sync(server.clone(), false).await?;
 
     // those tasks should exist on rep2 now
-    let mut t12 = rep2.get_task(uuid1)?.expect("expected task 1 on rep2");
-    let t22 = rep2.get_task(uuid2)?.expect("expected task 2 on rep2");
+    let mut t12 = rep2
+        .get_task(uuid1)
+        .await?
+        .expect("expected task 1 on rep2");
+    let t22 = rep2
+        .get_task(uuid2)
+        .await?
+        .expect("expected task 2 on rep2");
 
     assert_eq!(t12.get_description(), "test 1");
     assert_eq!(t12.is_active(), true);
@@ -49,43 +55,49 @@ fn cross_sync() -> anyhow::Result<()> {
     // make non-conflicting changes on the two replicas
     let mut ops = Operations::new();
     t2.set_status(Status::Completed, &mut ops)?;
-    rep2.commit_operations(ops)?;
+    rep1.commit_operations(ops).await?;
 
     let mut ops = Operations::new();
     t12.set_status(Status::Completed, &mut ops)?;
-    rep2.commit_operations(ops)?;
+    rep2.commit_operations(ops).await?;
 
     // sync those changes back and forth
-    rep1.sync(&mut server, false)?; // rep1 -> server
-    rep2.sync(&mut server, false)?; // server -> rep2, rep2 -> server
-    rep1.sync(&mut server, false)?; // server -> rep1
+    rep1.sync(server.clone(), false).await?; // rep1 -> server
+    rep2.sync(server.clone(), false).await?; // server -> rep2, rep2 -> server
+    rep1.sync(server.clone(), false).await?; // server -> rep1
 
-    let t1 = rep1.get_task(uuid1)?.expect("expected task 1 on rep1");
+    let t1 = rep1
+        .get_task(uuid1)
+        .await?
+        .expect("expected task 1 on rep1");
     assert_eq!(t1.get_status(), Status::Completed);
 
-    let mut t22 = rep2.get_task(uuid2)?.expect("expected task 2 on rep2");
+    let mut t22 = rep2
+        .get_task(uuid2)
+        .await?
+        .expect("expected task 2 on rep2");
     assert_eq!(t22.get_status(), Status::Completed);
 
-    rep1.rebuild_working_set(true)?;
-    rep2.rebuild_working_set(true)?;
+    rep1.rebuild_working_set(true).await?;
+    rep2.rebuild_working_set(true).await?;
 
     // Make task 2 pending again, and observe that it is in the working set in both replicas after
     // sync.
     let mut ops = Operations::new();
     t22.set_status(Status::Pending, &mut ops)?;
-    rep2.commit_operations(ops)?;
+    rep2.commit_operations(ops).await?;
 
-    let ws = rep2.working_set()?;
+    let ws = rep2.working_set().await?;
     assert_eq!(ws.by_index(1), Some(uuid2));
 
     // Pending status is not sync'd to rep1 yet.
-    let ws = rep1.working_set()?;
+    let ws = rep1.working_set().await?;
     assert_eq!(ws.by_index(1), None);
 
-    rep2.sync(&mut server, false)?;
-    rep1.sync(&mut server, false)?;
+    rep2.sync(server.clone(), false).await?;
+    rep1.sync(server.clone(), false).await?;
 
-    let ws = rep1.working_set()?;
+    let ws = rep1.working_set().await?;
     assert_eq!(ws.by_index(1), Some(uuid2));
 
     Ok(())

--- a/tests/syncing-proptest.rs
+++ b/tests/syncing-proptest.rs
@@ -33,60 +33,62 @@ proptest! {
 /// that results in a task being in different states in different replicas. Different tasks
 /// cannot interfere with one another, so this focuses on a single task.
 fn multi_replica_sync(action_sequence in actions()) {
-    let tmp_dir = TempDir::new().expect("TempDir failed");
-    let uuid = Uuid::parse_str("83a2f9ef-f455-4195-b92e-a54c161eebfc").unwrap();
-    let server_config = ServerConfig::Local {
-        server_dir: tmp_dir.path().to_path_buf(),
-    };
-    let mut server = server_config.into_server()?;
-    let mut replicas: [Replica<InMemoryStorage>; 3] = [
-        Replica::new(InMemoryStorage::new()),
-        Replica::new(InMemoryStorage::new()),
-        Replica::new(InMemoryStorage::new()),
-    ];
+    tokio::runtime::Runtime::new().unwrap().block_on(async {
+        let tmp_dir = TempDir::new().expect("TempDir failed");
+        let uuid = Uuid::parse_str("83a2f9ef-f455-4195-b92e-a54c161eebfc").unwrap();
+        let server_config = ServerConfig::Local {
+            server_dir: tmp_dir.path().to_path_buf(),
+        };
+        let server = server_config.into_server().unwrap();
+        let mut replicas = [
+            Replica::new(InMemoryStorage::new()),
+            Replica::new(InMemoryStorage::new()),
+            Replica::new(InMemoryStorage::new()),
+        ];
 
-    for (action, rep) in action_sequence {
-        println!("{:?} on rep {}", action, rep);
+        for (action, rep) in action_sequence {
+            println!("{:?} on rep {}", action, rep);
 
-        let rep = &mut replicas[rep as usize];
-        match action {
-            Action::Create => {
-                if rep.get_task_data(uuid).unwrap().is_none() {
-                    let mut ops = Operations::new();
-                    TaskData::create(uuid, &mut ops);
-                    rep.commit_operations(ops).unwrap();
-                }
-            },
-            Action::Update(p, v) => {
-                if let Some(mut t) = rep.get_task_data(uuid).unwrap() {
-                    let mut ops = Operations::new();
-                    t.update(p, Some(v), &mut ops);
-                    rep.commit_operations(ops).unwrap();
-                }
-            },
-            Action::Delete => {
-                if let Some(mut t) = rep.get_task_data(uuid).unwrap() {
-                    let mut ops = Operations::new();
-                    t.delete(&mut ops);
-                    rep.commit_operations(ops).unwrap();
-                }
-            },
-            Action::Sync => rep.sync(&mut server, false).unwrap(),
+            let rep = &mut replicas[rep as usize];
+            match action {
+                Action::Create => {
+                    if rep.get_task_data(uuid).await.unwrap().is_none() {
+                        let mut ops = Operations::new();
+                        TaskData::create(uuid, &mut ops);
+                        rep.commit_operations(ops).await.unwrap();
+                    }
+                },
+                Action::Update(p, v) => {
+                    if let Some(mut t) = rep.get_task_data(uuid).await.unwrap() {
+                        let mut ops = Operations::new();
+                        t.update(p, Some(v), &mut ops);
+                        rep.commit_operations(ops).await.unwrap();
+                    }
+                },
+                Action::Delete => {
+                    if let Some(mut t) = rep.get_task_data(uuid).await.unwrap() {
+                        let mut ops = Operations::new();
+                        t.delete(&mut ops);
+                        rep.commit_operations(ops).await.unwrap();
+                    }
+                },
+                Action::Sync => rep.sync(server.clone(), false).await.unwrap(),
+            }
         }
-    }
 
-    // Sync all of the replicas, twice, to flush out any un-synced changes.
-    for rep in &mut replicas {
-        rep.sync(&mut server, false).unwrap()
-    }
-    for rep in &mut replicas {
-        rep.sync(&mut server, false).unwrap()
-    }
+        // Sync all of the replicas, twice, to flush out any un-synced changes.
+        for rep in &mut replicas {
+            rep.sync(server.clone(), false).await.unwrap()
+        }
+        for rep in &mut replicas {
+            rep.sync(server.clone(), false).await.unwrap()
+        }
 
-    let t0 = replicas[0].get_task_data(uuid).unwrap();
-    let t1 = replicas[1].get_task_data(uuid).unwrap();
-    let t2 = replicas[2].get_task_data(uuid).unwrap();
-    assert_eq!(t0, t1);
-    assert_eq!(t1, t2);
+        let t0 = replicas[0].get_task_data(uuid).await.unwrap();
+        let t1 = replicas[1].get_task_data(uuid).await.unwrap();
+        let t2 = replicas[2].get_task_data(uuid).await.unwrap();
+        assert_eq!(t0, t1);
+        assert_eq!(t1, t2);
+    });
 }
 }

--- a/tests/update-and-delete-sync.rs
+++ b/tests/update-and-delete-sync.rs
@@ -2,29 +2,29 @@ use taskchampion::chrono::{TimeZone, Utc};
 use taskchampion::{storage::InMemoryStorage, Operations, Replica, ServerConfig, Status, Uuid};
 use tempfile::TempDir;
 
-#[test]
+#[tokio::test]
 #[cfg(feature = "server-local")]
-fn update_and_delete_sync_delete_first() -> anyhow::Result<()> {
-    update_and_delete_sync(true)
+async fn update_and_delete_sync_delete_first() -> anyhow::Result<()> {
+    update_and_delete_sync(true).await
 }
 
-#[test]
+#[tokio::test]
 #[cfg(feature = "server-local")]
-fn update_and_delete_sync_update_first() -> anyhow::Result<()> {
-    update_and_delete_sync(false)
+async fn update_and_delete_sync_update_first() -> anyhow::Result<()> {
+    update_and_delete_sync(false).await
 }
 
 /// Test what happens when an update is sync'd into a repo after a task is deleted.
 /// If delete_first, then the deletion is sync'd to the server first; otherwise
 /// the update is sync'd first.  Either way, the task is gone.
 #[cfg(feature = "server-local")]
-fn update_and_delete_sync(delete_first: bool) -> anyhow::Result<()> {
+async fn update_and_delete_sync(delete_first: bool) -> anyhow::Result<()> {
     // set up two replicas, and demonstrate replication between them
     let mut rep1 = Replica::new(InMemoryStorage::new());
     let mut rep2 = Replica::new(InMemoryStorage::new());
 
     let tmp_dir = TempDir::new().expect("TempDir failed");
-    let mut server = ServerConfig::Local {
+    let server = ServerConfig::Local {
         server_dir: tmp_dir.path().to_path_buf(),
     }
     .into_server()?;
@@ -32,53 +32,53 @@ fn update_and_delete_sync(delete_first: bool) -> anyhow::Result<()> {
     // add a task on rep1, and sync it to rep2
     let mut ops = Operations::new();
     let u = Uuid::new_v4();
-    let mut t = rep1.create_task(u, &mut ops)?;
+    let mut t = rep1.create_task(u, &mut ops).await?;
     t.set_description("test task".into(), &mut ops)?;
     t.set_status(Status::Pending, &mut ops)?;
     t.set_entry(Some(Utc::now()), &mut ops)?;
-    rep1.commit_operations(ops)?;
+    rep1.commit_operations(ops).await?;
 
-    rep1.sync(&mut server, false)?;
-    rep2.sync(&mut server, false)?;
+    rep1.sync(server.clone(), false).await?;
+    rep2.sync(server.clone(), false).await?;
 
     // mark the task as deleted, long in the past, on rep2
     {
         let mut ops = Operations::new();
-        let mut t = rep2.get_task(u)?.unwrap();
+        let mut t = rep2.get_task(u).await?.unwrap();
         t.set_status(Status::Deleted, &mut ops)?;
         t.set_modified(Utc.with_ymd_and_hms(1980, 1, 1, 0, 0, 0).unwrap(), &mut ops)?;
-        rep2.commit_operations(ops)?;
+        rep2.commit_operations(ops).await?;
     }
 
     // sync it back to rep1
-    rep2.sync(&mut server, false)?;
-    rep1.sync(&mut server, false)?;
+    rep2.sync(server.clone(), false).await?;
+    rep1.sync(server.clone(), false).await?;
 
     // expire the task on rep1 and check that it is gone locally
-    rep1.expire_tasks()?;
-    assert!(rep1.get_task(u)?.is_none());
+    rep1.expire_tasks().await?;
+    assert!(rep1.get_task(u).await?.is_none());
 
     // modify the task on rep2
     {
         let mut ops = Operations::new();
-        let mut t = rep2.get_task(u)?.unwrap();
+        let mut t = rep2.get_task(u).await?.unwrap();
         t.set_description("modified".to_string(), &mut ops)?;
-        rep2.commit_operations(ops)?;
+        rep2.commit_operations(ops).await?;
     }
 
     // sync back and forth
     if delete_first {
-        rep1.sync(&mut server, false)?;
+        rep1.sync(server.clone(), false).await?;
     }
-    rep2.sync(&mut server, false)?;
-    rep1.sync(&mut server, false)?;
+    rep2.sync(server.clone(), false).await?;
+    rep1.sync(server.clone(), false).await?;
     if !delete_first {
-        rep2.sync(&mut server, false)?;
+        rep2.sync(server.clone(), false).await?;
     }
 
     // check that the task is gone on both replicas
-    assert!(rep1.get_task(u)?.is_none());
-    assert!(rep2.get_task(u)?.is_none());
+    assert!(rep1.get_task(u).await?.is_none());
+    assert!(rep2.get_task(u).await?.is_none());
 
     Ok(())
 }


### PR DESCRIPTION
This change depends on #604.

The `Replica` and `Storage` APIs have been converted to be async. This makes the library non-blocking and suitable for use in WASM and other environments.

Key changes include:
* Most methods on `Replica` are now `async` and must be awaited.
* The `Storage` trait is now an `async_trait`, with its `txn` method becoming async.
* `SqliteStorage` is reimplemented using `tokio-rusqlite` to provide an async interface to the database. This required downgrading the `rusqlite` dependency to a compatible version.
* `InMemoryStorage` now uses a `Mutex` to ensure thread-safe access in async contexts.
* The `TaskDb` struct has been refactored into a stateless "namespace", removing it as a field from `Replica` and simplifying state management.
* `ServerConfig::into_server` now returns an `Arc<Mutex<dyn Server + Send>>` to allow servers to be shared safely across async tasks.
* All tests, examples, and internal call sites have been updated for the new async API, using `#[tokio::test]` and `await`.