### PR TITLE
Satisfy new lint 'mismatched_lifetime_syntaxes'

### DIFF
--- a/src/server/local/mod.rs
+++ b/src/server/local/mod.rs
@@ -23,7 +23,7 @@ pub(crate) struct LocalServer {
 }
 
 impl LocalServer {
-    fn txn(&mut self) -> Result<rusqlite::Transaction> {
+    fn txn(&'_ mut self) -> Result<rusqlite::Transaction<'_>> {
         let txn = self.con.transaction()?;
         Ok(txn)
     }


### PR DESCRIPTION
This clippy lint has been complaining since the latest Rust release. The idea is just to clarify that `Transaction` carries a lifetime based on `&mut self`.