### PR TITLE
feat: Add WASM Support

### DIFF
--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -88,3 +88,18 @@ jobs:
 
       - name: test
         run: cargo test
+
+  build-wasm:
+    name: Build for WASM
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v5
+
+    - name: Install Rust toolchain
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        targets: wasm32-unknown-unknown
+
+    - name: Build for wasm32
+      run: cargo build --target wasm32-unknown-unknown --no-default-features --features "storage-inmemory"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3057,7 +3057,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
 dependencies = [
  "getrandom 0.3.1",
+ "js-sys",
  "serde",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,20 +20,24 @@ resolver = "2"
 [features]
 default = ["sync", "bundled", "storage"]
 
+# (private) Support for the sync API
+sync-api = []
 # Support for all sync solutions
-sync = ["server-sync", "server-gcp", "server-aws", "server-local"]
+sync = ["sync-api", "server-sync", "server-gcp", "server-aws", "server-local"]
 # Support for sync to a server
-server-sync = ["encryption", "dep:ureq", "dep:url"]
+server-sync = ["sync-api", "encryption", "dep:ureq", "dep:url"]
 # Support for sync to GCP
-server-gcp = ["cloud", "encryption", "dep:google-cloud-storage"]
+server-gcp = ["sync-api", "cloud", "encryption", "dep:google-cloud-storage"]
 # Support for sync to AWS
-server-aws = ["cloud", "encryption", "dep:aws-sdk-s3", "dep:aws-config", "dep:aws-credential-types"]
+server-aws = ["sync-api", "cloud", "encryption", "dep:aws-sdk-s3", "dep:aws-config", "dep:aws-credential-types"]
 # Suppport for sync to another SQLite database on the same machine
-server-local = ["storage-sqlite"]
+server-local = ["sync-api", "storage-sqlite"]
 # Support for all task storage backends
 storage = ["storage-sqlite"]
 # Support for SQLite task storage
 storage-sqlite = ["dep:rusqlite", "dep:tokio-rusqlite"]
+# Support for the in-memory storage backend (WASM-compatible)
+storage-inmemory = []
 # (private) Support for sync protocol encryption
 encryption = ["dep:ring"]
 # (private) Generic support for cloud sync
@@ -62,13 +66,23 @@ serde_json = "^1.0"
 serde = { version = "^1.0.147", features = ["derive"] }
 strum = "0.27"
 strum_macros = "0.27"
-tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 thiserror = "2.0"
 ureq = { version = "^2.12.1", features = ["tls"], optional = true }
 uuid = { version = "^1.16.0", features = ["serde", "v4"] }
 url = { version = "2", optional = true }
 async-trait = "0.1.89"
 tokio-rusqlite = { version = "0.6.0", optional = true }
+# Use only WASM-compatible features by default
+tokio = { version = "1", features = ["macros"] }
+
+# For non-WASM targets, enable the multi-threaded runtime
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+tokio = { version = "1", features = ["rt-multi-thread"] }
+
+# For WASM targets, enable the single-threaded runtime and WASM-friendly uuid features
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+tokio = { version = "1", features = ["rt"] }
+uuid = { version = "^1.16.0", features = ["js"] }
 
 [dev-dependencies]
 proptest = "^1.7.0"

--- a/README.md
+++ b/README.md
@@ -20,3 +20,12 @@ The Rust API, as defined in [the docs](https://docs.rs/taskchampion/latest/taskc
 
 The Rust API follows semantic versioning.
 As this is still in the `0.x` phase, so breaking changes may occur but will be indicated with a change to the minor version.
+
+## Building for WebAssembly (WASM)
+When compiling this crate for a WebAssembly target (e.g., wasm32-unknown-unknown), you must disable the default features, as they include dependencies not compatible with WASM. Instead, select only the features you need that are WASM-compatible.
+
+For example, to build with in-memory storage, use the following command:
+
+```bash
+cargo build --target wasm32-unknown-unknown --no-default-features --features "storage-inmemory"
+```

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -74,11 +74,10 @@ impl From<ureq::Error> for Error {
 
 pub(crate) type Result<T> = std::result::Result<T, Error>;
 
-#[cfg(test)]
+#[cfg(all(test, feature = "server-sync"))]
 mod test {
     use super::*;
 
-    #[cfg(feature = "server-sync")]
     #[test]
     fn ureq_error_status() {
         let err = ureq::Error::Status(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,9 @@ pub use depmap::DependencyMap;
 pub use errors::Error;
 pub use operation::{Operation, Operations};
 pub use replica::Replica;
-pub use server::{Server, ServerConfig};
+pub use server::Server;
+#[cfg(feature = "sync-api")]
+pub use server::ServerConfig;
 pub use task::{utc_timestamp, Annotation, Status, Tag, Task, TaskData};
 pub use workingset::WorkingSet;
 

--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -1,4 +1,6 @@
+#[cfg(feature = "sync-api")]
 use super::types::Server;
+#[cfg(feature = "sync-api")]
 use crate::errors::Result;
 #[cfg(feature = "server-aws")]
 pub use crate::server::cloud::aws::AwsCredentials;
@@ -12,10 +14,10 @@ use crate::server::cloud::CloudServer;
 use crate::server::local::LocalServer;
 #[cfg(feature = "server-sync")]
 use crate::server::sync::SyncServer;
-use std::{
-    path::PathBuf,
-    sync::{Arc, Mutex},
-};
+#[cfg(feature = "server-local")]
+use std::path::PathBuf;
+#[cfg(feature = "sync-api")]
+use std::sync::{Arc, Mutex};
 #[cfg(feature = "server-sync")]
 use uuid::Uuid;
 
@@ -23,6 +25,7 @@ use uuid::Uuid;
 ///
 /// This enum is non-exhaustive, as users should only be constructing required
 /// variants, not matching on it.
+#[cfg(feature = "sync-api")]
 #[non_exhaustive]
 pub enum ServerConfig {
     /// A local task database, for situations with a single replica.
@@ -96,6 +99,7 @@ pub enum ServerConfig {
     },
 }
 
+#[cfg(feature = "sync-api")]
 impl ServerConfig {
     /// Get a server based on this configuration
     pub fn into_server(self) -> Result<Arc<Mutex<dyn Server + Send>>> {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -28,6 +28,7 @@ mod sync;
 #[cfg(feature = "cloud")]
 mod cloud;
 
+#[cfg(feature = "sync-api")]
 pub use config::*;
 pub use types::*;
 

--- a/tests/cross-sync.rs
+++ b/tests/cross-sync.rs
@@ -1,10 +1,11 @@
+#![cfg(feature = "server-local")]
+
 use chrono::Utc;
 use pretty_assertions::assert_eq;
 use taskchampion::{storage::InMemoryStorage, Operations, Replica, ServerConfig, Status, Uuid};
 use tempfile::TempDir;
 
 #[tokio::test]
-#[cfg(feature = "server-local")]
 async fn cross_sync() -> anyhow::Result<()> {
     // set up two replicas, and demonstrate replication between them
     let mut rep1 = Replica::new(InMemoryStorage::new());

--- a/tests/syncing-proptest.rs
+++ b/tests/syncing-proptest.rs
@@ -1,6 +1,7 @@
+#![cfg(feature = "storage-sqlite")]
+
 use pretty_assertions::assert_eq;
 use proptest::prelude::*;
-#[cfg(feature = "storage-sqlite")]
 use taskchampion::{storage::InMemoryStorage, Operations, Replica, ServerConfig, TaskData, Uuid};
 use tempfile::TempDir;
 
@@ -27,7 +28,6 @@ fn actions() -> impl Strategy<Value = Vec<(Action, u8)>> {
 
 proptest! {
 #[test]
-#[cfg(feature = "storage-sqlite")]
 /// Check that various sequences of operations on mulitple db's do not get the db's into an
 /// incompatible state.  The main concern here is that there might be a sequence of operations
 /// that results in a task being in different states in different replicas. Different tasks

--- a/tests/update-and-delete-sync.rs
+++ b/tests/update-and-delete-sync.rs
@@ -1,15 +1,15 @@
+#![cfg(feature = "server-local")]
+
 use taskchampion::chrono::{TimeZone, Utc};
 use taskchampion::{storage::InMemoryStorage, Operations, Replica, ServerConfig, Status, Uuid};
 use tempfile::TempDir;
 
 #[tokio::test]
-#[cfg(feature = "server-local")]
 async fn update_and_delete_sync_delete_first() -> anyhow::Result<()> {
     update_and_delete_sync(true).await
 }
 
 #[tokio::test]
-#[cfg(feature = "server-local")]
 async fn update_and_delete_sync_update_first() -> anyhow::Result<()> {
     update_and_delete_sync(false).await
 }
@@ -17,7 +17,6 @@ async fn update_and_delete_sync_update_first() -> anyhow::Result<()> {
 /// Test what happens when an update is sync'd into a repo after a task is deleted.
 /// If delete_first, then the deletion is sync'd to the server first; otherwise
 /// the update is sync'd first.  Either way, the task is gone.
-#[cfg(feature = "server-local")]
 async fn update_and_delete_sync(delete_first: bool) -> anyhow::Result<()> {
     // set up two replicas, and demonstrate replication between them
     let mut rep1 = Replica::new(InMemoryStorage::new());


### PR DESCRIPTION
This PR introduces support for compiling to the `wasm32-unknown-unknown` target, enabling its use in WASM environments.

To achieve this, several changes were made:
* **WASM-Specific Dependencies:** `Cargo.toml` now uses target-specific dependencies. For `wasm32`, `tokio` is configured with a single-threaded runtime and `uuid` to use JS-native random number generation. Non-WASM targets retain the multi-threaded `tokio` runtime.
* **Feature Flag Refactoring:** A new `sync-api` private feature was introduced to gate synchronization logic that is not WASM-compatible. Existing sync features now depend on this new feature flag. This allows building the core library without the networking and filesystem dependencies required for server sync.
* **In-Memory Storage:** A new `storage-inmemory` feature has been added. A future PR will add this functionality to provide a storage backend that is compatible with WASM environments.
* **CI Workflow:** A new GitHub Action, `build-wasm`, has been added to continuously verify that the crate builds successfully for the `wasm32` target.
* **Documentation:** The `README.md` has been updated with a new section explaining how to build the crate for WASM, highlighting the need to disable default features and select compatible ones.