### PR TITLE
changing timestamp-utility functions to pub

### DIFF
--- a/src/task/task.rs
+++ b/src/task/task.rs
@@ -546,16 +546,7 @@ impl Task {
         self.set_value(key, None, ops)
     }
 
-    // -- utility functions
-
-    fn is_known_key(key: &str) -> bool {
-        Prop::from_str(key).is_ok()
-            || key.starts_with("tag_")
-            || key.starts_with("annotation_")
-            || key.starts_with("dep_")
-    }
-
-    fn get_timestamp(&self, property: &str) -> Option<Timestamp> {
+    pub fn get_timestamp(&self, property: &str) -> Option<Timestamp> {
         if let Some(ts) = self.data.get(property) {
             if let Ok(ts) = ts.parse() {
                 return Some(utc_timestamp(ts));
@@ -565,13 +556,22 @@ impl Task {
         None
     }
 
-    fn set_timestamp(
+    pub fn set_timestamp(
         &mut self,
         property: &str,
         value: Option<Timestamp>,
         ops: &mut Operations,
     ) -> Result<()> {
         self.set_value(property, value.map(|v| v.timestamp().to_string()), ops)
+    }
+
+    // -- utility functions
+
+    fn is_known_key(key: &str) -> bool {
+        Prop::from_str(key).is_ok()
+            || key.starts_with("tag_")
+            || key.starts_with("annotation_")
+            || key.starts_with("dep_")
     }
 }
 

--- a/src/task/task.rs
+++ b/src/task/task.rs
@@ -546,6 +546,10 @@ impl Task {
         self.set_value(key, None, ops)
     }
 
+    /// Get the given timestamp property.
+    ///
+    /// This will return `None` if the property is not set, or if it is not a valid
+    /// timestamp. Otherwise, a correctly parsed Timestamp is returned.
     pub fn get_timestamp(&self, property: &str) -> Option<Timestamp> {
         if let Some(ts) = self.data.get(property) {
             if let Ok(ts) = ts.parse() {
@@ -556,6 +560,7 @@ impl Task {
         None
     }
 
+    /// Set the given timestamp property, mapping the value correctly.
     pub fn set_timestamp(
         &mut self,
         property: &str,


### PR DESCRIPTION
As suggested in issue #613, I've moved the timestamp utilities public. Also physically moved the functions outside the comment for utility functions for clarity. Will allow the same functionality to be used for other timestamp data in the task, such as `scheduled`.