### PR TITLE
Fix incorrect string quoting in schema

### DIFF
--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -19,6 +19,7 @@ jobs:
           - "server-gcp"
           - "server-aws"
           - "tls-native-roots"
+          - "bundled"
 
     name: "taskchampion ${{ matrix.features == '' && 'with no features' || format('with features {0}', matrix.features) }}"
     runs-on: ubuntu-latest


### PR DESCRIPTION
The use of `"$.Delete.uuid"` and similar in the operations.uuid column is invalid. SQLite version 3.45.1 at least allows this invalid syntax, but newer versions do not.

Unfortunately, fixing this requires a schema update, and requires dropping and re-creating the `operations_by_uuid` index. For users with a huge number of operations (millions), this could take some time to complete (10's of seconds).

I couldn't get a `VACUUM` to fail in a unit test, but the newest version of SQLite I could use easily was 3.50.2 (with the `bundled` feature, here enabled for CI)