### PR TITLE
Revert async changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,18 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
-name = "ahash"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy 0.8.26",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -89,9 +77,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.89"
+version = "0.1.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -716,21 +704,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-channel"
-version = "0.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
-
-[[package]]
 name = "crypto-bigint"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1164,15 +1137,6 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
@@ -1184,11 +1148,11 @@ dependencies = [
 
 [[package]]
 name = "hashlink"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
- "hashbrown 0.14.5",
+ "hashbrown",
 ]
 
 [[package]]
@@ -1554,7 +1518,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.2",
+ "hashbrown",
 ]
 
 [[package]]
@@ -1619,9 +1583,9 @@ checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.30.1"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+checksum = "133c182a6a2c87864fe97778797e46c7e999672690dc9fa3ee8e241aa4a9c13f"
 dependencies = [
  "cc",
  "pkg-config",
@@ -1662,7 +1626,7 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
- "hashbrown 0.15.2",
+ "hashbrown",
 ]
 
 [[package]]
@@ -1887,7 +1851,7 @@ version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
- "zerocopy 0.7.35",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2240,9 +2204,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.32.1"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+checksum = "165ca6e57b20e1351573e3729b958bc62f0e48025386970b6e4d29e7a7e71f3f"
 dependencies = [
  "bitflags",
  "fallible-iterator",
@@ -2703,7 +2667,6 @@ name = "taskchampion"
 version = "3.0.0-pre"
 dependencies = [
  "anyhow",
- "async-trait",
  "aws-config",
  "aws-credential-types",
  "aws-sdk-s3",
@@ -2724,7 +2687,6 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.6",
  "tokio",
- "tokio-rusqlite",
  "ureq",
  "url",
  "uuid",
@@ -2868,17 +2830,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "tokio-rusqlite"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b65501378eb676f400c57991f42cbd0986827ab5c5200c53f206d710fb32a945"
-dependencies = [
- "crossbeam-channel",
- "rusqlite",
- "tokio",
 ]
 
 [[package]]
@@ -3423,16 +3374,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "byteorder",
- "zerocopy-derive 0.7.35",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.8.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
-dependencies = [
- "zerocopy-derive 0.8.26",
+ "zerocopy-derive",
 ]
 
 [[package]]
@@ -3440,17 +3382,6 @@ name = "zerocopy-derive"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2664,7 +2664,7 @@ dependencies = [
 
 [[package]]
 name = "taskchampion"
-version = "3.0.0-pre"
+version = "2.0.4-pre"
 dependencies = [
  "anyhow",
  "aws-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,21 +25,21 @@ sync = ["server-sync", "server-gcp", "server-aws", "server-local"]
 # Support for sync to a server
 server-sync = ["encryption", "dep:ureq", "dep:url"]
 # Support for sync to GCP
-server-gcp = ["cloud", "encryption", "dep:google-cloud-storage"]
+server-gcp = ["cloud", "encryption", "dep:google-cloud-storage", "dep:tokio"]
 # Support for sync to AWS
-server-aws = ["cloud", "encryption", "dep:aws-sdk-s3", "dep:aws-config", "dep:aws-credential-types"]
+server-aws = ["cloud", "encryption", "dep:aws-sdk-s3", "dep:aws-config", "dep:aws-credential-types", "dep:tokio"]
 # Suppport for sync to another SQLite database on the same machine
 server-local = ["storage-sqlite"]
 # Support for all task storage backends
 storage = ["storage-sqlite"]
 # Support for SQLite task storage
-storage-sqlite = ["dep:rusqlite", "dep:tokio-rusqlite"]
+storage-sqlite = ["dep:rusqlite"]
 # (private) Support for sync protocol encryption
 encryption = ["dep:ring"]
 # (private) Generic support for cloud sync
 cloud = []
 # static bundling of dependencies
-bundled = ["rusqlite/bundled", "tokio-rusqlite/bundled"]
+bundled = ["rusqlite/bundled"]
 # use native CA roots, instead of bundled
 tls-native-roots = ["ureq/native-certs"]
 
@@ -57,18 +57,16 @@ flate2 = "1"
 google-cloud-storage = { version = "0.24.0", default-features = false, features = ["rustls-tls", "auth"], optional = true }
 log = "^0.4.17"
 ring = { version = "0.17", optional = true }
-rusqlite = { version = "0.32", optional = true}
+rusqlite = { version = "0.37", optional = true}
 serde_json = "^1.0"
 serde = { version = "^1.0.147", features = ["derive"] }
 strum = "0.27"
 strum_macros = "0.27"
-tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+tokio = { version = "1", features = ["rt-multi-thread"], optional = true }
 thiserror = "2.0"
 ureq = { version = "^2.12.1", features = ["tls"], optional = true }
 uuid = { version = "^1.16.0", features = ["serde", "v4"] }
 url = { version = "2", optional = true }
-async-trait = "0.1.89"
-tokio-rusqlite = { version = "0.6.0", optional = true }
 
 [dev-dependencies]
 proptest = "^1.7.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taskchampion"
-version = "3.0.0-pre"
+version = "2.0.4-pre"
 authors = ["Dustin J. Mitchell <dustin@mozilla.com>"]
 description = "Personal task-tracking"
 homepage = "https://gothenburgbitfactory.github.io/taskchampion/"

--- a/src/crate-doc.md
+++ b/src/crate-doc.md
@@ -18,6 +18,7 @@ Replicas are accessed using the [`Replica`] type.
 # Task Storage
 
 Replicas access the task database via a [storage object](crate::storage::Storage).
+Create a storage object with [`StorageConfig`].
 
 The [`storage`] module supports pluggable storage for a replica's data.
 An implementation is provided, but users of this crate can provide their own implementation as well.
@@ -35,7 +36,7 @@ Several server implementations are included, and users can define their own impl
 ```rust
 # #[cfg(feature = "storage-sqlite")]
 # {
-# use taskchampion::{storage::AccessMode, ServerConfig, Replica, storage::InMemoryStorage};
+# use taskchampion::{storage::AccessMode, ServerConfig, Replica, StorageConfig};
 # use tempfile::TempDir;
 # fn main() -> anyhow::Result<()> {
 # let taskdb_dir = TempDir::new()?;
@@ -43,8 +44,12 @@ Several server implementations are included, and users can define their own impl
 # let server_dir = TempDir::new()?;
 # let server_dir = server_dir.path().to_path_buf();
 // Create a new Replica, storing data on disk.
-let storage = InMemoryStorage::new();
-let mut replica: Replica<InMemoryStorage> = Replica::new(storage);
+let storage = StorageConfig::OnDisk {
+  taskdb_dir,
+  create_if_missing: true,
+  access_mode: AccessMode::ReadWrite,
+}.into_storage()?;
+let mut replica = Replica::new(storage);
 
 // Set up a local, on-disk server.
 let server_config = ServerConfig::Local { server_dir };

--- a/src/crate-doc.md
+++ b/src/crate-doc.md
@@ -37,8 +37,7 @@ Several server implementations are included, and users can define their own impl
 # {
 # use taskchampion::{storage::AccessMode, ServerConfig, Replica, storage::InMemoryStorage};
 # use tempfile::TempDir;
-# #[tokio::main]
-# async fn main() -> anyhow::Result<()> {
+# fn main() -> anyhow::Result<()> {
 # let taskdb_dir = TempDir::new()?;
 # let taskdb_dir = taskdb_dir.path().to_path_buf();
 # let server_dir = TempDir::new()?;
@@ -52,7 +51,7 @@ let server_config = ServerConfig::Local { server_dir };
 let mut server = server_config.into_server()?;
 
 // Sync to that server.
-replica.sync(server, true).await?;
+replica.sync(&mut server, true)?;
 #
 # Ok(())
 # }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -41,8 +41,6 @@ other_error!(serde_json::Error);
 other_error!(rusqlite::Error);
 #[cfg(feature = "storage-sqlite")]
 other_error!(crate::storage::sqlite::SqliteError);
-#[cfg(feature = "storage-sqlite")]
-other_error!(tokio_rusqlite::Error);
 
 #[cfg(feature = "server-gcp")]
 other_error!(google_cloud_storage::http::Error);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ pub use errors::Error;
 pub use operation::{Operation, Operations};
 pub use replica::Replica;
 pub use server::{Server, ServerConfig};
+pub use storage::StorageConfig;
 pub use task::{utc_timestamp, Annotation, Status, Tag, Task, TaskData};
 pub use workingset::WorkingSet;
 

--- a/src/replica.rs
+++ b/src/replica.rs
@@ -13,7 +13,7 @@ use anyhow::Context;
 use chrono::{DateTime, Duration, Utc};
 use log::trace;
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use uuid::Uuid;
 
 /// A replica represents an instance of a user's task data, providing an easy interface
@@ -39,8 +39,7 @@ use uuid::Uuid;
 # use taskchampion::chrono::{TimeZone, Utc};
 # use taskchampion::{storage::AccessMode, Operations, Replica, Status, Uuid, storage::SqliteStorage};
 # use tempfile::TempDir;
-# #[tokio::main]
-# async fn main() -> anyhow::Result<()> {
+# fn main() -> anyhow::Result<()> {
 # let tmp_dir = TempDir::new()?;
 # let mut replica: Replica<SqliteStorage> = Replica::new(SqliteStorage::new(
 #   tmp_dir.path().to_path_buf(),
@@ -50,13 +49,13 @@ use uuid::Uuid;
 // Create a new task, recording the required operations.
 let mut ops = Operations::new();
 let uuid = Uuid::new_v4();
-let mut t = replica.create_task(uuid, &mut ops).await?;
+let mut t = replica.create_task(uuid, &mut ops)?;
 t.set_description("my first task".into(), &mut ops)?;
 t.set_status(Status::Pending, &mut ops)?;
 t.set_entry(Some(Utc::now()), &mut ops)?;
 
 // Commit those operations to storage.
-replica.commit_operations(ops).await?;
+replica.commit_operations(ops)?;
 #
 # Ok(())
 # }
@@ -75,6 +74,8 @@ replica.commit_operations(ops).await?;
 pub struct Replica<S: Storage> {
     storage: S,
 
+    taskdb: TaskDb,
+
     /// If true, this replica has already added an undo point.
     added_undo_point: bool,
 
@@ -86,16 +87,22 @@ impl<S: Storage> Replica<S> {
     pub fn new(storage: S) -> Self {
         Self {
             storage,
+            taskdb: TaskDb::new(),
             added_undo_point: false,
             depmap: None,
         }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new_inmemory() -> Replica<InMemoryStorage> {
+        Replica::new(InMemoryStorage::new())
     }
 
     /// Update an existing task.  If the value is Some, the property is added or updated.  If the
     /// value is None, the property is deleted.  It is not an error to delete a nonexistent
     /// property.
     #[deprecated(since = "0.7.0", note = "please use TaskData instead")]
-    pub async fn update_task<S1, S2>(
+    pub fn update_task<S1, S2>(
         &mut self,
         uuid: Uuid,
         property: S1,
@@ -108,56 +115,52 @@ impl<S: Storage> Replica<S> {
         let value = value.map(|v| v.into());
         let property = property.into();
         let mut ops = self.make_operations();
-        let Some(mut task) = self.get_task_data(uuid).await? else {
+        let Some(mut task) = self.get_task_data(uuid)? else {
             return Err(Error::Database(format!("Task {} does not exist", uuid)));
         };
         task.update(property, value, &mut ops);
-        self.commit_operations(ops).await?;
-        self.storage
-            .txn(move |txn| {
-                Ok(TaskDb::get_task(txn, uuid)?.expect("task should exist after an update"))
-            })
-            .await
+        self.commit_operations(ops)?;
+        self.storage.txn(|txn| {
+            Ok(self
+                .taskdb
+                .get_task(txn, uuid)?
+                .expect("task should exist after an update"))
+        })
     }
 
     /// Get all tasks represented as a map keyed by UUID
-    pub async fn all_tasks(&mut self) -> Result<HashMap<Uuid, Task>> {
-        let depmap = self.dependency_map(false).await?;
-        self.storage
-            .txn(move |txn| {
-                let mut res = HashMap::new();
-                for (uuid, tm) in TaskDb::all_tasks(txn)?.drain(..) {
-                    res.insert(uuid, Task::new(TaskData::new(uuid, tm), depmap.clone()));
-                }
-                Ok(res)
-            })
-            .await
+    pub fn all_tasks(&mut self) -> Result<HashMap<Uuid, Task>> {
+        let depmap = self.dependency_map(false)?;
+        self.storage.txn(|txn| {
+            let mut res = HashMap::new();
+            for (uuid, tm) in self.taskdb.all_tasks(txn)?.drain(..) {
+                res.insert(uuid, Task::new(TaskData::new(uuid, tm), depmap.clone()));
+            }
+            Ok(res)
+        })
     }
 
     /// Get all task represented as a map of [`TaskData`] keyed by UUID
-    pub async fn all_task_data(&mut self) -> Result<HashMap<Uuid, TaskData>> {
-        self.storage
-            .txn(move |txn| {
-                let mut res = HashMap::new();
-                for (uuid, tm) in TaskDb::all_tasks(txn)?.drain(..) {
-                    res.insert(uuid, TaskData::new(uuid, tm));
-                }
-                Ok(res)
-            })
-            .await
+    pub fn all_task_data(&mut self) -> Result<HashMap<Uuid, TaskData>> {
+        self.storage.txn(|txn| {
+            let mut res = HashMap::new();
+            for (uuid, tm) in self.taskdb.all_tasks(txn)?.drain(..) {
+                res.insert(uuid, TaskData::new(uuid, tm));
+            }
+            Ok(res)
+        })
     }
 
     /// Get the UUIDs of all tasks
-    pub async fn all_task_uuids(&mut self) -> Result<Vec<Uuid>> {
-        self.storage.txn(|txn| TaskDb::all_task_uuids(txn)).await
+    pub fn all_task_uuids(&mut self) -> Result<Vec<Uuid>> {
+        self.storage.txn(|txn| self.taskdb.all_task_uuids(txn))
     }
 
     /// Get an array containing all pending tasks
-    pub async fn pending_tasks(&mut self) -> Result<Vec<Task>> {
-        let depmap = self.dependency_map(false).await?;
+    pub fn pending_tasks(&mut self) -> Result<Vec<Task>> {
+        let depmap = self.dependency_map(false)?;
         let res = self
-            .pending_task_data()
-            .await?
+            .pending_task_data()?
             .into_iter()
             .map(|taskdata| Task::new(taskdata, depmap.clone()))
             .collect();
@@ -165,29 +168,28 @@ impl<S: Storage> Replica<S> {
         Ok(res)
     }
 
-    pub async fn pending_task_data(&mut self) -> Result<Vec<TaskData>> {
-        self.storage
-            .txn(move |txn| {
-                let res = TaskDb::get_pending_tasks(txn)?
-                    .into_iter()
-                    .map(|(uuid, taskmap)| TaskData::new(uuid, taskmap))
-                    .collect::<Vec<_>>();
+    pub fn pending_task_data(&mut self) -> Result<Vec<TaskData>> {
+        self.storage.txn(|txn| {
+            let res = self
+                .taskdb
+                .get_pending_tasks(txn)?
+                .into_iter()
+                .map(|(uuid, taskmap)| TaskData::new(uuid, taskmap))
+                .collect::<Vec<_>>();
 
-                Ok(res)
-            })
-            .await
+            Ok(res)
+        })
     }
 
     /// Get the "working set" for this replica.  This is a snapshot of the current state,
     /// and it is up to the caller to decide how long to store this value.
-    pub async fn working_set(&mut self) -> Result<WorkingSet> {
+    pub fn working_set(&mut self) -> Result<WorkingSet> {
         self.storage
-            .txn(|txn| Replica::<S>::working_set_with_txn(txn))
-            .await
+            .txn(|txn| Replica::<S>::working_set_with_txn(&mut self.taskdb, txn))
     }
 
-    fn working_set_with_txn(txn: &mut dyn StorageTxn) -> Result<WorkingSet> {
-        Ok(WorkingSet::new(TaskDb::working_set(txn)?))
+    fn working_set_with_txn(taskdb: &mut TaskDb, txn: &mut dyn StorageTxn) -> Result<WorkingSet> {
+        Ok(WorkingSet::new(taskdb.working_set(txn)?))
     }
 
     /// Get the dependency map for all pending tasks.
@@ -204,29 +206,22 @@ impl<S: Storage> Replica<S> {
     ///
     /// Calculating this value requires a scan of the full working set and may not be performant.
     /// The [`TaskData`] API avoids generating this value.
-    pub async fn dependency_map(&mut self, force: bool) -> Result<Arc<DependencyMap>> {
-        if !force {
-            if let Some(depmap) = &self.depmap {
-                return Ok(depmap.clone());
-            }
-        }
-
-        let dm = self
-            .storage
-            .txn(|txn| {
+    pub fn dependency_map(&mut self, force: bool) -> Result<Arc<DependencyMap>> {
+        self.storage.txn(|txn| {
+            if force || self.depmap.is_none() {
                 // note: we can't use self.get_task here, as that depends on a
                 // DependencyMap
 
                 let mut dm = DependencyMap::new();
                 // temporary cache tracking whether tasks are considered Pending or not.
                 let mut is_pending_cache: HashMap<Uuid, bool> = HashMap::new();
-                let ws = Replica::<S>::working_set_with_txn(txn)?;
+                let ws = Replica::<S>::working_set_with_txn(&mut self.taskdb, txn)?;
                 // for each task in the working set
                 for i in 1..=ws.largest_index() {
                     // get the task UUID
                     if let Some(u) = ws.by_index(i) {
                         // get the task
-                        if let Some(taskmap) = TaskDb::get_task(txn, u)? {
+                        if let Some(taskmap) = self.taskdb.get_task(txn, u)? {
                             // search the task's keys
                             for p in taskmap.keys() {
                                 // for one matching `dep_..`
@@ -240,7 +235,7 @@ impl<S: Storage> Replica<S> {
                                                 *dep_pending
                                             } else if let Some(dep_taskmap) =
                                                 // or if we get the task
-                                                TaskDb::get_task(txn, dep)?
+                                                self.taskdb.get_task(txn, dep)?
                                             {
                                                 // and its status is "pending"
                                                 let dep_pending = matches!(
@@ -264,31 +259,33 @@ impl<S: Storage> Replica<S> {
                         }
                     }
                 }
-                Ok(dm)
-            })
-            .await?;
+                self.depmap = Some(Arc::new(dm));
+            }
 
-        self.depmap = Some(Arc::new(dm));
-        // at this point self.depmap is guaranteed to be Some(_)
-        Ok(self.depmap.as_ref().unwrap().clone())
+            // at this point self.depmap is guaranteed to be Some(_)
+            Ok(self.depmap.as_ref().unwrap().clone())
+        })
     }
 
     /// Get an existing task by its UUID
-    pub async fn get_task(&mut self, uuid: Uuid) -> Result<Option<Task>> {
-        let depmap = self.dependency_map(false).await?;
-        self.storage
-            .txn(move |txn| {
-                Ok(TaskDb::get_task(txn, uuid)?
-                    .map(move |tm| Task::new(TaskData::new(uuid, tm), depmap)))
-            })
-            .await
+    pub fn get_task(&mut self, uuid: Uuid) -> Result<Option<Task>> {
+        let depmap = self.dependency_map(false)?;
+        self.storage.txn(|txn| {
+            Ok(self
+                .taskdb
+                .get_task(txn, uuid)?
+                .map(move |tm| Task::new(TaskData::new(uuid, tm), depmap)))
+        })
     }
 
     /// Get an existing task by its UUID, as a [`TaskData`](crate::TaskData).
-    pub async fn get_task_data(&mut self, uuid: Uuid) -> Result<Option<TaskData>> {
-        self.storage
-            .txn(move |txn| Ok(TaskDb::get_task(txn, uuid)?.map(move |tm| TaskData::new(uuid, tm))))
-            .await
+    pub fn get_task_data(&mut self, uuid: Uuid) -> Result<Option<TaskData>> {
+        self.storage.txn(|txn| {
+            Ok(self
+                .taskdb
+                .get_task(txn, uuid)?
+                .map(move |tm| TaskData::new(uuid, tm)))
+        })
     }
 
     /// Get the operations that led to the given task.
@@ -301,10 +298,9 @@ impl<S: Storage> Replica<S> {
     /// conflicting operations were performed on different replicas. The "losing" operations in
     /// those conflicts may not appear on all replicas. In practice, conflicts are rare and the
     /// results of this function will be the same on all replicas for most tasks.
-    pub async fn get_task_operations(&mut self, uuid: Uuid) -> Result<Operations> {
+    pub fn get_task_operations(&mut self, uuid: Uuid) -> Result<Operations> {
         self.storage
-            .txn(move |txn| TaskDb::get_task_operations(txn, uuid))
-            .await
+            .txn(|txn| self.taskdb.get_task_operations(txn, uuid))
     }
 
     /// Create a new task, setting `modified`, `description`, `status`, and `entry`.
@@ -315,7 +311,7 @@ impl<S: Storage> Replica<S> {
         since = "0.7.0",
         note = "please use `create_task` and call `Task` methods `set_status`, `set_description`, and `set_entry`"
     )]
-    pub async fn new_task(&mut self, status: Status, description: String) -> Result<Task> {
+    pub fn new_task(&mut self, status: Status, description: String) -> Result<Task> {
         let uuid = Uuid::new_v4();
         let mut ops = self.make_operations();
         let now = format!("{}", Utc::now().timestamp());
@@ -324,11 +320,10 @@ impl<S: Storage> Replica<S> {
         task.update("description", Some(description), &mut ops);
         task.update("status", Some(status.to_taskmap().to_string()), &mut ops);
         task.update("entry", Some(now), &mut ops);
-        self.commit_operations(ops).await?;
+        self.commit_operations(ops)?;
         trace!("task {} created", uuid);
         Ok(self
-            .get_task(uuid)
-            .await?
+            .get_task(uuid)?
             .expect("Task should exist after creation"))
     }
 
@@ -336,11 +331,11 @@ impl<S: Storage> Replica<S> {
     ///
     /// Use [Uuid::new_v4] to invent a new task ID, if necessary. If the task already
     /// exists, it is returned.
-    pub async fn create_task(&mut self, uuid: Uuid, ops: &mut Operations) -> Result<Task> {
-        if let Some(task) = self.get_task(uuid).await? {
+    pub fn create_task(&mut self, uuid: Uuid, ops: &mut Operations) -> Result<Task> {
+        if let Some(task) = self.get_task(uuid)? {
             return Ok(task);
         }
-        let depmap = self.dependency_map(false).await?;
+        let depmap = self.dependency_map(false)?;
         Ok(Task::new(TaskData::create(uuid, ops), depmap))
     }
 
@@ -348,13 +343,12 @@ impl<S: Storage> Replica<S> {
     /// otherwise should be avoided in favor of `create_task`.  If the task already exists, this
     /// does nothing and returns the existing task.
     #[deprecated(since = "0.7.0", note = "please use TaskData instead")]
-    pub async fn import_task_with_uuid(&mut self, uuid: Uuid) -> Result<Task> {
+    pub fn import_task_with_uuid(&mut self, uuid: Uuid) -> Result<Task> {
         let mut ops = self.make_operations();
         TaskData::create(uuid, &mut ops);
-        self.commit_operations(ops).await?;
+        self.commit_operations(ops)?;
         Ok(self
-            .get_task(uuid)
-            .await?
+            .get_task(uuid)?
             .expect("Task should exist after creation"))
     }
 
@@ -366,13 +360,13 @@ impl<S: Storage> Replica<S> {
     /// after both replicas have fully synced, the resulting task will only have a `description`
     /// property.
     #[deprecated(since = "0.7.0", note = "please use TaskData::delete")]
-    pub async fn delete_task(&mut self, uuid: Uuid) -> Result<()> {
-        let Some(mut task) = self.get_task_data(uuid).await? else {
+    pub fn delete_task(&mut self, uuid: Uuid) -> Result<()> {
+        let Some(mut task) = self.get_task_data(uuid)? else {
             return Err(Error::Database(format!("Task {} does not exist", uuid)));
         };
         let mut ops = self.make_operations();
         task.delete(&mut ops);
-        self.commit_operations(ops).await?;
+        self.commit_operations(ops)?;
         trace!("task {} deleted", uuid);
         Ok(())
     }
@@ -381,43 +375,41 @@ impl<S: Storage> Replica<S> {
     ///
     /// All local state on the replica will be updated accordingly, including the working set and
     /// and temporarily cached data.
-    pub async fn commit_operations(&mut self, operations: Operations) -> Result<()> {
-        if operations.is_empty() {
-            return Ok(());
-        }
+    pub fn commit_operations(&mut self, operations: Operations) -> Result<()> {
+        self.storage.txn(|txn| {
+            if operations.is_empty() {
+                return Ok(());
+            }
 
-        self.storage
-            .txn(move |txn| {
-                // Add tasks to the working set when the status property is updated from anything other
-                // than pending or recurring to one of those two statuses.
-                let pending = Status::Pending.to_taskmap();
-                let recurring = Status::Recurring.to_taskmap();
-                let is_p_or_r = |val: &Option<String>| {
-                    if let Some(val) = val {
-                        val == pending || val == recurring
-                    } else {
-                        false
-                    }
-                };
-                let add_to_working_set = |op: &Operation| match op {
-                    Operation::Update {
-                        property,
-                        value,
-                        old_value,
-                        ..
-                    } => property == "status" && !is_p_or_r(old_value) && is_p_or_r(value),
-                    _ => false,
-                };
+            // Add tasks to the working set when the status property is updated from anything other
+            // than pending or recurring to one of those two statuses.
+            let pending = Status::Pending.to_taskmap();
+            let recurring = Status::Recurring.to_taskmap();
+            let is_p_or_r = |val: &Option<String>| {
+                if let Some(val) = val {
+                    val == pending || val == recurring
+                } else {
+                    false
+                }
+            };
+            let add_to_working_set = |op: &Operation| match op {
+                Operation::Update {
+                    property,
+                    value,
+                    old_value,
+                    ..
+                } => property == "status" && !is_p_or_r(old_value) && is_p_or_r(value),
+                _ => false,
+            };
+            self.taskdb
+                .commit_operations(txn, operations, add_to_working_set)?;
 
-                TaskDb::commit_operations(txn, operations, add_to_working_set)
-            })
-            .await?;
+            // The cached dependency map may now be invalid, do not retain it. Any existing Task values
+            // will continue to use the old map.
+            self.depmap = None;
 
-        // The cached dependency map may now be invalid, do not retain it. Any existing Task values
-        // will continue to use the old map.
-        self.depmap = None;
-
-        Ok(())
+            Ok(())
+        })
     }
 
     /// Synchronize this replica against the given server.  The working set is rebuilt after
@@ -430,21 +422,14 @@ impl<S: Storage> Replica<S> {
     ///
     /// Set this to true on systems more constrained in CPU, memory, or bandwidth than a typical desktop
     /// system
-    pub async fn sync(
-        &mut self,
-        server: Arc<Mutex<dyn Server + Send>>,
-        avoid_snapshots: bool,
-    ) -> Result<()> {
-        self.storage
-            .txn(move |txn| {
-                let mut server_guard = server.lock().unwrap();
-                TaskDb::sync(txn, &mut *server_guard, avoid_snapshots)
-                    .context("Failed to synchronize with server")?;
-                Ok(())
-            })
-            .await?;
+    pub fn sync(&mut self, server: &mut Box<dyn Server>, avoid_snapshots: bool) -> Result<()> {
+        self.storage.txn(|txn| {
+            self.taskdb
+                .sync(txn, server, avoid_snapshots)
+                .context("Failed to synchronize with server")?;
+            Ok(())
+        })?;
         self.rebuild_working_set(false)
-            .await
             .context("Failed to rebuild working set after sync")?;
         Ok(())
     }
@@ -454,10 +439,8 @@ impl<S: Storage> Replica<S> {
     ///
     /// The operations are returned in the order they were applied. Use
     /// [`Replica::commit_reversed_operations`] to "undo" them.
-    pub async fn get_undo_operations(&mut self) -> Result<Operations> {
-        self.storage
-            .txn(|txn| TaskDb::get_undo_operations(txn))
-            .await
+    pub fn get_undo_operations(&mut self) -> Result<Operations> {
+        self.storage.txn(|txn| self.taskdb.get_undo_operations(txn))
     }
 
     /// Commit the reverse of the given operations, beginning with the last operation in the given
@@ -465,11 +448,10 @@ impl<S: Storage> Replica<S> {
     ///
     /// This method only supports reversing operations if they precisely match local operations
     /// that have not yet been synchronized, and will return `false` if this is not the case.
-    pub async fn commit_reversed_operations(&mut self, operations: Operations) -> Result<bool> {
+    pub fn commit_reversed_operations(&mut self, operations: Operations) -> Result<bool> {
         let success = self
             .storage
-            .txn(|txn| TaskDb::commit_reversed_operations(txn, operations))
-            .await?;
+            .txn(|txn| self.taskdb.commit_reversed_operations(txn, operations))?;
         if !success {
             return Ok(false);
         }
@@ -477,7 +459,6 @@ impl<S: Storage> Replica<S> {
         // Both the dependency map and the working set are potentially now invalid.
         self.depmap = None;
         self.rebuild_working_set(false)
-            .await
             .context("Failed to rebuild working set after committing reversed operations")?;
 
         Ok(true)
@@ -487,25 +468,23 @@ impl<S: Storage> Replica<S> {
     /// `renumber` is true, then existing tasks may be moved to new working-set indices; in any
     /// case, on completion all pending and recurring tasks are in the working set and all tasks
     /// with other statuses are not.
-    pub async fn rebuild_working_set(&mut self, renumber: bool) -> Result<()> {
-        self.storage
-            .txn(move |txn| {
-                let pending = String::from(Status::Pending.to_taskmap());
-                let recurring = String::from(Status::Recurring.to_taskmap());
-                TaskDb::rebuild_working_set(
-                    txn,
-                    |t| {
-                        if let Some(st) = t.get("status") {
-                            st == &pending || st == &recurring
-                        } else {
-                            false
-                        }
-                    },
-                    renumber,
-                )?;
-                Ok(())
-            })
-            .await
+    pub fn rebuild_working_set(&mut self, renumber: bool) -> Result<()> {
+        self.storage.txn(|txn| {
+            let pending = String::from(Status::Pending.to_taskmap());
+            let recurring = String::from(Status::Recurring.to_taskmap());
+            self.taskdb.rebuild_working_set(
+                txn,
+                |t| {
+                    if let Some(st) = t.get("status") {
+                        st == &pending || st == &recurring
+                    } else {
+                        false
+                    }
+                },
+                renumber,
+            )?;
+            Ok(())
+        })
     }
 
     /// Expire old, deleted tasks.
@@ -515,12 +494,11 @@ impl<S: Storage> Replica<S> {
     ///
     /// Tasks are eligible for expiration when they have status Deleted and have not been modified
     /// for 180 days (about six months). Note that completed tasks are not eligible.
-    pub async fn expire_tasks(&mut self) -> Result<()> {
+    pub fn expire_tasks(&mut self) -> Result<()> {
         let six_mos_ago = Utc::now() - Duration::days(180);
         let mut ops = Operations::new();
         let deleted = Status::Deleted.to_taskmap();
-        self.all_task_data()
-            .await?
+        self.all_task_data()?
             .drain()
             .filter(|(_, t)| t.get("status") == Some(deleted))
             .filter(|(_, t)| {
@@ -531,7 +509,7 @@ impl<S: Storage> Replica<S> {
                 })
             })
             .for_each(|(_, mut t)| t.delete(&mut ops));
-        self.commit_operations(ops).await
+        self.commit_operations(ops)
     }
 
     /// Add an UndoPoint, if one has not already been added by this Replica.  This occurs
@@ -542,10 +520,10 @@ impl<S: Storage> Replica<S> {
         since = "0.7.0",
         note = "Push an `Operation::UndoPoint` onto your `Operations` instead."
     )]
-    pub async fn add_undo_point(&mut self, force: bool) -> Result<()> {
+    pub fn add_undo_point(&mut self, force: bool) -> Result<()> {
         if force || !self.added_undo_point {
             let ops = vec![Operation::UndoPoint];
-            self.commit_operations(ops).await?;
+            self.commit_operations(ops)?;
             self.added_undo_point = true;
         }
         Ok(())
@@ -563,13 +541,13 @@ impl<S: Storage> Replica<S> {
     }
 
     /// Get the number of operations local to this replica and not yet synchronized to the server.
-    pub async fn num_local_operations(&mut self) -> Result<usize> {
-        self.storage.txn(|txn| TaskDb::num_operations(txn)).await
+    pub fn num_local_operations(&mut self) -> Result<usize> {
+        self.storage.txn(|txn| self.taskdb.num_operations(txn))
     }
 
     /// Get the number of undo points available (number of times `undo` will succeed).
-    pub async fn num_undo_points(&mut self) -> Result<usize> {
-        self.storage.txn(|txn| TaskDb::num_undo_points(txn)).await
+    pub fn num_undo_points(&mut self) -> Result<usize> {
+        self.storage.txn(|txn| self.taskdb.num_undo_points(txn))
     }
 }
 
@@ -614,30 +592,24 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn new_task() {
-        let mut rep = Replica::new(InMemoryStorage::new());
+    #[test]
+    fn new_task() {
+        let mut rep = Replica::<InMemoryStorage>::new_inmemory();
 
         #[allow(deprecated)]
-        let t = rep
-            .new_task(Status::Pending, "a task".into())
-            .await
-            .unwrap();
+        let t = rep.new_task(Status::Pending, "a task".into()).unwrap();
         assert_eq!(t.get_description(), String::from("a task"));
         assert_eq!(t.get_status(), Status::Pending);
         assert!(t.get_modified().is_some());
     }
 
-    #[tokio::test]
-    async fn modify_task() -> Result<()> {
-        let mut rep = Replica::new(InMemoryStorage::new());
+    #[test]
+    fn modify_task() -> Result<()> {
+        let mut rep = Replica::<InMemoryStorage>::new_inmemory();
 
         // Further test the deprecated `new_task` method.
         #[allow(deprecated)]
-        let mut t = rep
-            .new_task(Status::Pending, "a task".into())
-            .await
-            .unwrap();
+        let mut t = rep.new_task(Status::Pending, "a task".into()).unwrap();
 
         let mut ops = Operations::new();
         t.set_description(String::from("past tense"), &mut ops)
@@ -648,139 +620,138 @@ mod tests {
         assert_eq!(t.get_status(), Status::Completed);
 
         // check that values have not changed in storage, yet
-        let t = rep.get_task(t.get_uuid()).await.unwrap().unwrap();
+        let t = rep.get_task(t.get_uuid()).unwrap().unwrap();
         assert_eq!(t.get_description(), "a task");
         assert_eq!(t.get_status(), Status::Pending);
 
         // check that values have changed in storage after commit
-        rep.commit_operations(ops).await.unwrap();
-        let t = rep.get_task(t.get_uuid()).await.unwrap().unwrap();
+        rep.commit_operations(ops).unwrap();
+        let t = rep.get_task(t.get_uuid()).unwrap().unwrap();
         assert_eq!(t.get_description(), "past tense");
         assert_eq!(t.get_status(), Status::Completed);
 
-        rep.storage
-            .txn(move |txn| {
-                // and check for the corresponding operations, cleaning out the timestamps
-                // and modified properties as these are based on the current time
-                assert_eq!(
-                    TaskDb::operations(txn)
-                        .drain(..)
-                        .map(clean_op)
-                        .collect::<Vec<_>>(),
-                    vec![
-                        Operation::UndoPoint,
-                        Operation::Create { uuid: t.get_uuid() },
-                        Operation::Update {
-                            uuid: t.get_uuid(),
-                            property: "modified".into(),
-                            old_value: None,
-                            value: Some("just-now".into()),
-                            timestamp: JUST_NOW.unwrap(),
-                        },
-                        Operation::Update {
-                            uuid: t.get_uuid(),
-                            property: "description".into(),
-                            old_value: None,
-                            value: Some("a task".into()),
-                            timestamp: JUST_NOW.unwrap(),
-                        },
-                        Operation::Update {
-                            uuid: t.get_uuid(),
-                            property: "status".into(),
-                            old_value: None,
-                            value: Some("pending".into()),
-                            timestamp: JUST_NOW.unwrap(),
-                        },
-                        Operation::Update {
-                            uuid: t.get_uuid(),
-                            property: "entry".into(),
-                            old_value: None,
-                            value: Some("just-now".into()),
-                            timestamp: JUST_NOW.unwrap(),
-                        },
-                        Operation::Update {
-                            uuid: t.get_uuid(),
-                            property: "modified".into(),
-                            old_value: Some("just-now".into()),
-                            value: Some("just-now".into()),
-                            timestamp: JUST_NOW.unwrap(),
-                        },
-                        Operation::Update {
-                            uuid: t.get_uuid(),
-                            property: "description".into(),
-                            old_value: Some("a task".into()),
-                            value: Some("past tense".into()),
-                            timestamp: JUST_NOW.unwrap(),
-                        },
-                        Operation::Update {
-                            uuid: t.get_uuid(),
-                            property: "end".into(),
-                            old_value: None,
-                            value: Some("just-now".into()),
-                            timestamp: JUST_NOW.unwrap(),
-                        },
-                        Operation::Update {
-                            uuid: t.get_uuid(),
-                            property: "status".into(),
-                            old_value: Some("pending".into()),
-                            value: Some("completed".into()),
-                            timestamp: JUST_NOW.unwrap(),
-                        },
-                    ]
-                );
-                Ok(())
-            })
-            .await?;
+        rep.storage.txn(|txn| {
+            // and check for the corresponding operations, cleaning out the timestamps
+            // and modified properties as these are based on the current time
+            assert_eq!(
+                rep.taskdb
+                    .operations(txn)
+                    .drain(..)
+                    .map(clean_op)
+                    .collect::<Vec<_>>(),
+                vec![
+                    Operation::UndoPoint,
+                    Operation::Create { uuid: t.get_uuid() },
+                    Operation::Update {
+                        uuid: t.get_uuid(),
+                        property: "modified".into(),
+                        old_value: None,
+                        value: Some("just-now".into()),
+                        timestamp: JUST_NOW.unwrap(),
+                    },
+                    Operation::Update {
+                        uuid: t.get_uuid(),
+                        property: "description".into(),
+                        old_value: None,
+                        value: Some("a task".into()),
+                        timestamp: JUST_NOW.unwrap(),
+                    },
+                    Operation::Update {
+                        uuid: t.get_uuid(),
+                        property: "status".into(),
+                        old_value: None,
+                        value: Some("pending".into()),
+                        timestamp: JUST_NOW.unwrap(),
+                    },
+                    Operation::Update {
+                        uuid: t.get_uuid(),
+                        property: "entry".into(),
+                        old_value: None,
+                        value: Some("just-now".into()),
+                        timestamp: JUST_NOW.unwrap(),
+                    },
+                    Operation::Update {
+                        uuid: t.get_uuid(),
+                        property: "modified".into(),
+                        old_value: Some("just-now".into()),
+                        value: Some("just-now".into()),
+                        timestamp: JUST_NOW.unwrap(),
+                    },
+                    Operation::Update {
+                        uuid: t.get_uuid(),
+                        property: "description".into(),
+                        old_value: Some("a task".into()),
+                        value: Some("past tense".into()),
+                        timestamp: JUST_NOW.unwrap(),
+                    },
+                    Operation::Update {
+                        uuid: t.get_uuid(),
+                        property: "end".into(),
+                        old_value: None,
+                        value: Some("just-now".into()),
+                        timestamp: JUST_NOW.unwrap(),
+                    },
+                    Operation::Update {
+                        uuid: t.get_uuid(),
+                        property: "status".into(),
+                        old_value: Some("pending".into()),
+                        value: Some("completed".into()),
+                        timestamp: JUST_NOW.unwrap(),
+                    },
+                ]
+            );
+            Ok(())
+        })?;
 
         // num_local_operations includes all but the undo point
-        assert_eq!(rep.num_local_operations().await.unwrap(), 9);
+        assert_eq!(rep.num_local_operations().unwrap(), 9);
 
         // num_undo_points includes only the undo point
-        assert_eq!(rep.num_undo_points().await.unwrap(), 1);
+        assert_eq!(rep.num_undo_points().unwrap(), 1);
 
         // A second undo point is counted.
         let ops = vec![Operation::UndoPoint];
-        rep.commit_operations(ops).await.unwrap();
-        assert_eq!(rep.num_undo_points().await.unwrap(), 2);
+        rep.commit_operations(ops).unwrap();
+        assert_eq!(rep.num_undo_points().unwrap(), 2);
 
         Ok(())
     }
 
-    #[tokio::test]
-    async fn delete_task() {
-        let mut rep = Replica::new(InMemoryStorage::new());
+    #[test]
+    fn delete_task() {
+        let mut rep = Replica::<InMemoryStorage>::new_inmemory();
 
         let uuid = Uuid::new_v4();
         let mut ops = Operations::new();
-        rep.create_task(uuid, &mut ops).await.unwrap();
-        rep.commit_operations(ops).await.unwrap();
+        rep.create_task(uuid, &mut ops).unwrap();
+        rep.commit_operations(ops).unwrap();
 
         #[allow(deprecated)]
-        rep.delete_task(uuid).await.unwrap();
-        assert_eq!(rep.get_task(uuid).await.unwrap(), None);
+        rep.delete_task(uuid).unwrap();
+        assert_eq!(rep.get_task(uuid).unwrap(), None);
     }
 
-    #[tokio::test]
-    async fn all_tasks() {
-        let mut rep = Replica::new(InMemoryStorage::new());
+    #[test]
+    fn all_tasks() {
+        let mut rep = Replica::<InMemoryStorage>::new_inmemory();
 
         let (uuid1, uuid2) = (Uuid::new_v4(), Uuid::new_v4());
         let mut ops = Operations::new();
-        rep.create_task(uuid1, &mut ops).await.unwrap();
-        rep.create_task(uuid2, &mut ops).await.unwrap();
-        rep.commit_operations(ops).await.unwrap();
+        rep.create_task(uuid1, &mut ops).unwrap();
+        rep.create_task(uuid2, &mut ops).unwrap();
+        rep.commit_operations(ops).unwrap();
 
-        let all_tasks = rep.all_tasks().await.unwrap();
+        let all_tasks = rep.all_tasks().unwrap();
         assert_eq!(all_tasks.len(), 2);
         assert_eq!(all_tasks.get(&uuid1).unwrap().get_uuid(), uuid1);
         assert_eq!(all_tasks.get(&uuid2).unwrap().get_uuid(), uuid2);
 
-        let all_tasks = rep.all_task_data().await.unwrap();
+        let all_tasks = rep.all_task_data().unwrap();
         assert_eq!(all_tasks.len(), 2);
         assert_eq!(all_tasks.get(&uuid1).unwrap().get_uuid(), uuid1);
         assert_eq!(all_tasks.get(&uuid2).unwrap().get_uuid(), uuid2);
 
-        let mut all_uuids = rep.all_task_uuids().await.unwrap();
+        let mut all_uuids = rep.all_task_uuids().unwrap();
         all_uuids.sort();
         let mut exp_uuids = vec![uuid1, uuid2];
         exp_uuids.sort();
@@ -788,43 +759,43 @@ mod tests {
         assert_eq!(all_uuids, exp_uuids);
     }
 
-    #[tokio::test]
-    async fn pending_tasks() {
-        let mut rep = Replica::new(InMemoryStorage::new());
+    #[test]
+    fn pending_tasks() {
+        let mut rep = Replica::<InMemoryStorage>::new_inmemory();
 
         let (uuid1, uuid2, uuid3) = (Uuid::new_v4(), Uuid::new_v4(), Uuid::new_v4());
         let mut ops = Operations::new();
 
-        let mut t1 = rep.create_task(uuid1, &mut ops).await.unwrap();
+        let mut t1 = rep.create_task(uuid1, &mut ops).unwrap();
         t1.set_status(Status::Pending, &mut ops).unwrap();
 
-        let mut t2 = rep.create_task(uuid2, &mut ops).await.unwrap();
+        let mut t2 = rep.create_task(uuid2, &mut ops).unwrap();
         t2.set_status(Status::Pending, &mut ops).unwrap();
 
-        let mut t3 = rep.create_task(uuid3, &mut ops).await.unwrap();
+        let mut t3 = rep.create_task(uuid3, &mut ops).unwrap();
         t3.set_status(Status::Completed, &mut ops).unwrap();
 
-        rep.commit_operations(ops).await.unwrap();
+        rep.commit_operations(ops).unwrap();
 
-        let pending_tasks = rep.pending_tasks().await.unwrap();
+        let pending_tasks = rep.pending_tasks().unwrap();
         assert_eq!(pending_tasks.len(), 2);
         assert_eq!(pending_tasks.first().unwrap().get_uuid(), uuid1);
         assert_eq!(pending_tasks.get(1).unwrap().get_uuid(), uuid2);
     }
 
-    #[tokio::test]
-    async fn commit_operations() -> Result<()> {
+    #[test]
+    fn commit_operations() -> Result<()> {
         // This mostly tests the working-set callback, as `TaskDB::commit_operations` has
         // tests for the remaining functionality.
-        let mut rep = Replica::new(InMemoryStorage::new());
+        let mut rep = Replica::<InMemoryStorage>::new_inmemory();
 
         // Generate the depmap so later assertions can verify it is reset.
-        rep.dependency_map(true).await.unwrap();
+        rep.dependency_map(true).unwrap();
         assert!(rep.depmap.is_some());
 
         let mut ops = Operations::new();
         let uuid1 = Uuid::new_v4();
-        let mut t = rep.create_task(uuid1, &mut ops).await.unwrap();
+        let mut t = rep.create_task(uuid1, &mut ops).unwrap();
         t.set_status(Status::Pending, &mut ops).unwrap();
 
         // uuid2 is created and deleted, but this does not affect the
@@ -911,9 +882,9 @@ mod tests {
         let uuid12 = Uuid::new_v4();
         ops.push(update_op(uuid12, "status", Some("pending"), None));
 
-        rep.commit_operations(ops).await?;
+        rep.commit_operations(ops)?;
 
-        let ws = rep.working_set().await?;
+        let ws = rep.working_set()?;
         assert!(ws.by_uuid(uuid1).is_some());
         assert!(ws.by_uuid(uuid2).is_none());
         assert!(ws.by_uuid(uuid3).is_none());
@@ -933,86 +904,85 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
-    async fn commit_reversed_operations() -> Result<()> {
+    #[test]
+    fn commit_reversed_operations() -> Result<()> {
         let uuid1 = Uuid::new_v4();
         let uuid2 = Uuid::new_v4();
         let uuid3 = Uuid::new_v4();
 
-        let mut rep = Replica::new(InMemoryStorage::new());
+        let mut rep = Replica::<InMemoryStorage>::new_inmemory();
 
         let mut ops = Operations::new();
         ops.push(Operation::UndoPoint);
-        rep.create_task(uuid1, &mut ops).await.unwrap();
+        rep.create_task(uuid1, &mut ops).unwrap();
         ops.push(Operation::UndoPoint);
-        rep.create_task(uuid2, &mut ops).await.unwrap();
-        rep.commit_operations(ops).await?;
-        assert_eq!(rep.num_undo_points().await.unwrap(), 2);
+        rep.create_task(uuid2, &mut ops).unwrap();
+        rep.commit_operations(ops)?;
+        assert_eq!(rep.num_undo_points().unwrap(), 2);
 
         // Trying to reverse-commit the wrong operations fails.
         let ops = vec![Operation::Delete {
             uuid: uuid3,
             old_task: TaskMap::new(),
         }];
-        assert!(!rep.commit_reversed_operations(ops).await?);
+        assert!(!rep.commit_reversed_operations(ops)?);
 
         // Commiting the correct operations succeeds
-        let ops = rep.get_undo_operations().await?;
-        assert!(rep.commit_reversed_operations(ops).await?);
-        assert_eq!(rep.num_undo_points().await.unwrap(), 1);
+        let ops = rep.get_undo_operations()?;
+        assert!(rep.commit_reversed_operations(ops)?);
+        assert_eq!(rep.num_undo_points().unwrap(), 1);
 
         Ok(())
     }
 
-    #[tokio::test]
-    async fn get_and_modify() {
-        let mut rep = Replica::new(InMemoryStorage::new());
+    #[test]
+    fn get_and_modify() {
+        let mut rep = Replica::<InMemoryStorage>::new_inmemory();
 
         let mut ops = Operations::new();
         let uuid = Uuid::new_v4();
-        let mut t = rep.create_task(uuid, &mut ops).await.unwrap();
+        let mut t = rep.create_task(uuid, &mut ops).unwrap();
         t.set_status(Status::Pending, &mut ops).unwrap();
         t.set_description("another task".into(), &mut ops).unwrap();
-        rep.commit_operations(ops).await.unwrap();
+        rep.commit_operations(ops).unwrap();
 
-        let mut t = rep.get_task(uuid).await.unwrap().unwrap();
+        let mut t = rep.get_task(uuid).unwrap().unwrap();
         assert_eq!(t.get_description(), String::from("another task"));
 
         let mut ops = Operations::new();
         t.set_status(Status::Deleted, &mut ops).unwrap();
         t.set_description("gone".into(), &mut ops).unwrap();
-        rep.commit_operations(ops).await.unwrap();
+        rep.commit_operations(ops).unwrap();
 
-        let t = rep.get_task(uuid).await.unwrap().unwrap();
+        let t = rep.get_task(uuid).unwrap().unwrap();
         assert_eq!(t.get_status(), Status::Deleted);
         assert_eq!(t.get_description(), "gone");
 
-        rep.rebuild_working_set(true).await.unwrap();
+        rep.rebuild_working_set(true).unwrap();
 
-        let ws = rep.working_set().await.unwrap();
+        let ws = rep.working_set().unwrap();
         assert!(ws.by_uuid(t.get_uuid()).is_none());
     }
 
-    #[tokio::test]
-    async fn get_task_data_and_operations() {
-        let mut rep = Replica::new(InMemoryStorage::new());
+    #[test]
+    fn get_task_data_and_operations() {
+        let mut rep = Replica::<InMemoryStorage>::new_inmemory();
 
         let uuid1 = Uuid::new_v4();
         let uuid2 = Uuid::new_v4();
         let mut ops = Operations::new();
-        let mut t = rep.create_task(uuid1, &mut ops).await.unwrap();
+        let mut t = rep.create_task(uuid1, &mut ops).unwrap();
         t.set_description("another task".into(), &mut ops).unwrap();
-        let mut t2 = rep.create_task(uuid2, &mut ops).await.unwrap();
+        let mut t2 = rep.create_task(uuid2, &mut ops).unwrap();
         t2.set_description("a distraction!".into(), &mut ops)
             .unwrap();
-        rep.commit_operations(ops).await.unwrap();
+        rep.commit_operations(ops).unwrap();
 
-        let t = rep.get_task_data(uuid1).await.unwrap().unwrap();
+        let t = rep.get_task_data(uuid1).unwrap().unwrap();
         assert_eq!(t.get_uuid(), uuid1);
         assert_eq!(t.get("description"), Some("another task"));
         assert_eq!(
             rep.get_task_operations(uuid1)
-                .await
                 .unwrap()
                 .into_iter()
                 .map(clean_op)
@@ -1036,87 +1006,84 @@ mod tests {
             ]
         );
 
-        assert!(rep.get_task_data(Uuid::new_v4()).await.unwrap().is_none());
-        assert_eq!(
-            rep.get_task_operations(Uuid::new_v4()).await.unwrap(),
-            vec![]
-        );
+        assert!(rep.get_task_data(Uuid::new_v4()).unwrap().is_none());
+        assert_eq!(rep.get_task_operations(Uuid::new_v4()).unwrap(), vec![]);
     }
 
-    #[tokio::test]
-    async fn rebuild_working_set_includes_recurring() {
-        let mut rep = Replica::new(InMemoryStorage::new());
+    #[test]
+    fn rebuild_working_set_includes_recurring() {
+        let mut rep = Replica::<InMemoryStorage>::new_inmemory();
 
         let uuid = Uuid::new_v4();
         let mut ops = Operations::new();
-        let mut t = rep.create_task(uuid, &mut ops).await.unwrap();
+        let mut t = rep.create_task(uuid, &mut ops).unwrap();
         t.set_status(Status::Completed, &mut ops).unwrap();
-        rep.commit_operations(ops).await.unwrap();
+        rep.commit_operations(ops).unwrap();
 
-        let mut t = rep.get_task(uuid).await.unwrap().unwrap();
+        let mut t = rep.get_task(uuid).unwrap().unwrap();
         let mut ops = Operations::new();
         t.set_status(Status::Recurring, &mut ops).unwrap();
-        rep.commit_operations(ops).await.unwrap();
+        rep.commit_operations(ops).unwrap();
 
-        rep.rebuild_working_set(true).await.unwrap();
+        rep.rebuild_working_set(true).unwrap();
 
-        let ws = rep.working_set().await.unwrap();
+        let ws = rep.working_set().unwrap();
         assert!(ws.by_uuid(uuid).is_some());
     }
 
-    #[tokio::test]
-    async fn new_pending_adds_to_working_set() {
-        let mut rep = Replica::new(InMemoryStorage::new());
+    #[test]
+    fn new_pending_adds_to_working_set() {
+        let mut rep = Replica::<InMemoryStorage>::new_inmemory();
 
         let uuid = Uuid::new_v4();
         let mut ops = Operations::new();
-        let mut t = rep.create_task(uuid, &mut ops).await.unwrap();
+        let mut t = rep.create_task(uuid, &mut ops).unwrap();
         t.set_status(Status::Pending, &mut ops).unwrap();
-        rep.commit_operations(ops).await.unwrap();
+        rep.commit_operations(ops).unwrap();
 
-        let ws = rep.working_set().await.unwrap();
+        let ws = rep.working_set().unwrap();
         assert_eq!(ws.len(), 1); // only one non-none value
         assert!(ws.by_index(0).is_none());
         assert_eq!(ws.by_index(1), Some(uuid));
 
-        let ws = rep.working_set().await.unwrap();
+        let ws = rep.working_set().unwrap();
         assert_eq!(ws.by_uuid(t.get_uuid()), Some(1));
     }
 
-    #[tokio::test]
-    async fn new_recurring_adds_to_working_set() {
-        let mut rep = Replica::new(InMemoryStorage::new());
+    #[test]
+    fn new_recurring_adds_to_working_set() {
+        let mut rep = Replica::<InMemoryStorage>::new_inmemory();
 
         let uuid = Uuid::new_v4();
         let mut ops = Operations::new();
-        let mut t = rep.create_task(uuid, &mut ops).await.unwrap();
+        let mut t = rep.create_task(uuid, &mut ops).unwrap();
         t.set_status(Status::Recurring, &mut ops).unwrap();
-        rep.commit_operations(ops).await.unwrap();
+        rep.commit_operations(ops).unwrap();
 
-        let ws = rep.working_set().await.unwrap();
+        let ws = rep.working_set().unwrap();
         assert_eq!(ws.len(), 1); // only one non-none value
         assert!(ws.by_index(0).is_none());
         assert_eq!(ws.by_index(1), Some(uuid));
 
-        let ws = rep.working_set().await.unwrap();
+        let ws = rep.working_set().unwrap();
         assert_eq!(ws.by_uuid(t.get_uuid()), Some(1));
     }
 
-    #[tokio::test]
-    async fn get_does_not_exist() {
-        let mut rep = Replica::new(InMemoryStorage::new());
+    #[test]
+    fn get_does_not_exist() {
+        let mut rep = Replica::<InMemoryStorage>::new_inmemory();
         let uuid = Uuid::new_v4();
-        assert_eq!(rep.get_task(uuid).await.unwrap(), None);
+        assert_eq!(rep.get_task(uuid).unwrap(), None);
     }
 
-    #[tokio::test]
-    async fn expire() {
-        let mut rep = Replica::new(InMemoryStorage::new());
+    #[test]
+    fn expire() {
+        let mut rep = Replica::<InMemoryStorage>::new_inmemory();
         let mut ops = Operations::new();
 
         // uuid1 is old but pending, so is not expired.
         let keeper_uuid1 = Uuid::new_v4();
-        let mut t = rep.create_task(keeper_uuid1, &mut ops).await.unwrap();
+        let mut t = rep.create_task(keeper_uuid1, &mut ops).unwrap();
         t.set_description("keeper 1".into(), &mut ops).unwrap();
         t.set_modified(Utc.with_ymd_and_hms(1980, 1, 1, 0, 0, 0).unwrap(), &mut ops)
             .unwrap();
@@ -1124,7 +1091,7 @@ mod tests {
 
         // uuid2 is old but completed, so is not expired.
         let keeper_uuid2 = Uuid::new_v4();
-        let mut t = rep.create_task(keeper_uuid2, &mut ops).await.unwrap();
+        let mut t = rep.create_task(keeper_uuid2, &mut ops).unwrap();
         t.set_description("keeper 2".into(), &mut ops).unwrap();
         t.set_modified(Utc.with_ymd_and_hms(1980, 1, 1, 0, 0, 0).unwrap(), &mut ops)
             .unwrap();
@@ -1132,7 +1099,7 @@ mod tests {
 
         // uuid3 is deleted but recently modified, so is not expired.
         let keeper_uuid3 = Uuid::new_v4();
-        let mut t = rep.create_task(keeper_uuid3, &mut ops).await.unwrap();
+        let mut t = rep.create_task(keeper_uuid3, &mut ops).unwrap();
         t.set_description("keeper 3".into(), &mut ops).unwrap();
         t.set_status(Status::Deleted, &mut ops).unwrap();
         t.set_modified(Utc::now(), &mut ops).unwrap();
@@ -1140,29 +1107,29 @@ mod tests {
 
         // uuid4 was deleted long ago, so it is expired.
         let goner_uuid4 = Uuid::new_v4();
-        let mut t = rep.create_task(goner_uuid4, &mut ops).await.unwrap();
+        let mut t = rep.create_task(goner_uuid4, &mut ops).unwrap();
         t.set_description("goner".into(), &mut ops).unwrap();
         t.set_status(Status::Deleted, &mut ops).unwrap();
         t.set_modified(Utc.with_ymd_and_hms(1980, 1, 1, 0, 0, 0).unwrap(), &mut ops)
             .unwrap();
-        rep.commit_operations(ops).await.unwrap();
+        rep.commit_operations(ops).unwrap();
 
-        rep.expire_tasks().await.unwrap();
+        rep.expire_tasks().unwrap();
 
-        assert!(rep.get_task_data(keeper_uuid1).await.unwrap().is_some());
-        assert!(rep.get_task_data(keeper_uuid2).await.unwrap().is_some());
-        assert!(rep.get_task_data(keeper_uuid3).await.unwrap().is_some());
-        assert!(rep.get_task_data(goner_uuid4).await.unwrap().is_none());
+        assert!(rep.get_task_data(keeper_uuid1).unwrap().is_some());
+        assert!(rep.get_task_data(keeper_uuid2).unwrap().is_some());
+        assert!(rep.get_task_data(keeper_uuid3).unwrap().is_some());
+        assert!(rep.get_task_data(goner_uuid4).unwrap().is_none());
     }
 
-    #[tokio::test]
-    async fn dependency_map() {
-        let mut rep = Replica::new(InMemoryStorage::new());
+    #[test]
+    fn dependency_map() {
+        let mut rep = Replica::<InMemoryStorage>::new_inmemory();
 
         let mut tasks = vec![];
         let mut ops = Operations::new();
         for _ in 0..4 {
-            let mut t = rep.create_task(Uuid::new_v4(), &mut ops).await.unwrap();
+            let mut t = rep.create_task(Uuid::new_v4(), &mut ops).unwrap();
             t.set_status(Status::Pending, &mut ops).unwrap();
             tasks.push(t);
         }
@@ -1181,11 +1148,11 @@ mod tests {
         let mut t = tasks.pop().unwrap();
         t.add_dependency(uuids[0], &mut ops).unwrap();
 
-        rep.commit_operations(ops).await.unwrap();
+        rep.commit_operations(ops).unwrap();
 
         // generate the dependency map, forcing an update based on the newly-added dependencies.
         // This need not be forced since the `commit_operations` invalidated the cached value.
-        let dm = rep.dependency_map(false).await.unwrap();
+        let dm = rep.dependency_map(false).unwrap();
 
         assert_eq!(
             dm.dependencies(uuids[3]).collect::<HashSet<_>>(),
@@ -1224,13 +1191,12 @@ mod tests {
         // mark t[0] as done, removing it from the working set
         let mut ops = Operations::new();
         rep.get_task(uuids[0])
-            .await
             .unwrap()
             .unwrap()
             .done(&mut ops)
             .unwrap();
-        rep.commit_operations(ops).await.unwrap();
-        let dm = rep.dependency_map(false).await.unwrap();
+        rep.commit_operations(ops).unwrap();
+        let dm = rep.dependency_map(false).unwrap();
 
         assert_eq!(
             dm.dependencies(uuids[3]).collect::<HashSet<_>>(),

--- a/src/replica.rs
+++ b/src/replica.rs
@@ -2,7 +2,7 @@ use crate::depmap::DependencyMap;
 use crate::errors::Result;
 use crate::operation::{Operation, Operations};
 use crate::server::Server;
-use crate::storage::{Storage, StorageTxn, TaskMap};
+use crate::storage::{Storage, TaskMap};
 use crate::task::{Status, Task};
 use crate::taskdb::TaskDb;
 use crate::workingset::WorkingSet;
@@ -70,8 +70,6 @@ replica.commit_operations(ops)?;
 /// pending tasks are automatically added to the working set, and the working set can be
 /// "renumbered" when necessary.
 pub struct Replica {
-    storage: Box<dyn Storage>,
-
     taskdb: TaskDb,
 
     /// If true, this replica has already added an undo point.
@@ -84,8 +82,7 @@ pub struct Replica {
 impl Replica {
     pub fn new(storage: Box<dyn Storage>) -> Replica {
         Replica {
-            storage,
-            taskdb: TaskDb::new(),
+            taskdb: TaskDb::new(storage),
             added_undo_point: false,
             depmap: None,
         }
@@ -120,19 +117,17 @@ impl Replica {
         };
         task.update(property, value, &mut ops);
         self.commit_operations(ops)?;
-        let mut txn = self.storage.txn()?;
         Ok(self
             .taskdb
-            .get_task(txn.as_mut(), uuid)?
+            .get_task(uuid)?
             .expect("task should exist after an update"))
     }
 
     /// Get all tasks represented as a map keyed by UUID
     pub fn all_tasks(&mut self) -> Result<HashMap<Uuid, Task>> {
         let depmap = self.dependency_map(false)?;
-        let mut txn = self.storage.txn()?;
         let mut res = HashMap::new();
-        for (uuid, tm) in self.taskdb.all_tasks(txn.as_mut())?.drain(..) {
+        for (uuid, tm) in self.taskdb.all_tasks()?.drain(..) {
             res.insert(uuid, Task::new(TaskData::new(uuid, tm), depmap.clone()));
         }
         Ok(res)
@@ -140,9 +135,8 @@ impl Replica {
 
     /// Get all task represented as a map of [`TaskData`] keyed by UUID
     pub fn all_task_data(&mut self) -> Result<HashMap<Uuid, TaskData>> {
-        let mut txn = self.storage.txn()?;
         let mut res = HashMap::new();
-        for (uuid, tm) in self.taskdb.all_tasks(txn.as_mut())?.drain(..) {
+        for (uuid, tm) in self.taskdb.all_tasks()?.drain(..) {
             res.insert(uuid, TaskData::new(uuid, tm));
         }
         Ok(res)
@@ -150,8 +144,7 @@ impl Replica {
 
     /// Get the UUIDs of all tasks
     pub fn all_task_uuids(&mut self) -> Result<Vec<Uuid>> {
-        let mut txn = self.storage.txn()?;
-        self.taskdb.all_task_uuids(txn.as_mut())
+        self.taskdb.all_task_uuids()
     }
 
     /// Get an array containing all pending tasks
@@ -167,10 +160,9 @@ impl Replica {
     }
 
     pub fn pending_task_data(&mut self) -> Result<Vec<TaskData>> {
-        let mut txn = self.storage.txn()?;
         let res = self
             .taskdb
-            .get_pending_tasks(txn.as_mut())?
+            .get_pending_tasks()?
             .into_iter()
             .map(|(uuid, taskmap)| TaskData::new(uuid, taskmap))
             .collect::<Vec<_>>();
@@ -181,12 +173,7 @@ impl Replica {
     /// Get the "working set" for this replica.  This is a snapshot of the current state,
     /// and it is up to the caller to decide how long to store this value.
     pub fn working_set(&mut self) -> Result<WorkingSet> {
-        let mut txn = self.storage.txn()?;
-        Replica::working_set_with_txn(&mut self.taskdb, txn.as_mut())
-    }
-
-    fn working_set_with_txn(taskdb: &mut TaskDb, txn: &mut dyn StorageTxn) -> Result<WorkingSet> {
-        Ok(WorkingSet::new(taskdb.working_set(txn)?))
+        Ok(WorkingSet::new(self.taskdb.working_set()?))
     }
 
     /// Get the dependency map for all pending tasks.
@@ -204,7 +191,6 @@ impl Replica {
     /// Calculating this value requires a scan of the full working set and may not be performant.
     /// The [`TaskData`] API avoids generating this value.
     pub fn dependency_map(&mut self, force: bool) -> Result<Arc<DependencyMap>> {
-        let mut txn = self.storage.txn()?;
         if force || self.depmap.is_none() {
             // note: we can't use self.get_task here, as that depends on a
             // DependencyMap
@@ -212,13 +198,13 @@ impl Replica {
             let mut dm = DependencyMap::new();
             // temporary cache tracking whether tasks are considered Pending or not.
             let mut is_pending_cache: HashMap<Uuid, bool> = HashMap::new();
-            let ws = Replica::working_set_with_txn(&mut self.taskdb, txn.as_mut())?;
+            let ws = self.working_set()?;
             // for each task in the working set
             for i in 1..=ws.largest_index() {
                 // get the task UUID
                 if let Some(u) = ws.by_index(i) {
                     // get the task
-                    if let Some(taskmap) = self.taskdb.get_task(txn.as_mut(), u)? {
+                    if let Some(taskmap) = self.taskdb.get_task(u)? {
                         // search the task's keys
                         for p in taskmap.keys() {
                             // for one matching `dep_..`
@@ -232,7 +218,7 @@ impl Replica {
                                             *dep_pending
                                         } else if let Some(dep_taskmap) =
                                             // or if we get the task
-                                            self.taskdb.get_task(txn.as_mut(), dep)?
+                                            self.taskdb.get_task(dep)?
                                         {
                                             // and its status is "pending"
                                             let dep_pending = matches!(
@@ -266,19 +252,17 @@ impl Replica {
     /// Get an existing task by its UUID
     pub fn get_task(&mut self, uuid: Uuid) -> Result<Option<Task>> {
         let depmap = self.dependency_map(false)?;
-        let mut txn = self.storage.txn()?;
         Ok(self
             .taskdb
-            .get_task(txn.as_mut(), uuid)?
+            .get_task(uuid)?
             .map(move |tm| Task::new(TaskData::new(uuid, tm), depmap)))
     }
 
     /// Get an existing task by its UUID, as a [`TaskData`](crate::TaskData).
     pub fn get_task_data(&mut self, uuid: Uuid) -> Result<Option<TaskData>> {
-        let mut txn = self.storage.txn()?;
         Ok(self
             .taskdb
-            .get_task(txn.as_mut(), uuid)?
+            .get_task(uuid)?
             .map(move |tm| TaskData::new(uuid, tm)))
     }
 
@@ -293,8 +277,7 @@ impl Replica {
     /// those conflicts may not appear on all replicas. In practice, conflicts are rare and the
     /// results of this function will be the same on all replicas for most tasks.
     pub fn get_task_operations(&mut self, uuid: Uuid) -> Result<Operations> {
-        let mut txn = self.storage.txn()?;
-        self.taskdb.get_task_operations(txn.as_mut(), uuid)
+        self.taskdb.get_task_operations(uuid)
     }
 
     /// Create a new task, setting `modified`, `description`, `status`, and `entry`.
@@ -370,7 +353,6 @@ impl Replica {
     /// All local state on the replica will be updated accordingly, including the working set and
     /// and temporarily cached data.
     pub fn commit_operations(&mut self, operations: Operations) -> Result<()> {
-        let mut txn = self.storage.txn()?;
         if operations.is_empty() {
             return Ok(());
         }
@@ -396,7 +378,7 @@ impl Replica {
             _ => false,
         };
         self.taskdb
-            .commit_operations(txn.as_mut(), operations, add_to_working_set)?;
+            .commit_operations(operations, add_to_working_set)?;
 
         // The cached dependency map may now be invalid, do not retain it. Any existing Task values
         // will continue to use the old map.
@@ -417,7 +399,7 @@ impl Replica {
     /// system
     pub fn sync(&mut self, server: &mut Box<dyn Server>, avoid_snapshots: bool) -> Result<()> {
         self.taskdb
-            .sync(self.storage.txn()?.as_mut(), server, avoid_snapshots)
+            .sync(server, avoid_snapshots)
             .context("Failed to synchronize with server")?;
         self.rebuild_working_set(false)
             .context("Failed to rebuild working set after sync")?;
@@ -430,8 +412,7 @@ impl Replica {
     /// The operations are returned in the order they were applied. Use
     /// [`Replica::commit_reversed_operations`] to "undo" them.
     pub fn get_undo_operations(&mut self) -> Result<Operations> {
-        let mut txn = self.storage.txn()?;
-        self.taskdb.get_undo_operations(txn.as_mut())
+        self.taskdb.get_undo_operations()
     }
 
     /// Commit the reverse of the given operations, beginning with the last operation in the given
@@ -440,10 +421,7 @@ impl Replica {
     /// This method only supports reversing operations if they precisely match local operations
     /// that have not yet been synchronized, and will return `false` if this is not the case.
     pub fn commit_reversed_operations(&mut self, operations: Operations) -> Result<bool> {
-        if !self
-            .taskdb
-            .commit_reversed_operations(self.storage.txn()?.as_mut(), operations)?
-        {
+        if !self.taskdb.commit_reversed_operations(operations)? {
             return Ok(false);
         }
 
@@ -460,11 +438,9 @@ impl Replica {
     /// case, on completion all pending and recurring tasks are in the working set and all tasks
     /// with other statuses are not.
     pub fn rebuild_working_set(&mut self, renumber: bool) -> Result<()> {
-        let mut txn = self.storage.txn()?;
         let pending = String::from(Status::Pending.to_taskmap());
         let recurring = String::from(Status::Recurring.to_taskmap());
         self.taskdb.rebuild_working_set(
-            txn.as_mut(),
             |t| {
                 if let Some(st) = t.get("status") {
                     st == &pending || st == &recurring
@@ -501,7 +477,6 @@ impl Replica {
             .for_each(|(_, mut t)| t.delete(&mut ops));
         self.commit_operations(ops)
     }
-
     /// Add an UndoPoint, if one has not already been added by this Replica.  This occurs
     /// automatically when a change is made.  The `force` flag allows forcing a new UndoPoint
     /// even if one has already been created by this Replica, and may be useful when a Replica
@@ -532,21 +507,19 @@ impl Replica {
 
     /// Get the number of operations local to this replica and not yet synchronized to the server.
     pub fn num_local_operations(&mut self) -> Result<usize> {
-        let mut txn = self.storage.txn()?;
-        self.taskdb.num_operations(txn.as_mut())
+        self.taskdb.num_operations()
     }
 
     /// Get the number of undo points available (number of times `undo` will succeed).
     pub fn num_undo_points(&mut self) -> Result<usize> {
-        let mut txn = self.storage.txn()?;
-        self.taskdb.num_undo_points(txn.as_mut())
+        self.taskdb.num_undo_points()
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{storage::TaskMap, task::Status};
+    use crate::task::Status;
     use chrono::{DateTime, TimeZone};
     use pretty_assertions::assert_eq;
     use std::collections::HashSet;
@@ -596,7 +569,7 @@ mod tests {
     }
 
     #[test]
-    fn modify_task() -> Result<()> {
+    fn modify_task() {
         let mut rep = Replica::new_inmemory();
 
         // Further test the deprecated `new_task` method.
@@ -622,78 +595,75 @@ mod tests {
         assert_eq!(t.get_description(), "past tense");
         assert_eq!(t.get_status(), Status::Completed);
 
-        {
-            let mut txn = rep.storage.txn()?;
-            // and check for the corresponding operations, cleaning out the timestamps
-            // and modified properties as these are based on the current time
-            assert_eq!(
-                rep.taskdb
-                    .operations(txn.as_mut())
-                    .drain(..)
-                    .map(clean_op)
-                    .collect::<Vec<_>>(),
-                vec![
-                    Operation::UndoPoint,
-                    Operation::Create { uuid: t.get_uuid() },
-                    Operation::Update {
-                        uuid: t.get_uuid(),
-                        property: "modified".into(),
-                        old_value: None,
-                        value: Some("just-now".into()),
-                        timestamp: JUST_NOW.unwrap(),
-                    },
-                    Operation::Update {
-                        uuid: t.get_uuid(),
-                        property: "description".into(),
-                        old_value: None,
-                        value: Some("a task".into()),
-                        timestamp: JUST_NOW.unwrap(),
-                    },
-                    Operation::Update {
-                        uuid: t.get_uuid(),
-                        property: "status".into(),
-                        old_value: None,
-                        value: Some("pending".into()),
-                        timestamp: JUST_NOW.unwrap(),
-                    },
-                    Operation::Update {
-                        uuid: t.get_uuid(),
-                        property: "entry".into(),
-                        old_value: None,
-                        value: Some("just-now".into()),
-                        timestamp: JUST_NOW.unwrap(),
-                    },
-                    Operation::Update {
-                        uuid: t.get_uuid(),
-                        property: "modified".into(),
-                        old_value: Some("just-now".into()),
-                        value: Some("just-now".into()),
-                        timestamp: JUST_NOW.unwrap(),
-                    },
-                    Operation::Update {
-                        uuid: t.get_uuid(),
-                        property: "description".into(),
-                        old_value: Some("a task".into()),
-                        value: Some("past tense".into()),
-                        timestamp: JUST_NOW.unwrap(),
-                    },
-                    Operation::Update {
-                        uuid: t.get_uuid(),
-                        property: "end".into(),
-                        old_value: None,
-                        value: Some("just-now".into()),
-                        timestamp: JUST_NOW.unwrap(),
-                    },
-                    Operation::Update {
-                        uuid: t.get_uuid(),
-                        property: "status".into(),
-                        old_value: Some("pending".into()),
-                        value: Some("completed".into()),
-                        timestamp: JUST_NOW.unwrap(),
-                    },
-                ]
-            );
-        }
+        // and check for the corresponding operations, cleaning out the timestamps
+        // and modified properties as these are based on the current time
+        assert_eq!(
+            rep.taskdb
+                .operations()
+                .drain(..)
+                .map(clean_op)
+                .collect::<Vec<_>>(),
+            vec![
+                Operation::UndoPoint,
+                Operation::Create { uuid: t.get_uuid() },
+                Operation::Update {
+                    uuid: t.get_uuid(),
+                    property: "modified".into(),
+                    old_value: None,
+                    value: Some("just-now".into()),
+                    timestamp: JUST_NOW.unwrap(),
+                },
+                Operation::Update {
+                    uuid: t.get_uuid(),
+                    property: "description".into(),
+                    old_value: None,
+                    value: Some("a task".into()),
+                    timestamp: JUST_NOW.unwrap(),
+                },
+                Operation::Update {
+                    uuid: t.get_uuid(),
+                    property: "status".into(),
+                    old_value: None,
+                    value: Some("pending".into()),
+                    timestamp: JUST_NOW.unwrap(),
+                },
+                Operation::Update {
+                    uuid: t.get_uuid(),
+                    property: "entry".into(),
+                    old_value: None,
+                    value: Some("just-now".into()),
+                    timestamp: JUST_NOW.unwrap(),
+                },
+                Operation::Update {
+                    uuid: t.get_uuid(),
+                    property: "modified".into(),
+                    old_value: Some("just-now".into()),
+                    value: Some("just-now".into()),
+                    timestamp: JUST_NOW.unwrap(),
+                },
+                Operation::Update {
+                    uuid: t.get_uuid(),
+                    property: "description".into(),
+                    old_value: Some("a task".into()),
+                    value: Some("past tense".into()),
+                    timestamp: JUST_NOW.unwrap(),
+                },
+                Operation::Update {
+                    uuid: t.get_uuid(),
+                    property: "end".into(),
+                    old_value: None,
+                    value: Some("just-now".into()),
+                    timestamp: JUST_NOW.unwrap(),
+                },
+                Operation::Update {
+                    uuid: t.get_uuid(),
+                    property: "status".into(),
+                    old_value: Some("pending".into()),
+                    value: Some("completed".into()),
+                    timestamp: JUST_NOW.unwrap(),
+                },
+            ]
+        );
 
         // num_local_operations includes all but the undo point
         assert_eq!(rep.num_local_operations().unwrap(), 9);
@@ -705,8 +675,6 @@ mod tests {
         let ops = vec![Operation::UndoPoint];
         rep.commit_operations(ops).unwrap();
         assert_eq!(rep.num_undo_points().unwrap(), 2);
-
-        Ok(())
     }
 
     #[test]

--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -12,10 +12,7 @@ use crate::server::cloud::CloudServer;
 use crate::server::local::LocalServer;
 #[cfg(feature = "server-sync")]
 use crate::server::sync::SyncServer;
-use std::{
-    path::PathBuf,
-    sync::{Arc, Mutex},
-};
+use std::path::PathBuf;
 #[cfg(feature = "server-sync")]
 use uuid::Uuid;
 
@@ -98,41 +95,35 @@ pub enum ServerConfig {
 
 impl ServerConfig {
     /// Get a server based on this configuration
-    pub fn into_server(self) -> Result<Arc<Mutex<dyn Server + Send>>> {
+    pub fn into_server(self) -> Result<Box<dyn Server>> {
         Ok(match self {
             #[cfg(feature = "server-local")]
-            ServerConfig::Local { server_dir } => {
-                Arc::new(Mutex::new(LocalServer::new(server_dir)?))
-            }
+            ServerConfig::Local { server_dir } => Box::new(LocalServer::new(server_dir)?),
             #[cfg(feature = "server-sync")]
             ServerConfig::Remote {
                 url,
                 client_id,
                 encryption_secret,
-            } => Arc::new(Mutex::new(SyncServer::new(
-                url,
-                client_id,
-                encryption_secret,
-            )?)),
+            } => Box::new(SyncServer::new(url, client_id, encryption_secret)?),
             #[cfg(feature = "server-gcp")]
             ServerConfig::Gcp {
                 bucket,
                 credential_path,
                 encryption_secret,
-            } => Arc::new(Mutex::new(CloudServer::new(
+            } => Box::new(CloudServer::new(
                 GcpService::new(bucket, credential_path)?,
                 encryption_secret,
-            )?)),
+            )?),
             #[cfg(feature = "server-aws")]
             ServerConfig::Aws {
                 region,
                 bucket,
                 credentials,
                 encryption_secret,
-            } => Arc::new(Mutex::new(CloudServer::new(
+            } => Box::new(CloudServer::new(
                 AwsService::new(region, bucket, credentials)?,
                 encryption_secret,
-            )?)),
+            )?),
         })
     }
 }

--- a/src/storage/config.rs
+++ b/src/storage/config.rs
@@ -1,5 +1,49 @@
+#[cfg(feature = "storage-sqlite")]
+use super::sqlite::SqliteStorage;
+use super::{inmemory::InMemoryStorage, Storage};
+use crate::errors::Result;
+use std::path::PathBuf;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AccessMode {
     ReadOnly,
     ReadWrite,
+}
+
+/// The configuration required for a replica's storage.
+#[non_exhaustive]
+pub enum StorageConfig {
+    /// Store the data on disk.  This is the common choice.
+    #[cfg(feature = "storage-sqlite")]
+    OnDisk {
+        /// Path containing the task DB.
+        taskdb_dir: PathBuf,
+
+        /// Create the DB if it does not already exist. This will occur
+        /// even if access_mode is `ReadOnly`.
+        create_if_missing: bool,
+
+        /// Access mode for this database.
+        access_mode: AccessMode,
+    },
+    /// Store the data in memory.  This is only useful for testing.
+    InMemory,
+}
+
+impl StorageConfig {
+    pub fn into_storage(self) -> Result<Box<dyn Storage>> {
+        Ok(match self {
+            #[cfg(feature = "storage-sqlite")]
+            StorageConfig::OnDisk {
+                taskdb_dir,
+                create_if_missing,
+                access_mode,
+            } => Box::new(SqliteStorage::new(
+                taskdb_dir,
+                access_mode,
+                create_if_missing,
+            )?),
+            StorageConfig::InMemory => Box::new(InMemoryStorage::new()),
+        })
+    }
 }

--- a/src/storage/inmemory.rs
+++ b/src/storage/inmemory.rs
@@ -3,10 +3,8 @@
 use crate::errors::{Error, Result};
 use crate::operation::Operation;
 use crate::storage::{Storage, StorageTxn, TaskMap, VersionId, DEFAULT_BASE_VERSION};
-use async_trait::async_trait;
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
-use std::sync::Mutex;
 use uuid::Uuid;
 
 #[derive(PartialEq, Debug, Clone)]
@@ -18,14 +16,14 @@ struct Data {
 }
 
 struct Txn<'t> {
-    storage: &'t mut Data,
+    storage: &'t mut InMemoryStorage,
     new_data: Option<Data>,
 }
 
 impl Txn<'_> {
     fn mut_data_ref(&mut self) -> &mut Data {
         if self.new_data.is_none() {
-            self.new_data = Some(self.storage.clone());
+            self.new_data = Some(self.storage.data.clone());
         }
         if let Some(ref mut data) = self.new_data {
             data
@@ -38,7 +36,7 @@ impl Txn<'_> {
         if let Some(ref data) = self.new_data {
             data
         } else {
-            self.storage
+            &self.storage.data
         }
     }
 
@@ -226,7 +224,7 @@ impl StorageTxn for Txn<'_> {
     fn commit(&mut self) -> Result<()> {
         // copy the new_data back into storage to commit the transaction
         if let Some(data) = self.new_data.take() {
-            *self.storage = data;
+            self.storage.data = data;
         }
         Ok(())
     }
@@ -234,39 +232,33 @@ impl StorageTxn for Txn<'_> {
 
 /// InMemoryStorage is a simple in-memory task storage implementation.  It is not useful for
 /// production data, but is useful for testing purposes.
-#[derive(Debug)]
+#[derive(PartialEq, Debug, Clone)]
 pub struct InMemoryStorage {
-    data: Mutex<Data>,
+    data: Data,
 }
 
 impl InMemoryStorage {
     pub fn new() -> InMemoryStorage {
         InMemoryStorage {
-            data: Mutex::new(Data {
+            data: Data {
                 tasks: HashMap::new(),
                 base_version: DEFAULT_BASE_VERSION,
                 operations: vec![],
                 working_set: vec![None],
-            }),
+            },
         }
     }
 }
 
-#[async_trait]
 impl Storage for InMemoryStorage {
-    async fn txn<F, R>(&self, f: F) -> Result<R>
+    fn txn<F, R>(&mut self, f: F) -> Result<R>
     where
-        F: for<'a> FnOnce(&'a mut (dyn StorageTxn + 'a)) -> Result<R> + Send + 'static,
-        R: Send + 'static,
+        F: for<'a> FnOnce(&'a mut (dyn StorageTxn + 'a)) -> Result<R>,
     {
-        let mut guard = self.data.lock().unwrap();
-
-        let mut txn = Txn {
-            storage: &mut guard,
+        f(&mut Txn {
+            storage: self,
             new_data: None,
-        };
-
-        f(&mut txn)
+        })
     }
 }
 

--- a/src/storage/inmemory.rs
+++ b/src/storage/inmemory.rs
@@ -233,12 +233,12 @@ impl StorageTxn for Txn<'_> {
 /// InMemoryStorage is a simple in-memory task storage implementation.  It is not useful for
 /// production data, but is useful for testing purposes.
 #[derive(PartialEq, Debug, Clone)]
-pub struct InMemoryStorage {
+pub(super) struct InMemoryStorage {
     data: Data,
 }
 
 impl InMemoryStorage {
-    pub fn new() -> InMemoryStorage {
+    pub(super) fn new() -> InMemoryStorage {
         InMemoryStorage {
             data: Data {
                 tasks: HashMap::new(),
@@ -251,14 +251,11 @@ impl InMemoryStorage {
 }
 
 impl Storage for InMemoryStorage {
-    fn txn<F, R>(&mut self, f: F) -> Result<R>
-    where
-        F: for<'a> FnOnce(&'a mut (dyn StorageTxn + 'a)) -> Result<R>,
-    {
-        f(&mut Txn {
+    fn txn<'a>(&'a mut self) -> Result<Box<dyn StorageTxn + 'a>> {
+        Ok(Box::new(Txn {
             storage: self,
             new_data: None,
-        })
+        }))
     }
 }
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -10,7 +10,6 @@ traits defined here and pass the result to [`Replica`](crate::Replica).
 
 use crate::errors::Result;
 use crate::operation::Operation;
-use async_trait::async_trait;
 use std::collections::HashMap;
 use uuid::Uuid;
 
@@ -154,23 +153,9 @@ pub trait StorageTxn {
 
 /// A trait for objects able to act as task storage.  Most of the interesting behavior is in the
 /// [`crate::storage::StorageTxn`] trait.
-///
-/// ## Concurrency
-///
-/// The [`Storage::txn`] method is `async` but takes a **synchronous** closure `f`. This allows
-/// the use of database drivers with blocking APIs (like `rusqlite`) without stalling
-/// the async runtime.
-///
-/// Implementations of this trait must execute the closure on a separate thread, for
-/// example by using `tokio::task::spawn_blocking`.
-#[async_trait]
-pub trait Storage: Send + Sync {
-    /// Begins an async transaction.
-    ///
-    /// The provided closure `f` is synchronous and will be executed by the storage
-    /// backend on a blocking-safe thread.
-    async fn txn<F, R>(&self, f: F) -> Result<R>
+pub trait Storage {
+    /// Begin a transaction
+    fn txn<F, R>(&mut self, f: F) -> Result<R>
     where
-        F: for<'a> FnOnce(&'a mut (dyn StorageTxn + 'a)) -> Result<R> + Send + 'static,
-        R: Send + 'static;
+        F: for<'a> FnOnce(&'a mut (dyn StorageTxn + 'a)) -> Result<R>;
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -4,7 +4,8 @@ This module defines the backend storage used by [`Replica`](crate::Replica).
 It defines a [trait](crate::storage::Storage) for storage implementations, and provides a default
 on-disk implementation as well as an in-memory implementation for testing.
 
-Users who wish to implement their own storage backends can implement the
+Typical uses of this crate do not interact directly with this module; [`StorageConfig`] is
+sufficient. However, users who wish to implement their own storage backends can implement the
 traits defined here and pass the result to [`Replica`](crate::Replica).
 */
 
@@ -21,14 +22,9 @@ mod config;
 #[cfg(feature = "storage-sqlite")]
 pub(crate) mod sqlite;
 
-#[cfg(feature = "storage-sqlite")]
-pub use sqlite::SqliteStorage;
-
-pub use config::AccessMode;
+pub use config::{AccessMode, StorageConfig};
 
 mod inmemory;
-
-pub use inmemory::InMemoryStorage;
 
 #[doc(hidden)]
 /// For compatibility with 0.6 and earlier, [`Operation`] is re-exported here.
@@ -155,7 +151,5 @@ pub trait StorageTxn {
 /// [`crate::storage::StorageTxn`] trait.
 pub trait Storage {
     /// Begin a transaction
-    fn txn<F, R>(&mut self, f: F) -> Result<R>
-    where
-        F: for<'a> FnOnce(&'a mut (dyn StorageTxn + 'a)) -> Result<R>;
+    fn txn<'a>(&'a mut self) -> Result<Box<dyn StorageTxn + 'a>>;
 }

--- a/src/storage/sqlite.rs
+++ b/src/storage/sqlite.rs
@@ -3,7 +3,6 @@ use crate::operation::Operation;
 use crate::storage::config::AccessMode;
 use crate::storage::{Storage, StorageTxn, TaskMap, VersionId, DEFAULT_BASE_VERSION};
 use anyhow::Context;
-use async_trait::async_trait;
 use rusqlite::types::{FromSql, ToSql};
 use rusqlite::{params, Connection, OpenFlags, OptionalExtension, TransactionBehavior};
 use std::path::Path;
@@ -80,7 +79,7 @@ impl ToSql for Operation {
 
 /// SqliteStorage is an on-disk storage backed by SQLite3.
 pub struct SqliteStorage {
-    con: tokio_rusqlite::Connection,
+    con: Connection,
     access_mode: AccessMode,
 }
 
@@ -132,10 +131,7 @@ impl SqliteStorage {
             schema::upgrade_db(&mut con)?;
         }
 
-        Ok(Self {
-            access_mode,
-            con: con.into(),
-        })
+        Ok(Self { access_mode, con })
     }
 }
 
@@ -174,27 +170,18 @@ impl<'t> Txn<'t> {
     }
 }
 
-#[async_trait]
 impl Storage for SqliteStorage {
-    async fn txn<F, R>(&self, f: F) -> Result<R>
+    fn txn<F, R>(&mut self, f: F) -> Result<R>
     where
-        F: for<'a> FnOnce(&'a mut (dyn StorageTxn + 'a)) -> Result<R> + Send + 'static,
-        R: Send + 'static,
+        F: for<'a> FnOnce(&'a mut (dyn StorageTxn + 'a)) -> Result<R>,
     {
-        let access_mode = self.access_mode;
-        self.con
-            .call(move |con| {
-                let txn = con.transaction_with_behavior(TransactionBehavior::Immediate)?;
-
-                let mut txn_wrapper = Txn {
-                    txn: Some(txn),
-                    access_mode,
-                };
-
-                f(&mut txn_wrapper).map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))
-            })
-            .await
-            .map_err(Into::into)
+        let txn = self
+            .con
+            .transaction_with_behavior(TransactionBehavior::Immediate)?;
+        f(&mut Txn {
+            txn: Some(txn),
+            access_mode: self.access_mode,
+        })
     }
 }
 
@@ -512,7 +499,7 @@ impl StorageTxn for Txn<'_> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{errors, storage::taskmap_with};
+    use crate::storage::taskmap_with;
     use chrono::Utc;
     use pretty_assertions::assert_eq;
     use rstest::rstest;
@@ -630,39 +617,33 @@ mod test {
         Ok(())
     }
 
-    #[tokio::test]
-    async fn test_empty_dir() -> Result<()> {
+    #[test]
+    fn test_empty_dir() -> Result<()> {
         let tmp_dir = TempDir::new()?;
         let non_existant = tmp_dir.path().join("subdir");
-        let storage = SqliteStorage::new(non_existant.clone(), AccessMode::ReadWrite, true)?;
+        let mut storage = SqliteStorage::new(non_existant.clone(), AccessMode::ReadWrite, true)?;
         let uuid = Uuid::new_v4();
 
-        storage
-            .txn(move |txn| {
-                assert!(txn.create_task(uuid)?);
-                txn.commit()?;
-                Ok(())
-            })
-            .await?;
+        storage.txn(|txn| {
+            assert!(txn.create_task(uuid)?);
+            txn.commit()?;
+            Ok(())
+        })?;
 
-        storage
-            .txn(move |txn| {
-                let task = txn.get_task(uuid)?;
-                assert_eq!(task, Some(taskmap_with(vec![])));
-                Ok(())
-            })
-            .await?;
+        storage.txn(|txn| {
+            let task = txn.get_task(uuid)?;
+            assert_eq!(task, Some(taskmap_with(vec![])));
+            Ok(())
+        })?;
 
         // Re-open the DB.
-        let storage = SqliteStorage::new(non_existant, AccessMode::ReadWrite, true)?;
+        let mut storage = SqliteStorage::new(non_existant, AccessMode::ReadWrite, true)?;
 
-        storage
-            .txn(move |txn| {
-                let task = txn.get_task(uuid)?;
-                assert_eq!(task, Some(taskmap_with(vec![])));
-                Ok(())
-            })
-            .await?;
+        storage.txn(|txn| {
+            let task = txn.get_task(uuid)?;
+            assert_eq!(task, Some(taskmap_with(vec![])));
+            Ok(())
+        })?;
 
         Ok(())
     }
@@ -670,135 +651,116 @@ mod test {
     /// Test upgrading from a TaskChampion-0.8.0 database, ensuring that some basic task data
     /// remains intact from that version. This provides a basic coverage test of all schema
     /// upgrade functions.
-    #[tokio::test]
-    async fn test_0_8_0_db() -> Result<()> {
+    #[test]
+    fn test_0_8_0_db() -> Result<()> {
         let tmp_dir = TempDir::new()?;
         create_0_8_0_db(tmp_dir.path())?;
-        let storage = SqliteStorage::new(tmp_dir.path(), AccessMode::ReadWrite, true)?;
-
-        let db_version = storage
-            .con
-            .call(|conn| Ok(schema::get_db_version(conn)))
-            .await??;
-        assert_eq!(db_version, schema::LATEST_VERSION);
-
+        let mut storage = SqliteStorage::new(tmp_dir.path(), AccessMode::ReadWrite, true)?;
+        assert_eq!(
+            schema::get_db_version(&mut storage.con)?,
+            schema::LATEST_VERSION,
+        );
         let one = Uuid::parse_str("e2956511-fd47-4e40-926a-52616229c2fa").unwrap();
         let two = Uuid::parse_str("1d125b41-ee1d-49a7-9319-0506dee414f8").unwrap();
 
-        storage
-            .txn(move |txn| {
-                let mut task_one = txn.get_task(one)?.unwrap();
-                assert_eq!(task_one.get("description").unwrap(), "one");
+        storage.txn(|txn| {
+            let mut task_one = txn.get_task(one)?.unwrap();
+            assert_eq!(task_one.get("description").unwrap(), "one");
 
-                let task_two = txn.get_task(two)?.unwrap();
-                assert_eq!(task_two.get("description").unwrap(), "two");
+            let task_two = txn.get_task(two)?.unwrap();
+            assert_eq!(task_two.get("description").unwrap(), "two");
 
-                let ops = txn.unsynced_operations()?;
-                assert_eq!(ops.len(), 14);
-                assert_eq!(ops[0], Operation::UndoPoint);
+            let ops = txn.unsynced_operations()?;
+            assert_eq!(ops.len(), 14);
+            assert_eq!(ops[0], Operation::UndoPoint);
 
-                task_one.insert("description".into(), "updated".into());
-                txn.set_task(one, task_one)?;
-                txn.add_operation(Operation::Update {
-                    uuid: one,
-                    property: "description".into(),
-                    old_value: Some("one".into()),
-                    value: Some("updated".into()),
-                    timestamp: Utc::now(),
-                })?;
-                txn.commit()?;
-                Ok(())
-            })
-            .await?;
+            task_one.insert("description".into(), "updated".into());
+            txn.set_task(one, task_one)?;
+            txn.add_operation(Operation::Update {
+                uuid: one,
+                property: "description".into(),
+                old_value: Some("one".into()),
+                value: Some("updated".into()),
+                timestamp: Utc::now(),
+            })?;
+            txn.commit()?;
+            Ok(())
+        })?;
 
         // Read back the modification.
-        storage
-            .txn(move |txn| {
-                let task_one = txn.get_task(one)?.unwrap();
-                assert_eq!(task_one.get("description").unwrap(), "updated");
-                let ops = txn.unsynced_operations()?;
-                assert_eq!(ops.len(), 15);
-                Ok(())
-            })
-            .await?;
+
+        storage.txn(|txn| {
+            let task_one = txn.get_task(one)?.unwrap();
+            assert_eq!(task_one.get("description").unwrap(), "updated");
+            let ops = txn.unsynced_operations()?;
+            assert_eq!(ops.len(), 15);
+            Ok(())
+        })?;
 
         // Check the UUID fields on the operations directly in the DB.
-        let num_ops = storage
-            .con
-            .call(|conn| {
-                let t = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
-                let mut q = t.prepare("SELECT data, uuid FROM operations ORDER BY id ASC")?;
-                let mut num_ops = 0;
-
-                let rows = q
-                    .query_map([], |r| {
-                        let uuid: Option<StoredUuid> = r.get("uuid")?;
-                        let operation: Operation = r.get("data")?;
-                        Ok((uuid.map(|su| su.0), operation))
-                    })
-                    .context("Get all operations")
-                    .map_err(|e| tokio_rusqlite::Error::Other(e.into()))?;
-
-                for row in rows {
-                    let (uuid, operation) = row?;
-                    assert_eq!(uuid, operation.get_uuid());
-                    num_ops += 1;
-                }
-                Ok(num_ops)
-            })
-            .await?;
-
-        assert_eq!(num_ops, 15);
+        {
+            let t = storage
+                .con
+                .transaction_with_behavior(TransactionBehavior::Immediate)?;
+            let mut q = t.prepare("SELECT data, uuid FROM operations ORDER BY id ASC")?;
+            let mut num_ops = 0;
+            for row in q
+                .query_map([], |r| {
+                    let uuid: Option<StoredUuid> = r.get("uuid")?;
+                    let operation: Operation = r.get("data")?;
+                    Ok((uuid.map(|su| su.0), operation))
+                })
+                .context("Get all operations")?
+            {
+                let (uuid, operation) = row?;
+                assert_eq!(uuid, operation.get_uuid());
+                num_ops += 1;
+            }
+            assert_eq!(num_ops, 15);
+        }
 
         Ok(())
     }
 
-    #[tokio::test]
-    async fn test_concurrent_access() -> Result<()> {
+    #[test]
+    fn test_concurrent_access() -> Result<()> {
         let tmp_dir = TempDir::new()?;
 
         // Initialize the DB once, as schema modifications are not isolated by transactions.
-        SqliteStorage::new(tmp_dir.path(), AccessMode::ReadWrite, true)?;
+        SqliteStorage::new(tmp_dir.path(), AccessMode::ReadWrite, true).unwrap();
 
-        let db_path = tmp_dir.path().to_path_buf();
-
-        // First thread begins a transaction, writes immediately, waits 100ms, and commits it.
-        let path1 = db_path.clone();
-        let handle1 = tokio::spawn(async move {
-            let storage = SqliteStorage::new(path1, AccessMode::ReadWrite, true).unwrap();
-            let u = Uuid::new_v4();
-            storage
-                .txn(move |txn| {
-                    txn.set_base_version(u).unwrap();
-                    thread::sleep(Duration::from_millis(100));
-                    txn.commit().unwrap();
-                    Ok(())
-                })
-                .await
-                .unwrap();
+        thread::scope(|scope| {
+            // First thread begins a transaction, writes immediately, waits 100ms, and commits it.
+            scope.spawn(|| {
+                let mut storage =
+                    SqliteStorage::new(tmp_dir.path(), AccessMode::ReadWrite, true).unwrap();
+                let u = Uuid::new_v4();
+                storage
+                    .txn(|txn| {
+                        txn.set_base_version(u).unwrap();
+                        thread::sleep(Duration::from_millis(100));
+                        txn.commit().unwrap();
+                        Ok(())
+                    })
+                    .unwrap();
+            });
+            // Second thread waits 50ms, and begins a transaction. This
+            // should wait for the first to complete, but the regression would be a SQLITE_BUSY
+            // failure.
+            scope.spawn(|| {
+                thread::sleep(Duration::from_millis(50));
+                let mut storage =
+                    SqliteStorage::new(tmp_dir.path(), AccessMode::ReadWrite, true).unwrap();
+                let u = Uuid::new_v4();
+                storage
+                    .txn(|txn| {
+                        txn.set_base_version(u).unwrap();
+                        txn.commit().unwrap();
+                        Ok(())
+                    })
+                    .unwrap();
+            });
         });
-
-        // Second thread waits 50ms, and begins a transaction. This
-        // should wait for the first to complete, but the regression would be a SQLITE_BUSY
-        // failure.
-        let path2 = db_path;
-        let handle2 = tokio::spawn(async move {
-            thread::sleep(Duration::from_millis(50));
-            let storage = SqliteStorage::new(path2, AccessMode::ReadWrite, true).unwrap();
-            let u = Uuid::new_v4();
-            storage
-                .txn(move |txn| {
-                    txn.set_base_version(u).unwrap();
-                    txn.commit().unwrap();
-                    Ok(())
-                })
-                .await
-                .unwrap();
-        });
-
-        handle1.await.map_err(|e| errors::Error::Other(e.into()))?;
-        handle2.await.map_err(|e| errors::Error::Other(e.into()))?;
-
         Ok(())
     }
 
@@ -808,49 +770,46 @@ mod test {
     #[case::create_non_existent(false, true)]
     #[case::create_exists(true, true)]
     #[case::exists_dont_create(true, false)]
-    #[tokio::test]
-    async fn test_read_only(#[case] exists: bool, #[case] create: bool) -> Result<()> {
+    fn test_read_only(#[case] exists: bool, #[case] create: bool) -> Result<()> {
         let tmp_dir = TempDir::new()?;
         // If the DB should already exist, create it.
         if exists {
             SqliteStorage::new(tmp_dir.path(), AccessMode::ReadWrite, true)?;
         }
-        let storage = SqliteStorage::new(tmp_dir.path(), AccessMode::ReadOnly, create)?;
+        let mut storage = SqliteStorage::new(tmp_dir.path(), AccessMode::ReadOnly, create)?;
 
         fn is_read_only_err<T: std::fmt::Debug>(res: Result<T>) -> bool {
             &res.unwrap_err().to_string() == "Task storage was opened in read-only mode"
         }
 
-        storage
-            .txn(move |txn| {
-                let taskmap = TaskMap::new();
-                let op = Operation::UndoPoint;
+        storage.txn(|txn| {
+            let taskmap = TaskMap::new();
+            let op = Operation::UndoPoint;
 
-                // Mutating things fail.
-                assert!(is_read_only_err(txn.create_task(Uuid::new_v4())));
-                assert!(is_read_only_err(txn.set_task(Uuid::new_v4(), taskmap)));
-                assert!(is_read_only_err(txn.delete_task(Uuid::new_v4())));
-                assert!(is_read_only_err(txn.set_base_version(Uuid::new_v4())));
-                assert!(is_read_only_err(txn.add_operation(op.clone())));
-                assert!(is_read_only_err(txn.remove_operation(op)));
-                assert!(is_read_only_err(txn.sync_complete()));
-                assert!(is_read_only_err(txn.add_to_working_set(Uuid::new_v4())));
-                assert!(is_read_only_err(txn.set_working_set_item(1, None)));
-                assert!(is_read_only_err(txn.clear_working_set()));
-                assert!(is_read_only_err(txn.commit()));
+            // Mutating things fail.
+            assert!(is_read_only_err(txn.create_task(Uuid::new_v4())));
+            assert!(is_read_only_err(txn.set_task(Uuid::new_v4(), taskmap)));
+            assert!(is_read_only_err(txn.delete_task(Uuid::new_v4())));
+            assert!(is_read_only_err(txn.set_base_version(Uuid::new_v4())));
+            assert!(is_read_only_err(txn.add_operation(op.clone())));
+            assert!(is_read_only_err(txn.remove_operation(op)));
+            assert!(is_read_only_err(txn.sync_complete()));
+            assert!(is_read_only_err(txn.add_to_working_set(Uuid::new_v4())));
+            assert!(is_read_only_err(txn.set_working_set_item(1, None)));
+            assert!(is_read_only_err(txn.clear_working_set()));
+            assert!(is_read_only_err(txn.commit()));
 
-                // Read-only things succeed.
-                assert_eq!(txn.get_task(Uuid::new_v4())?, None);
-                assert_eq!(txn.get_pending_tasks()?.len(), 0);
-                assert_eq!(txn.all_tasks()?.len(), 0);
-                assert_eq!(txn.base_version()?, Uuid::nil());
-                assert_eq!(txn.get_task_operations(Uuid::new_v4())?.len(), 0);
-                assert_eq!(txn.unsynced_operations()?.len(), 0);
-                assert_eq!(txn.num_unsynced_operations()?, 0);
-                assert_eq!(txn.get_working_set()?.len(), 1);
-                Ok(())
-            })
-            .await?;
+            // Read-only things succeed.
+            assert_eq!(txn.get_task(Uuid::new_v4())?, None);
+            assert_eq!(txn.get_pending_tasks()?.len(), 0);
+            assert_eq!(txn.all_tasks()?.len(), 0);
+            assert_eq!(txn.base_version()?, Uuid::nil());
+            assert_eq!(txn.get_task_operations(Uuid::new_v4())?.len(), 0);
+            assert_eq!(txn.unsynced_operations()?.len(), 0);
+            assert_eq!(txn.num_unsynced_operations()?, 0);
+            assert_eq!(txn.get_working_set()?.len(), 1);
+            Ok(())
+        })?;
 
         Ok(())
     }

--- a/src/storage/test.rs
+++ b/src/storage/test.rs
@@ -13,765 +13,655 @@ use uuid::Uuid;
 /// Define a collection of storage tests that apply to all storage implementations.
 macro_rules! storage_tests {
     ($storage:expr) => {
-        #[tokio::test]
-        async fn get_working_set_empty() -> $crate::errors::Result<()> {
-            $crate::storage::test::get_working_set_empty($storage).await
+        #[test]
+        fn get_working_set_empty() -> $crate::errors::Result<()> {
+            $crate::storage::test::get_working_set_empty($storage)
         }
 
-        #[tokio::test]
-        async fn add_to_working_set() -> $crate::errors::Result<()> {
-            $crate::storage::test::add_to_working_set($storage).await
+        #[test]
+        fn add_to_working_set() -> $crate::errors::Result<()> {
+            $crate::storage::test::add_to_working_set($storage)
         }
 
-        #[tokio::test]
-        async fn clear_working_set() -> $crate::errors::Result<()> {
-            $crate::storage::test::clear_working_set($storage).await
+        #[test]
+        fn clear_working_set() -> $crate::errors::Result<()> {
+            $crate::storage::test::clear_working_set($storage)
         }
 
-        #[tokio::test]
-        async fn drop_transaction() -> $crate::errors::Result<()> {
-            $crate::storage::test::drop_transaction($storage).await
+        #[test]
+        fn drop_transaction() -> $crate::errors::Result<()> {
+            $crate::storage::test::drop_transaction($storage)
         }
 
-        #[tokio::test]
-        async fn create() -> $crate::errors::Result<()> {
-            $crate::storage::test::create($storage).await
+        #[test]
+        fn create() -> $crate::errors::Result<()> {
+            $crate::storage::test::create($storage)
         }
 
-        #[tokio::test]
-        async fn create_exists() -> $crate::errors::Result<()> {
-            $crate::storage::test::create_exists($storage).await
+        #[test]
+        fn create_exists() -> $crate::errors::Result<()> {
+            $crate::storage::test::create_exists($storage)
         }
 
-        #[tokio::test]
-        async fn get_missing() -> $crate::errors::Result<()> {
-            $crate::storage::test::get_missing($storage).await
+        #[test]
+        fn get_missing() -> $crate::errors::Result<()> {
+            $crate::storage::test::get_missing($storage)
         }
 
-        #[tokio::test]
-        async fn set_task() -> $crate::errors::Result<()> {
-            $crate::storage::test::set_task($storage).await
+        #[test]
+        fn set_task() -> $crate::errors::Result<()> {
+            $crate::storage::test::set_task($storage)
         }
 
-        #[tokio::test]
-        async fn delete_task_missing() -> $crate::errors::Result<()> {
-            $crate::storage::test::delete_task_missing($storage).await
+        #[test]
+        fn delete_task_missing() -> $crate::errors::Result<()> {
+            $crate::storage::test::delete_task_missing($storage)
         }
 
-        #[tokio::test]
-        async fn delete_task_exists() -> $crate::errors::Result<()> {
-            $crate::storage::test::delete_task_exists($storage).await
+        #[test]
+        fn delete_task_exists() -> $crate::errors::Result<()> {
+            $crate::storage::test::delete_task_exists($storage)
         }
 
-        #[tokio::test]
-        async fn all_tasks_empty() -> $crate::errors::Result<()> {
-            $crate::storage::test::all_tasks_empty($storage).await
+        #[test]
+        fn all_tasks_empty() -> $crate::errors::Result<()> {
+            $crate::storage::test::all_tasks_empty($storage)
         }
 
-        #[tokio::test]
-        async fn all_tasks_and_uuids() -> $crate::errors::Result<()> {
-            $crate::storage::test::all_tasks_and_uuids($storage).await
+        #[test]
+        fn all_tasks_and_uuids() -> $crate::errors::Result<()> {
+            $crate::storage::test::all_tasks_and_uuids($storage)
         }
 
-        #[tokio::test]
-        async fn base_version_default() -> Result<()> {
-            $crate::storage::test::base_version_default($storage).await
+        #[test]
+        fn base_version_default() -> Result<()> {
+            $crate::storage::test::base_version_default($storage)
         }
 
-        #[tokio::test]
-        async fn base_version_setting() -> Result<()> {
-            $crate::storage::test::base_version_setting($storage).await
+        #[test]
+        fn base_version_setting() -> Result<()> {
+            $crate::storage::test::base_version_setting($storage)
         }
 
-        #[tokio::test]
-        async fn unsynced_operations() -> Result<()> {
-            $crate::storage::test::unsynced_operations($storage).await
+        #[test]
+        fn unsynced_operations() -> Result<()> {
+            $crate::storage::test::unsynced_operations($storage)
         }
 
-        #[tokio::test]
-        async fn remove_operations() -> Result<()> {
-            $crate::storage::test::remove_operations($storage).await
+        #[test]
+        fn remove_operations() -> Result<()> {
+            $crate::storage::test::remove_operations($storage)
         }
 
-        #[tokio::test]
-        async fn task_operations() -> Result<()> {
-            $crate::storage::test::task_operations($storage).await
+        #[test]
+        fn task_operations() -> Result<()> {
+            $crate::storage::test::task_operations($storage)
         }
 
-        #[tokio::test]
-        async fn sync_complete() -> Result<()> {
-            $crate::storage::test::sync_complete($storage).await
+        #[test]
+        fn sync_complete() -> Result<()> {
+            $crate::storage::test::sync_complete($storage)
         }
 
-        #[tokio::test]
-        async fn set_working_set_item() -> Result<()> {
-            $crate::storage::test::set_working_set_item($storage).await
+        #[test]
+        fn set_working_set_item() -> Result<()> {
+            $crate::storage::test::set_working_set_item($storage)
         }
     };
 }
 pub(crate) use storage_tests;
 
-pub(super) async fn get_working_set_empty(storage: impl Storage) -> Result<()> {
-    storage
-        .txn(move |txn| {
-            let ws = txn.get_working_set()?;
-            assert_eq!(ws, vec![None]);
-            Ok(())
-        })
-        .await
+pub(super) fn get_working_set_empty(mut storage: impl Storage) -> Result<()> {
+    storage.txn(|txn| {
+        let ws = txn.get_working_set()?;
+        assert_eq!(ws, vec![None]);
+        Ok(())
+    })
 }
 
-pub(super) async fn add_to_working_set(storage: impl Storage) -> Result<()> {
+pub(super) fn add_to_working_set(mut storage: impl Storage) -> Result<()> {
     let uuid1 = Uuid::new_v4();
     let uuid2 = Uuid::new_v4();
 
-    storage
-        .txn(move |txn| {
-            txn.add_to_working_set(uuid1)?;
-            txn.add_to_working_set(uuid2)?;
-            txn.commit()
-        })
-        .await?;
+    storage.txn(|txn| {
+        txn.add_to_working_set(uuid1)?;
+        txn.add_to_working_set(uuid2)?;
+        txn.commit()
+    })?;
 
-    storage
-        .txn(move |txn| {
-            let ws = txn.get_working_set()?;
-            assert_eq!(ws, vec![None, Some(uuid1), Some(uuid2)]);
-            Ok(())
-        })
-        .await
+    storage.txn(|txn| {
+        let ws = txn.get_working_set()?;
+        assert_eq!(ws, vec![None, Some(uuid1), Some(uuid2)]);
+        Ok(())
+    })
 }
 
-pub(super) async fn clear_working_set(storage: impl Storage) -> Result<()> {
+pub(super) fn clear_working_set(mut storage: impl Storage) -> Result<()> {
     let uuid1 = Uuid::new_v4();
     let uuid2 = Uuid::new_v4();
 
-    storage
-        .txn(move |txn| {
-            txn.add_to_working_set(uuid1)?;
-            txn.add_to_working_set(uuid2)?;
-            txn.commit()
-        })
-        .await?;
+    storage.txn(|txn| {
+        txn.add_to_working_set(uuid1)?;
+        txn.add_to_working_set(uuid2)?;
+        txn.commit()
+    })?;
 
-    storage
-        .txn(move |txn| {
-            txn.clear_working_set()?;
-            txn.add_to_working_set(uuid2)?;
-            txn.add_to_working_set(uuid1)?;
-            txn.commit()
-        })
-        .await?;
+    storage.txn(|txn| {
+        txn.clear_working_set()?;
+        txn.add_to_working_set(uuid2)?;
+        txn.add_to_working_set(uuid1)?;
+        txn.commit()
+    })?;
 
-    storage
-        .txn(move |txn| {
-            let ws = txn.get_working_set()?;
-            assert_eq!(ws, vec![None, Some(uuid2), Some(uuid1)]);
-            Ok(())
-        })
-        .await
+    storage.txn(|txn| {
+        let ws = txn.get_working_set()?;
+        assert_eq!(ws, vec![None, Some(uuid2), Some(uuid1)]);
+        Ok(())
+    })
 }
 
-pub(super) async fn drop_transaction(storage: impl Storage) -> Result<()> {
+pub(super) fn drop_transaction(mut storage: impl Storage) -> Result<()> {
     let uuid1 = Uuid::new_v4();
     let uuid2 = Uuid::new_v4();
 
-    storage
-        .txn(move |txn| {
-            assert!(txn.create_task(uuid1)?);
-            txn.commit()
-        })
-        .await?;
+    storage.txn(|txn| {
+        assert!(txn.create_task(uuid1)?);
+        txn.commit()
+    })?;
 
-    let result: Result<()> = storage
-        .txn(move |txn| {
-            assert!(txn.create_task(uuid2)?);
-            Err(Error::Other(anyhow!("Intentional error")))
-        })
-        .await;
+    let result: Result<()> = storage.txn(|txn| {
+        assert!(txn.create_task(uuid2)?);
+        Err(Error::Other(anyhow!("Intentional error")))
+    });
 
     assert!(result.is_err());
 
-    storage
-        .txn(move |txn| {
-            let uuids = txn.all_task_uuids()?;
-            assert_eq!(uuids, [uuid1]);
-            Ok(())
-        })
-        .await
+    storage.txn(|txn| {
+        let uuids = txn.all_task_uuids()?;
+        assert_eq!(uuids, [uuid1]);
+        Ok(())
+    })
 }
 
-pub(super) async fn create(storage: impl Storage) -> Result<()> {
+pub(super) fn create(mut storage: impl Storage) -> Result<()> {
     let uuid = Uuid::new_v4();
 
-    storage
-        .txn(move |txn| {
-            assert!(txn.create_task(uuid)?);
-            txn.commit()
-        })
-        .await?;
+    storage.txn(|txn| {
+        assert!(txn.create_task(uuid)?);
+        txn.commit()
+    })?;
 
-    storage
-        .txn(move |txn| {
-            let task = txn.get_task(uuid)?;
-            assert_eq!(task, Some(taskmap_with(vec![])));
-            Ok(())
-        })
-        .await
+    storage.txn(|txn| {
+        let task = txn.get_task(uuid)?;
+        assert_eq!(task, Some(taskmap_with(vec![])));
+        Ok(())
+    })
 }
 
-pub(super) async fn create_exists(storage: impl Storage) -> Result<()> {
+pub(super) fn create_exists(mut storage: impl Storage) -> Result<()> {
     let uuid = Uuid::new_v4();
 
-    storage
-        .txn(move |txn| {
-            assert!(txn.create_task(uuid)?);
-            txn.commit()
-        })
-        .await?;
+    storage.txn(|txn| {
+        assert!(txn.create_task(uuid)?);
+        txn.commit()
+    })?;
 
-    storage
-        .txn(move |txn| {
-            assert!(!txn.create_task(uuid)?);
-            txn.commit()
-        })
-        .await
+    storage.txn(|txn| {
+        assert!(!txn.create_task(uuid)?);
+        txn.commit()
+    })
 }
 
-pub(super) async fn get_missing(storage: impl Storage) -> Result<()> {
+pub(super) fn get_missing(mut storage: impl Storage) -> Result<()> {
     let uuid = Uuid::new_v4();
-    storage
-        .txn(move |txn| {
-            let task = txn.get_task(uuid)?;
-            assert_eq!(task, None);
-            Ok(())
-        })
-        .await
+    storage.txn(|txn| {
+        let task = txn.get_task(uuid)?;
+        assert_eq!(task, None);
+        Ok(())
+    })
 }
 
-pub(super) async fn set_task(storage: impl Storage) -> Result<()> {
+pub(super) fn set_task(mut storage: impl Storage) -> Result<()> {
     let uuid = Uuid::new_v4();
-    storage
-        .txn(move |txn| {
-            txn.set_task(uuid, taskmap_with(vec![("k".to_string(), "v".to_string())]))?;
-            txn.commit()
-        })
-        .await?;
+    storage.txn(|txn| {
+        txn.set_task(uuid, taskmap_with(vec![("k".to_string(), "v".to_string())]))?;
+        txn.commit()
+    })?;
 
-    storage
-        .txn(move |txn| {
-            let task = txn.get_task(uuid)?;
-            assert_eq!(
-                task,
-                Some(taskmap_with(vec![("k".to_string(), "v".to_string())]))
-            );
-            Ok(())
-        })
-        .await
+    storage.txn(|txn| {
+        let task = txn.get_task(uuid)?;
+        assert_eq!(
+            task,
+            Some(taskmap_with(vec![("k".to_string(), "v".to_string())]))
+        );
+        Ok(())
+    })
 }
 
-pub(super) async fn delete_task_missing(storage: impl Storage) -> Result<()> {
+pub(super) fn delete_task_missing(mut storage: impl Storage) -> Result<()> {
     let uuid = Uuid::new_v4();
-    storage
-        .txn(move |txn| {
-            assert!(!txn.delete_task(uuid)?);
-            Ok(())
-        })
-        .await
+    storage.txn(|txn| {
+        assert!(!txn.delete_task(uuid)?);
+        Ok(())
+    })
 }
 
-pub(super) async fn delete_task_exists(storage: impl Storage) -> Result<()> {
+pub(super) fn delete_task_exists(mut storage: impl Storage) -> Result<()> {
     let uuid = Uuid::new_v4();
-    storage
-        .txn(move |txn| {
-            assert!(txn.create_task(uuid)?);
-            txn.commit()
-        })
-        .await?;
+    storage.txn(|txn| {
+        assert!(txn.create_task(uuid)?);
+        txn.commit()
+    })?;
 
-    storage
-        .txn(move |txn| {
-            assert!(txn.delete_task(uuid)?);
-            txn.commit()
-        })
-        .await
+    storage.txn(|txn| {
+        assert!(txn.delete_task(uuid)?);
+        txn.commit()
+    })
 }
 
-pub(super) async fn all_tasks_empty(storage: impl Storage) -> Result<()> {
-    storage
-        .txn(move |txn| {
-            let tasks = txn.all_tasks()?;
-            assert_eq!(tasks, vec![]);
-            Ok(())
-        })
-        .await
+pub(super) fn all_tasks_empty(mut storage: impl Storage) -> Result<()> {
+    storage.txn(|txn| {
+        let tasks = txn.all_tasks()?;
+        assert_eq!(tasks, vec![]);
+        Ok(())
+    })
 }
 
-pub(super) async fn all_tasks_and_uuids(storage: impl Storage) -> Result<()> {
+pub(super) fn all_tasks_and_uuids(mut storage: impl Storage) -> Result<()> {
     let uuid1 = Uuid::new_v4();
     let uuid2 = Uuid::new_v4();
-    storage
-        .txn(move |txn| {
-            assert!(txn.create_task(uuid1)?);
-            txn.set_task(
+    storage.txn(|txn| {
+        assert!(txn.create_task(uuid1)?);
+        txn.set_task(
+            uuid1,
+            taskmap_with(vec![("num".to_string(), "1".to_string())]),
+        )?;
+        assert!(txn.create_task(uuid2)?);
+        txn.set_task(
+            uuid2,
+            taskmap_with(vec![("num".to_string(), "2".to_string())]),
+        )?;
+        txn.commit()
+    })?;
+
+    storage.txn(|txn| {
+        let mut tasks = txn.all_tasks()?;
+
+        // order is nondeterministic, so sort by uuid
+        tasks.sort_by(|a, b| a.0.cmp(&b.0));
+
+        let mut exp = vec![
+            (
                 uuid1,
                 taskmap_with(vec![("num".to_string(), "1".to_string())]),
-            )?;
-            assert!(txn.create_task(uuid2)?);
-            txn.set_task(
+            ),
+            (
                 uuid2,
                 taskmap_with(vec![("num".to_string(), "2".to_string())]),
-            )?;
-            txn.commit()
-        })
-        .await?;
+            ),
+        ];
+        exp.sort_by(|a, b| a.0.cmp(&b.0));
 
-    storage
-        .txn(move |txn| {
-            let mut tasks = txn.all_tasks()?;
+        assert_eq!(tasks, exp);
+        Ok(())
+    })?;
 
-            // order is nondeterministic, so sort by uuid
-            tasks.sort_by(|a, b| a.0.cmp(&b.0));
+    storage.txn(|txn| {
+        let mut uuids = txn.all_task_uuids()?;
+        uuids.sort();
 
-            let mut exp = vec![
-                (
-                    uuid1,
-                    taskmap_with(vec![("num".to_string(), "1".to_string())]),
-                ),
-                (
-                    uuid2,
-                    taskmap_with(vec![("num".to_string(), "2".to_string())]),
-                ),
-            ];
-            exp.sort_by(|a, b| a.0.cmp(&b.0));
+        let mut exp = vec![uuid1, uuid2];
+        exp.sort();
 
-            assert_eq!(tasks, exp);
-            Ok(())
-        })
-        .await?;
-
-    storage
-        .txn(move |txn| {
-            let mut uuids = txn.all_task_uuids()?;
-            uuids.sort();
-
-            let mut exp = vec![uuid1, uuid2];
-            exp.sort();
-
-            assert_eq!(uuids, exp);
-            Ok(())
-        })
-        .await
+        assert_eq!(uuids, exp);
+        Ok(())
+    })
 }
 
-pub(super) async fn base_version_default(storage: impl Storage) -> Result<()> {
-    storage
-        .txn(move |txn| {
-            assert_eq!(txn.base_version()?, DEFAULT_BASE_VERSION);
-            Ok(())
-        })
-        .await
+pub(super) fn base_version_default(mut storage: impl Storage) -> Result<()> {
+    storage.txn(|txn| {
+        assert_eq!(txn.base_version()?, DEFAULT_BASE_VERSION);
+        Ok(())
+    })
 }
 
-pub(super) async fn base_version_setting(storage: impl Storage) -> Result<()> {
+pub(super) fn base_version_setting(mut storage: impl Storage) -> Result<()> {
     let u = Uuid::new_v4();
-    storage
-        .txn(move |txn| {
-            txn.set_base_version(u)?;
-            txn.commit()
-        })
-        .await?;
+    storage.txn(|txn| {
+        txn.set_base_version(u)?;
+        txn.commit()
+    })?;
 
-    storage
-        .txn(move |txn| {
-            assert_eq!(txn.base_version()?, u);
-            Ok(())
-        })
-        .await
+    storage.txn(|txn| {
+        assert_eq!(txn.base_version()?, u);
+        Ok(())
+    })
 }
 
-pub(super) async fn unsynced_operations(storage: impl Storage) -> Result<()> {
+pub(super) fn unsynced_operations(mut storage: impl Storage) -> Result<()> {
     let uuid1 = Uuid::new_v4();
     let uuid2 = Uuid::new_v4();
     let uuid3 = Uuid::new_v4();
 
     // create some operations
-    storage
-        .txn(move |txn| {
-            txn.add_operation(Operation::Create { uuid: uuid1 })?;
-            txn.add_operation(Operation::Create { uuid: uuid2 })?;
-            txn.commit()
-        })
-        .await?;
+    storage.txn(|txn| {
+        txn.add_operation(Operation::Create { uuid: uuid1 })?;
+        txn.add_operation(Operation::Create { uuid: uuid2 })?;
+        txn.commit()
+    })?;
 
     // read them back
-    storage
-        .txn(move |txn| {
-            let ops = txn.unsynced_operations()?;
-            assert_eq!(
-                ops,
-                vec![
-                    Operation::Create { uuid: uuid1 },
-                    Operation::Create { uuid: uuid2 },
-                ]
-            );
+    storage.txn(|txn| {
+        let ops = txn.unsynced_operations()?;
+        assert_eq!(
+            ops,
+            vec![
+                Operation::Create { uuid: uuid1 },
+                Operation::Create { uuid: uuid2 },
+            ]
+        );
 
-            assert_eq!(txn.num_unsynced_operations()?, 2);
-            Ok(())
-        })
-        .await?;
+        assert_eq!(txn.num_unsynced_operations()?, 2);
+        Ok(())
+    })?;
 
     // Sync them.
-    storage
-        .txn(move |txn| {
-            txn.sync_complete()?;
-            txn.commit()
-        })
-        .await?;
+    storage.txn(|txn| {
+        txn.sync_complete()?;
+        txn.commit()
+    })?;
 
     // create some more operations (to test adding operations after sync)
-    storage
-        .txn(move |txn| {
-            txn.add_operation(Operation::Create { uuid: uuid3 })?;
-            txn.add_operation(Operation::Delete {
-                uuid: uuid3,
-                old_task: TaskMap::new(),
-            })?;
-            txn.commit()
-        })
-        .await?;
+    storage.txn(|txn| {
+        txn.add_operation(Operation::Create { uuid: uuid3 })?;
+        txn.add_operation(Operation::Delete {
+            uuid: uuid3,
+            old_task: TaskMap::new(),
+        })?;
+        txn.commit()
+    })?;
 
     // read them back
-    storage
-        .txn(move |txn| {
-            let ops = txn.unsynced_operations()?;
-            assert_eq!(
-                ops,
-                vec![
-                    Operation::Create { uuid: uuid3 },
-                    Operation::Delete {
-                        uuid: uuid3,
-                        old_task: TaskMap::new()
-                    },
-                ]
-            );
-            assert_eq!(txn.num_unsynced_operations()?, 2);
-            Ok(())
-        })
-        .await?;
+    storage.txn(|txn| {
+        let ops = txn.unsynced_operations()?;
+        assert_eq!(
+            ops,
+            vec![
+                Operation::Create { uuid: uuid3 },
+                Operation::Delete {
+                    uuid: uuid3,
+                    old_task: TaskMap::new()
+                },
+            ]
+        );
+        assert_eq!(txn.num_unsynced_operations()?, 2);
+        Ok(())
+    })?;
 
     // Remove the right one
-    storage
-        .txn(move |txn| {
-            txn.remove_operation(Operation::Delete {
-                uuid: uuid3,
-                old_task: TaskMap::new(),
-            })?;
-            txn.commit()
-        })
-        .await?;
+    storage.txn(|txn| {
+        txn.remove_operation(Operation::Delete {
+            uuid: uuid3,
+            old_task: TaskMap::new(),
+        })?;
+        txn.commit()
+    })?;
 
     // read the remaining op back
-    storage
-        .txn(move |txn| {
-            let ops = txn.unsynced_operations()?;
-            assert_eq!(ops, vec![Operation::Create { uuid: uuid3 },]);
-            assert_eq!(txn.num_unsynced_operations()?, 1);
-            Ok(())
-        })
-        .await
+    storage.txn(|txn| {
+        let ops = txn.unsynced_operations()?;
+        assert_eq!(ops, vec![Operation::Create { uuid: uuid3 },]);
+        assert_eq!(txn.num_unsynced_operations()?, 1);
+        Ok(())
+    })
 }
 
-pub(super) async fn remove_operations(storage: impl Storage) -> Result<()> {
+pub(super) fn remove_operations(mut storage: impl Storage) -> Result<()> {
     let uuid1 = Uuid::new_v4();
     let uuid2 = Uuid::new_v4();
     let uuid3 = Uuid::new_v4();
     let uuid4 = Uuid::new_v4();
 
     // Create some tasks and operations.
-    storage
-        .txn(move |txn| {
-            txn.create_task(uuid1)?;
-            txn.create_task(uuid2)?;
-            txn.create_task(uuid3)?;
+    storage.txn(|txn| {
+        txn.create_task(uuid1)?;
+        txn.create_task(uuid2)?;
+        txn.create_task(uuid3)?;
 
-            txn.add_operation(Operation::Create { uuid: uuid1 })?;
-            txn.add_operation(Operation::Create { uuid: uuid2 })?;
-            txn.add_operation(Operation::Create { uuid: uuid3 })?;
-            txn.commit()
-        })
-        .await?;
+        txn.add_operation(Operation::Create { uuid: uuid1 })?;
+        txn.add_operation(Operation::Create { uuid: uuid2 })?;
+        txn.add_operation(Operation::Create { uuid: uuid3 })?;
+        txn.commit()
+    })?;
 
     // Remove the uuid3 operation.
-    storage
-        .txn(move |txn| {
-            txn.remove_operation(Operation::Create { uuid: uuid3 })?;
-            assert_eq!(txn.num_unsynced_operations()?, 2);
-            txn.commit()
-        })
-        .await?;
+    storage.txn(|txn| {
+        txn.remove_operation(Operation::Create { uuid: uuid3 })?;
+        assert_eq!(txn.num_unsynced_operations()?, 2);
+        txn.commit()
+    })?;
 
     // Remove a nonexistent operation
-    storage
-        .txn(move |txn| {
-            assert!(txn
-                .remove_operation(Operation::Create { uuid: uuid4 })
-                .is_err());
-            Ok(())
-        })
-        .await?;
+    storage.txn(|txn| {
+        assert!(txn
+            .remove_operation(Operation::Create { uuid: uuid4 })
+            .is_err());
+        Ok(())
+    })?;
 
     // Remove an operation that is not most recent.
-    storage
-        .txn(move |txn| {
-            assert!(txn
-                .remove_operation(Operation::Create { uuid: uuid1 })
-                .is_err());
-            Ok(())
-        })
-        .await?;
+    storage.txn(|txn| {
+        assert!(txn
+            .remove_operation(Operation::Create { uuid: uuid1 })
+            .is_err());
+        Ok(())
+    })?;
 
     // Mark operations as synced.
-    storage
-        .txn(move |txn| {
-            txn.sync_complete()?;
-            txn.commit()
-        })
-        .await?;
+    storage.txn(|txn| {
+        txn.sync_complete()?;
+        txn.commit()
+    })?;
 
     // Try to remove the synced operation.
-    storage
-        .txn(move |txn| {
-            assert!(txn
-                .remove_operation(Operation::Create { uuid: uuid2 })
-                .is_err());
-            Ok(())
-        })
-        .await
+    storage.txn(|txn| {
+        assert!(txn
+            .remove_operation(Operation::Create { uuid: uuid2 })
+            .is_err());
+        Ok(())
+    })
 }
 
-pub(super) async fn task_operations(storage: impl Storage) -> Result<()> {
+pub(super) fn task_operations(mut storage: impl Storage) -> Result<()> {
     let uuid1 = Uuid::new_v4();
     let uuid2 = Uuid::new_v4();
     let uuid3 = Uuid::new_v4();
     let now = Utc::now();
 
     // Create some tasks and operations.
-    storage
-        .txn(move |txn| {
-            txn.create_task(uuid1)?;
-            txn.create_task(uuid2)?;
-            txn.create_task(uuid3)?;
+    storage.txn(|txn| {
+        txn.create_task(uuid1)?;
+        txn.create_task(uuid2)?;
+        txn.create_task(uuid3)?;
 
-            txn.add_operation(Operation::UndoPoint)?;
-            txn.add_operation(Operation::Create { uuid: uuid1 })?;
-            txn.add_operation(Operation::Create { uuid: uuid1 })?;
-            txn.add_operation(Operation::UndoPoint)?;
-            txn.add_operation(Operation::Delete {
+        txn.add_operation(Operation::UndoPoint)?;
+        txn.add_operation(Operation::Create { uuid: uuid1 })?;
+        txn.add_operation(Operation::Create { uuid: uuid1 })?;
+        txn.add_operation(Operation::UndoPoint)?;
+        txn.add_operation(Operation::Delete {
+            uuid: uuid2,
+            old_task: TaskMap::new(),
+        })?;
+        txn.add_operation(Operation::Update {
+            uuid: uuid3,
+            property: "p".into(),
+            old_value: None,
+            value: Some("P".into()),
+            timestamp: now,
+        })?;
+        txn.add_operation(Operation::Delete {
+            uuid: uuid3,
+            old_task: TaskMap::new(),
+        })?;
+
+        txn.commit()
+    })?;
+
+    // remove the last operation to verify it doesn't appear
+    storage.txn(|txn| {
+        txn.remove_operation(Operation::Delete {
+            uuid: uuid3,
+            old_task: TaskMap::new(),
+        })?;
+        txn.commit()
+    })?;
+
+    // read them back
+    storage.txn(|txn| {
+        let ops = txn.get_task_operations(uuid1)?;
+        assert_eq!(
+            ops,
+            vec![
+                Operation::Create { uuid: uuid1 },
+                Operation::Create { uuid: uuid1 },
+            ]
+        );
+        let ops = txn.get_task_operations(uuid2)?;
+        assert_eq!(
+            ops,
+            vec![Operation::Delete {
                 uuid: uuid2,
-                old_task: TaskMap::new(),
-            })?;
-            txn.add_operation(Operation::Update {
+                old_task: TaskMap::new()
+            }]
+        );
+        let ops = txn.get_task_operations(uuid3)?;
+        assert_eq!(
+            ops,
+            vec![Operation::Update {
                 uuid: uuid3,
                 property: "p".into(),
                 old_value: None,
                 value: Some("P".into()),
                 timestamp: now,
-            })?;
-            txn.add_operation(Operation::Delete {
-                uuid: uuid3,
-                old_task: TaskMap::new(),
-            })?;
-
-            txn.commit()
-        })
-        .await?;
-
-    // remove the last operation to verify it doesn't appear
-    storage
-        .txn(move |txn| {
-            txn.remove_operation(Operation::Delete {
-                uuid: uuid3,
-                old_task: TaskMap::new(),
-            })?;
-            txn.commit()
-        })
-        .await?;
-
-    // read them back
-    storage
-        .txn(move |txn| {
-            let ops = txn.get_task_operations(uuid1)?;
-            assert_eq!(
-                ops,
-                vec![
-                    Operation::Create { uuid: uuid1 },
-                    Operation::Create { uuid: uuid1 },
-                ]
-            );
-            let ops = txn.get_task_operations(uuid2)?;
-            assert_eq!(
-                ops,
-                vec![Operation::Delete {
-                    uuid: uuid2,
-                    old_task: TaskMap::new()
-                }]
-            );
-            let ops = txn.get_task_operations(uuid3)?;
-            assert_eq!(
-                ops,
-                vec![Operation::Update {
-                    uuid: uuid3,
-                    property: "p".into(),
-                    old_value: None,
-                    value: Some("P".into()),
-                    timestamp: now,
-                }]
-            );
-            Ok(())
-        })
-        .await?;
+            }]
+        );
+        Ok(())
+    })?;
 
     // Sync and verify the task operations still exist.
-    storage
-        .txn(move |txn| {
-            txn.sync_complete()?;
+    storage.txn(|txn| {
+        txn.sync_complete()?;
 
-            let ops = txn.get_task_operations(uuid1)?;
-            assert_eq!(ops.len(), 2);
-            let ops = txn.get_task_operations(uuid2)?;
-            assert_eq!(ops.len(), 1);
-            let ops = txn.get_task_operations(uuid3)?;
-            assert_eq!(ops.len(), 1);
-            Ok(())
-        })
-        .await
+        let ops = txn.get_task_operations(uuid1)?;
+        assert_eq!(ops.len(), 2);
+        let ops = txn.get_task_operations(uuid2)?;
+        assert_eq!(ops.len(), 1);
+        let ops = txn.get_task_operations(uuid3)?;
+        assert_eq!(ops.len(), 1);
+        Ok(())
+    })
 }
 
-pub(super) async fn sync_complete(storage: impl Storage) -> Result<()> {
+pub(super) fn sync_complete(mut storage: impl Storage) -> Result<()> {
     let uuid1 = Uuid::new_v4();
     let uuid2 = Uuid::new_v4();
 
     // Create some tasks and operations.
-    storage
-        .txn(move |txn| {
-            txn.create_task(uuid1)?;
-            txn.create_task(uuid2)?;
+    storage.txn(|txn| {
+        txn.create_task(uuid1)?;
+        txn.create_task(uuid2)?;
 
-            txn.add_operation(Operation::Create { uuid: uuid1 })?;
-            txn.add_operation(Operation::Create { uuid: uuid2 })?;
+        txn.add_operation(Operation::Create { uuid: uuid1 })?;
+        txn.add_operation(Operation::Create { uuid: uuid2 })?;
 
-            txn.commit()
-        })
-        .await?;
+        txn.commit()
+    })?;
 
     // Sync and verify the task operations still exist.
-    storage
-        .txn(move |txn| {
-            txn.sync_complete()?;
+    storage.txn(|txn| {
+        txn.sync_complete()?;
 
-            let ops = txn.get_task_operations(uuid1)?;
-            assert_eq!(ops.len(), 1);
-            let ops = txn.get_task_operations(uuid2)?;
-            assert_eq!(ops.len(), 1);
-            Ok(())
-        })
-        .await?;
+        let ops = txn.get_task_operations(uuid1)?;
+        assert_eq!(ops.len(), 1);
+        let ops = txn.get_task_operations(uuid2)?;
+        assert_eq!(ops.len(), 1);
+        Ok(())
+    })?;
 
     // Delete uuid2.
-    storage
-        .txn(move |txn| {
-            txn.delete_task(uuid2)?;
-            txn.add_operation(Operation::Delete {
-                uuid: uuid2,
-                old_task: TaskMap::new(),
-            })?;
+    storage.txn(|txn| {
+        txn.delete_task(uuid2)?;
+        txn.add_operation(Operation::Delete {
+            uuid: uuid2,
+            old_task: TaskMap::new(),
+        })?;
 
-            txn.commit()
-        })
-        .await?;
+        txn.commit()
+    })?;
 
     // Sync and verify that uuid1's operations still exist, but uuid2's do not.
-    storage
-        .txn(move |txn| {
-            txn.sync_complete()?;
+    storage.txn(|txn| {
+        txn.sync_complete()?;
 
-            let ops = txn.get_task_operations(uuid1)?;
-            assert_eq!(ops.len(), 1);
-            let ops = txn.get_task_operations(uuid2)?;
-            assert_eq!(ops.len(), 0);
-            Ok(())
-        })
-        .await
+        let ops = txn.get_task_operations(uuid1)?;
+        assert_eq!(ops.len(), 1);
+        let ops = txn.get_task_operations(uuid2)?;
+        assert_eq!(ops.len(), 0);
+        Ok(())
+    })
 }
 
-pub(super) async fn set_working_set_item(storage: impl Storage) -> Result<()> {
+pub(super) fn set_working_set_item(mut storage: impl Storage) -> Result<()> {
     let uuid1 = Uuid::new_v4();
     let uuid2 = Uuid::new_v4();
 
-    storage
-        .txn(move |txn| {
-            txn.add_to_working_set(uuid1)?;
-            txn.add_to_working_set(uuid2)?;
-            txn.commit()
-        })
-        .await?;
+    storage.txn(|txn| {
+        txn.add_to_working_set(uuid1)?;
+        txn.add_to_working_set(uuid2)?;
+        txn.commit()
+    })?;
 
-    storage
-        .txn(move |txn| {
-            let ws = txn.get_working_set()?;
-            assert_eq!(ws, vec![None, Some(uuid1), Some(uuid2)]);
-            Ok(())
-        })
-        .await?;
+    storage.txn(|txn| {
+        let ws = txn.get_working_set()?;
+        assert_eq!(ws, vec![None, Some(uuid1), Some(uuid2)]);
+        Ok(())
+    })?;
 
     // Clear one item
-    storage
-        .txn(move |txn| {
-            txn.set_working_set_item(1, None)?;
-            txn.commit()
-        })
-        .await?;
+    storage.txn(|txn| {
+        txn.set_working_set_item(1, None)?;
+        txn.commit()
+    })?;
 
-    storage
-        .txn(move |txn| {
-            let ws = txn.get_working_set()?;
-            assert_eq!(ws, vec![None, None, Some(uuid2)]);
-            Ok(())
-        })
-        .await?;
+    storage.txn(|txn| {
+        let ws = txn.get_working_set()?;
+        assert_eq!(ws, vec![None, None, Some(uuid2)]);
+        Ok(())
+    })?;
 
     // Override item
-    storage
-        .txn(move |txn| {
-            txn.set_working_set_item(2, Some(uuid1))?;
-            txn.commit()
-        })
-        .await?;
+    storage.txn(|txn| {
+        txn.set_working_set_item(2, Some(uuid1))?;
+        txn.commit()
+    })?;
 
-    storage
-        .txn(move |txn| {
-            let ws = txn.get_working_set()?;
-            assert_eq!(ws, vec![None, None, Some(uuid1)]);
-            Ok(())
-        })
-        .await?;
+    storage.txn(|txn| {
+        let ws = txn.get_working_set()?;
+        assert_eq!(ws, vec![None, None, Some(uuid1)]);
+        Ok(())
+    })?;
 
     // Set the last item to None
-    storage
-        .txn(move |txn| {
-            txn.set_working_set_item(1, Some(uuid1))?;
-            txn.set_working_set_item(2, None)?;
-            txn.commit()
-        })
-        .await?;
+    storage.txn(|txn| {
+        txn.set_working_set_item(1, Some(uuid1))?;
+        txn.set_working_set_item(2, None)?;
+        txn.commit()
+    })?;
 
-    storage
-        .txn(move |txn| {
-            let ws = txn.get_working_set()?;
-            // Note no trailing `None`.
-            assert_eq!(ws, vec![None, Some(uuid1)]);
-            Ok(())
-        })
-        .await
+    storage.txn(|txn| {
+        let ws = txn.get_working_set()?;
+        // Note no trailing `None`.
+        assert_eq!(ws, vec![None, Some(uuid1)]);
+        Ok(())
+    })
 }

--- a/src/task/task.rs
+++ b/src/task/task.rs
@@ -584,7 +584,7 @@ impl Task {
 #[allow(deprecated)]
 mod test {
     use super::*;
-    use crate::{storage::InMemoryStorage, Replica};
+    use crate::Replica;
     use pretty_assertions::assert_eq;
     use std::collections::HashSet;
 
@@ -599,7 +599,7 @@ mod test {
         modify: MODIFY,
         assert: ASSERT,
     ) {
-        let mut replica = Replica::<InMemoryStorage>::new_inmemory();
+        let mut replica = Replica::new_inmemory();
         let mut ops = Operations::new();
         let uuid = Uuid::new_v4();
         let mut task = replica.create_task(uuid, &mut ops).unwrap();
@@ -1465,7 +1465,7 @@ mod test {
 
     #[test]
     fn dependencies_tags() {
-        let mut rep = Replica::<InMemoryStorage>::new_inmemory();
+        let mut rep = Replica::new_inmemory();
         let mut ops = Operations::new();
         let (uuid1, uuid2) = (Uuid::new_v4(), Uuid::new_v4());
 

--- a/src/task/task.rs
+++ b/src/task/task.rs
@@ -595,14 +595,14 @@ mod test {
     // Test task mutation by modifying a task and checking the assertions both on the
     // modified task and on a re-loaded task after the operations are committed. Then,
     // apply the same operations again and check that the result is the same.
-    async fn with_mut_task<MODIFY: Fn(&mut Task, &mut Operations), ASSERT: Fn(&Task)>(
+    fn with_mut_task<MODIFY: Fn(&mut Task, &mut Operations), ASSERT: Fn(&Task)>(
         modify: MODIFY,
         assert: ASSERT,
     ) {
-        let mut replica = Replica::new(InMemoryStorage::new());
+        let mut replica = Replica::<InMemoryStorage>::new_inmemory();
         let mut ops = Operations::new();
         let uuid = Uuid::new_v4();
-        let mut task = replica.create_task(uuid, &mut ops).await.unwrap();
+        let mut task = replica.create_task(uuid, &mut ops).unwrap();
 
         // Modify the task
         modify(&mut task, &mut ops);
@@ -610,10 +610,10 @@ mod test {
         // Check assertions about the task before committing it.
         assert(&task);
         println!("commiting operations from first call to modify function");
-        replica.commit_operations(ops).await.unwrap();
+        replica.commit_operations(ops).unwrap();
 
         // Check assertions on task loaded from storage
-        let mut task = replica.get_task(uuid).await.unwrap().unwrap();
+        let mut task = replica.get_task(uuid).unwrap().unwrap();
         assert(&task);
 
         // Apply the operations again, checking that they do not fail.
@@ -623,10 +623,10 @@ mod test {
         // Changes should still be as expected before commit.
         assert(&task);
         println!("commiting operations from second call to modify function");
-        replica.commit_operations(ops).await.unwrap();
+        replica.commit_operations(ops).unwrap();
 
         // Changes should still be as expected when loaded from storage.
-        let task = replica.get_task(uuid).await.unwrap().unwrap();
+        let task = replica.get_task(uuid).unwrap().unwrap();
         assert(&task);
     }
 
@@ -640,14 +640,14 @@ mod test {
         Tag::from_inner(TagInner::Synthetic(synth))
     }
 
-    #[tokio::test]
-    async fn test_is_active_never_started() {
+    #[test]
+    fn test_is_active_never_started() {
         let task = Task::new(TaskData::new(Uuid::new_v4(), TaskMap::new()), dm());
         assert!(!task.is_active());
     }
 
-    #[tokio::test]
-    async fn test_is_active_active() {
+    #[test]
+    fn test_is_active_active() {
         let task = Task::new(
             TaskData::new(
                 Uuid::new_v4(),
@@ -661,20 +661,20 @@ mod test {
         assert!(task.is_active());
     }
 
-    #[tokio::test]
-    async fn test_is_active_inactive() {
+    #[test]
+    fn test_is_active_inactive() {
         let task = Task::new(TaskData::new(Uuid::new_v4(), Default::default()), dm());
         assert!(!task.is_active());
     }
 
-    #[tokio::test]
-    async fn test_entry_not_set() {
+    #[test]
+    fn test_entry_not_set() {
         let task = Task::new(TaskData::new(Uuid::new_v4(), TaskMap::new()), dm());
         assert_eq!(task.get_entry(), None);
     }
 
-    #[tokio::test]
-    async fn test_entry_set() {
+    #[test]
+    fn test_entry_set() {
         let ts = Utc.with_ymd_and_hms(1980, 1, 1, 0, 0, 0).unwrap();
         let task = Task::new(
             TaskData::new(
@@ -688,16 +688,16 @@ mod test {
         assert_eq!(task.get_entry(), Some(ts));
     }
 
-    #[tokio::test]
-    async fn test_wait_not_set() {
+    #[test]
+    fn test_wait_not_set() {
         let task = Task::new(TaskData::new(Uuid::new_v4(), TaskMap::new()), dm());
 
         assert!(!task.is_waiting());
         assert_eq!(task.get_wait(), None);
     }
 
-    #[tokio::test]
-    async fn test_wait_in_past() {
+    #[test]
+    fn test_wait_in_past() {
         let ts = Utc.with_ymd_and_hms(1970, 1, 1, 0, 0, 0).unwrap();
         let task = Task::new(
             TaskData::new(
@@ -713,8 +713,8 @@ mod test {
         assert_eq!(task.get_wait(), Some(ts));
     }
 
-    #[tokio::test]
-    async fn test_wait_in_future() {
+    #[test]
+    fn test_wait_in_future() {
         let ts = Utc.with_ymd_and_hms(3000, 1, 1, 0, 0, 0).unwrap();
         let task = Task::new(
             TaskData::new(
@@ -730,8 +730,8 @@ mod test {
         assert_eq!(task.get_wait(), Some(ts));
     }
 
-    #[tokio::test]
-    async fn test_has_tag() {
+    #[test]
+    fn test_has_tag() {
         let task = Task::new(
             TaskData::new(
                 Uuid::new_v4(),
@@ -752,8 +752,8 @@ mod test {
         assert!(!task.has_tag(&stag(SyntheticTag::Waiting)));
     }
 
-    #[tokio::test]
-    async fn test_get_tags() {
+    #[test]
+    fn test_get_tags() {
         let task = Task::new(
             TaskData::new(
                 Uuid::new_v4(),
@@ -780,8 +780,8 @@ mod test {
         assert_eq!(tags, exp);
     }
 
-    #[tokio::test]
-    async fn test_get_tags_invalid_tags() {
+    #[test]
+    fn test_get_tags_invalid_tags() {
         let task = Task::new(
             TaskData::new(
                 Uuid::new_v4(),
@@ -809,8 +809,8 @@ mod test {
         );
     }
 
-    #[tokio::test]
-    async fn test_get_due() {
+    #[test]
+    fn test_get_due() {
         let test_time = Utc.with_ymd_and_hms(2033, 1, 1, 0, 0, 0).unwrap();
         let task = Task::new(
             TaskData::new(
@@ -824,8 +824,8 @@ mod test {
         assert_eq!(task.get_due(), Some(test_time))
     }
 
-    #[tokio::test]
-    async fn test_get_invalid_due() {
+    #[test]
+    fn test_get_invalid_due() {
         let task = Task::new(
             TaskData::new(
                 Uuid::new_v4(),
@@ -838,25 +838,24 @@ mod test {
         assert_eq!(task.get_due(), None);
     }
 
-    #[tokio::test]
-    async fn test_due_new_task() {
-        with_mut_task(|_task, _ops| {}, |task| assert_eq!(task.get_due(), None)).await;
+    #[test]
+    fn test_due_new_task() {
+        with_mut_task(|_task, _ops| {}, |task| assert_eq!(task.get_due(), None));
     }
 
-    #[tokio::test]
-    async fn test_add_due() {
+    #[test]
+    fn test_add_due() {
         let test_time = Utc.with_ymd_and_hms(2033, 1, 1, 0, 0, 0).unwrap();
         with_mut_task(
             |task, ops| {
                 task.set_due(Some(test_time), ops).unwrap();
             },
             |task| assert_eq!(task.get_due(), Some(test_time)),
-        )
-        .await;
+        );
     }
 
-    #[tokio::test]
-    async fn test_remove_due() {
+    #[test]
+    fn test_remove_due() {
         with_mut_task(
             |task, ops| {
                 task.data.update("due", Some("some-time".into()), ops);
@@ -866,18 +865,17 @@ mod test {
             |task| {
                 assert!(!task.data.has("due"));
             },
-        )
-        .await;
+        );
     }
 
-    #[tokio::test]
-    async fn test_get_priority_default() {
+    #[test]
+    fn test_get_priority_default() {
         let task = Task::new(TaskData::new(Uuid::new_v4(), TaskMap::new()), dm());
         assert_eq!(task.get_priority(), "");
     }
 
-    #[tokio::test]
-    async fn test_get_annotations() {
+    #[test]
+    fn test_get_annotations() {
         let task = Task::new(
             TaskData::new(
                 Uuid::new_v4(),
@@ -916,8 +914,8 @@ mod test {
         );
     }
 
-    #[tokio::test]
-    async fn test_add_annotation() {
+    #[test]
+    fn test_add_annotation() {
         with_mut_task(
             |task, ops| {
                 task.add_annotation(
@@ -933,12 +931,11 @@ mod test {
                 let k = "annotation_1635301900";
                 assert_eq!(task.data.get(k).unwrap(), "right message".to_owned());
             },
-        )
-        .await;
+        );
     }
 
-    #[tokio::test]
-    async fn test_add_annotation_overwrite() {
+    #[test]
+    fn test_add_annotation_overwrite() {
         with_mut_task(
             |task, ops| {
                 task.add_annotation(
@@ -962,12 +959,11 @@ mod test {
                 let k = "annotation_1635301900";
                 assert_eq!(task.data.get(k).unwrap(), "right message 2".to_owned());
             },
-        )
-        .await;
+        );
     }
 
-    #[tokio::test]
-    async fn test_remove_annotation() {
+    #[test]
+    fn test_remove_annotation() {
         with_mut_task(
             |task, ops| {
                 task.data
@@ -987,12 +983,11 @@ mod test {
                 anns.sort();
                 assert_eq!(anns, vec![]);
             },
-        )
-        .await;
+        );
     }
 
-    #[tokio::test]
-    async fn test_set_get_priority() {
+    #[test]
+    fn test_set_get_priority() {
         with_mut_task(
             |task, ops| {
                 task.set_priority("H".into(), ops).unwrap();
@@ -1000,23 +995,21 @@ mod test {
             |task| {
                 assert_eq!(task.get_priority(), "H");
             },
-        )
-        .await;
+        );
     }
 
-    #[tokio::test]
-    async fn test_get_priority_new_task() {
+    #[test]
+    fn test_get_priority_new_task() {
         with_mut_task(
             |_task, _ops| {},
             |task| {
                 assert_eq!(task.get_priority(), "");
             },
-        )
-        .await;
+        );
     }
 
-    #[tokio::test]
-    async fn test_set_status_pending() {
+    #[test]
+    fn test_set_status_pending() {
         with_mut_task(
             |task, ops| {
                 task.data.update("status", Some("completed".into()), ops);
@@ -1030,12 +1023,11 @@ mod test {
                 assert!(task.has_tag(&stag(SyntheticTag::Pending)));
                 assert!(!task.has_tag(&stag(SyntheticTag::Completed)));
             },
-        )
-        .await;
+        );
     }
 
-    #[tokio::test]
-    async fn test_set_status_recurring() {
+    #[test]
+    fn test_set_status_recurring() {
         with_mut_task(
             |task, ops| {
                 task.data.update("status", Some("completed".into()), ops);
@@ -1048,12 +1040,11 @@ mod test {
                 assert!(!task.has_tag(&stag(SyntheticTag::Pending))); // recurring is not +PENDING
                 assert!(!task.has_tag(&stag(SyntheticTag::Completed)));
             },
-        )
-        .await;
+        );
     }
 
-    #[tokio::test]
-    async fn test_set_status_completed() {
+    #[test]
+    fn test_set_status_completed() {
         with_mut_task(
             |task, ops| {
                 task.set_status(Status::Completed, ops).unwrap();
@@ -1064,12 +1055,11 @@ mod test {
                 assert!(!task.has_tag(&stag(SyntheticTag::Pending)));
                 assert!(task.has_tag(&stag(SyntheticTag::Completed)));
             },
-        )
-        .await;
+        );
     }
 
-    #[tokio::test]
-    async fn test_set_status_deleted() {
+    #[test]
+    fn test_set_status_deleted() {
         with_mut_task(
             |task, ops| {
                 task.set_status(Status::Deleted, ops).unwrap();
@@ -1080,12 +1070,11 @@ mod test {
                 assert!(!task.has_tag(&stag(SyntheticTag::Pending)));
                 assert!(!task.has_tag(&stag(SyntheticTag::Completed)));
             },
-        )
-        .await;
+        );
     }
 
-    #[tokio::test]
-    async fn test_set_get_value() {
+    #[test]
+    fn test_set_get_value() {
         let property = "property-name";
         with_mut_task(
             |task, ops| {
@@ -1094,12 +1083,11 @@ mod test {
             |task| {
                 assert_eq!(task.get_value(property), Some("value"));
             },
-        )
-        .await;
+        );
     }
 
-    #[tokio::test]
-    async fn test_set_get_value_none() {
+    #[test]
+    fn test_set_get_value_none() {
         let property = "property-name";
         with_mut_task(
             |task, ops| {
@@ -1109,12 +1097,11 @@ mod test {
             |task| {
                 assert_eq!(task.get_value(property), None);
             },
-        )
-        .await;
+        );
     }
 
-    #[tokio::test]
-    async fn test_start() {
+    #[test]
+    fn test_start() {
         with_mut_task(
             |task, ops| {
                 task.start(ops).unwrap();
@@ -1122,12 +1109,11 @@ mod test {
             |task| {
                 assert!(task.data.has("start"));
             },
-        )
-        .await;
+        );
     }
 
-    #[tokio::test]
-    async fn test_stop() {
+    #[test]
+    fn test_stop() {
         with_mut_task(
             |task, ops| {
                 task.data.update("start", Some("right now".into()), ops);
@@ -1136,12 +1122,11 @@ mod test {
             |task| {
                 assert!(!task.data.has("start"));
             },
-        )
-        .await;
+        );
     }
 
-    #[tokio::test]
-    async fn test_done() {
+    #[test]
+    fn test_done() {
         with_mut_task(
             |task, ops| {
                 task.done(ops).unwrap();
@@ -1151,12 +1136,11 @@ mod test {
                 assert!(task.data.has("end"));
                 assert!(task.has_tag(&stag(SyntheticTag::Completed)));
             },
-        )
-        .await;
+        );
     }
 
-    #[tokio::test]
-    async fn test_delete() {
+    #[test]
+    fn test_delete() {
         with_mut_task(
             |task, ops| {
                 #[allow(deprecated)]
@@ -1167,12 +1151,11 @@ mod test {
                 assert!(task.data.has("end"));
                 assert!(!task.has_tag(&stag(SyntheticTag::Completed)));
             },
-        )
-        .await;
+        );
     }
 
-    #[tokio::test]
-    async fn test_add_tags() {
+    #[test]
+    fn test_add_tags() {
         with_mut_task(
             |task, ops| {
                 task.add_tag(&utag("abc"), ops).unwrap();
@@ -1181,12 +1164,11 @@ mod test {
                 assert!(task.data.has("tag_abc"));
                 assert!(task.has_tag(&utag("abc")));
             },
-        )
-        .await;
+        );
     }
 
-    #[tokio::test]
-    async fn test_remove_tags() {
+    #[test]
+    fn test_remove_tags() {
         with_mut_task(
             |task, ops| {
                 task.data.update("tag_abc", Some("x".into()), ops);
@@ -1195,12 +1177,11 @@ mod test {
             |task| {
                 assert!(!task.data.has("tag_abc"));
             },
-        )
-        .await;
+        );
     }
 
-    #[tokio::test]
-    async fn test_get_udas() {
+    #[test]
+    fn test_get_udas() {
         let task = Task::new(
             TaskData::new(
                 Uuid::new_v4(),
@@ -1231,8 +1212,8 @@ mod test {
         );
     }
 
-    #[tokio::test]
-    async fn test_get_uda() {
+    #[test]
+    fn test_get_uda() {
         let task = Task::new(
             TaskData::new(
                 Uuid::new_v4(),
@@ -1253,8 +1234,8 @@ mod test {
         assert_eq!(task.get_uda("bugzilla", "url"), None);
     }
 
-    #[tokio::test]
-    async fn test_get_legacy_uda() {
+    #[test]
+    fn test_get_legacy_uda() {
         let task = Task::new(
             TaskData::new(
                 Uuid::new_v4(),
@@ -1277,8 +1258,8 @@ mod test {
         assert_eq!(task.get_legacy_uda("bugzilla.url"), None);
     }
 
-    #[tokio::test]
-    async fn test_get_user_defined_attribute() {
+    #[test]
+    fn test_get_user_defined_attribute() {
         let task = Task::new(
             TaskData::new(
                 Uuid::new_v4(),
@@ -1301,8 +1282,8 @@ mod test {
         assert_eq!(task.get_user_defined_attribute("bugzilla.url"), None);
     }
 
-    #[tokio::test]
-    async fn test_set_uda() {
+    #[test]
+    fn test_set_uda() {
         with_mut_task(
             |task, ops| {
                 task.set_uda("jira", "url", "h://y", ops).unwrap();
@@ -1317,11 +1298,10 @@ mod test {
                 );
             },
         )
-        .await
     }
 
-    #[tokio::test]
-    async fn test_set_legacy_uda() {
+    #[test]
+    fn test_set_legacy_uda() {
         with_mut_task(
             |task, ops| {
                 task.set_legacy_uda("jira.url", "h://y", ops).unwrap();
@@ -1336,11 +1316,10 @@ mod test {
                 );
             },
         )
-        .await
     }
 
-    #[tokio::test]
-    async fn test_set_user_defined_attribute() {
+    #[test]
+    fn test_set_user_defined_attribute() {
         with_mut_task(
             |task, ops| {
                 task.set_user_defined_attribute("jira.url", "h://y", ops)
@@ -1357,11 +1336,10 @@ mod test {
                 );
             },
         )
-        .await
     }
 
-    #[tokio::test]
-    async fn test_set_uda_invalid() {
+    #[test]
+    fn test_set_uda_invalid() {
         with_mut_task(
             |task, ops| {
                 assert!(task.set_uda("", "modified", "123", ops).is_err());
@@ -1377,11 +1355,10 @@ mod test {
             },
             |_task| {},
         )
-        .await
     }
 
-    #[tokio::test]
-    async fn test_remove_uda() {
+    #[test]
+    fn test_remove_uda() {
         with_mut_task(
             |task, ops| {
                 task.data.update("github.id", Some("123".into()), ops);
@@ -1392,11 +1369,10 @@ mod test {
                 assert_eq!(udas, vec![]);
             },
         )
-        .await
     }
 
-    #[tokio::test]
-    async fn test_remove_legacy_uda() {
+    #[test]
+    fn test_remove_legacy_uda() {
         with_mut_task(
             |task, ops| {
                 task.data.update("githubid", Some("123".into()), ops);
@@ -1407,11 +1383,10 @@ mod test {
                 assert_eq!(udas, vec![]);
             },
         )
-        .await
     }
 
-    #[tokio::test]
-    async fn test_remove_user_defined_attribute() {
+    #[test]
+    fn test_remove_user_defined_attribute() {
         with_mut_task(
             |task, ops| {
                 task.data.update("githubid", Some("123".into()), ops);
@@ -1422,11 +1397,10 @@ mod test {
                 assert_eq!(udas, vec![]);
             },
         )
-        .await
     }
 
-    #[tokio::test]
-    async fn test_remove_uda_invalid() {
+    #[test]
+    fn test_remove_uda_invalid() {
         with_mut_task(
             |task, ops| {
                 assert!(task.remove_uda("", "modified", ops).is_err());
@@ -1438,11 +1412,10 @@ mod test {
             },
             |_task| {},
         )
-        .await
     }
 
-    #[tokio::test]
-    async fn test_dependencies_one() {
+    #[test]
+    fn test_dependencies_one() {
         let dep1 = Uuid::new_v4();
         with_mut_task(
             |task, ops| {
@@ -1453,11 +1426,10 @@ mod test {
                 assert!(deps.contains(&dep1));
             },
         )
-        .await
     }
 
-    #[tokio::test]
-    async fn test_dependencies_two() {
+    #[test]
+    fn test_dependencies_two() {
         let dep1 = Uuid::new_v4();
         let dep2 = Uuid::new_v4();
         with_mut_task(
@@ -1471,11 +1443,10 @@ mod test {
                 assert!(deps.contains(&dep2));
             },
         )
-        .await
     }
 
-    #[tokio::test]
-    async fn test_dependencies_removed() {
+    #[test]
+    fn test_dependencies_removed() {
         let dep1 = Uuid::new_v4();
         let dep2 = Uuid::new_v4();
         with_mut_task(
@@ -1490,29 +1461,28 @@ mod test {
                 assert!(!deps.contains(&dep2));
             },
         )
-        .await
     }
 
-    #[tokio::test]
-    async fn dependencies_tags() {
-        let mut rep = Replica::new(InMemoryStorage::new());
+    #[test]
+    fn dependencies_tags() {
+        let mut rep = Replica::<InMemoryStorage>::new_inmemory();
         let mut ops = Operations::new();
         let (uuid1, uuid2) = (Uuid::new_v4(), Uuid::new_v4());
 
-        let mut t1 = rep.create_task(uuid1, &mut ops).await.unwrap();
+        let mut t1 = rep.create_task(uuid1, &mut ops).unwrap();
         t1.set_status(Status::Pending, &mut ops).unwrap();
         t1.add_dependency(uuid2, &mut ops).unwrap();
 
-        let mut t2 = rep.create_task(uuid2, &mut ops).await.unwrap();
+        let mut t2 = rep.create_task(uuid2, &mut ops).unwrap();
         t2.set_status(Status::Pending, &mut ops).unwrap();
 
-        rep.commit_operations(ops).await.unwrap();
+        rep.commit_operations(ops).unwrap();
 
         // force-refresh depmap
-        rep.dependency_map(true).await.unwrap();
+        rep.dependency_map(true).unwrap();
 
-        let t1 = rep.get_task(uuid1).await.unwrap().unwrap();
-        let t2 = rep.get_task(uuid2).await.unwrap().unwrap();
+        let t1 = rep.get_task(uuid1).unwrap().unwrap();
+        let t2 = rep.get_task(uuid2).unwrap().unwrap();
         assert!(t1.has_tag(&stag(SyntheticTag::Blocked)));
         assert!(!t1.has_tag(&stag(SyntheticTag::Unblocked)));
         assert!(!t1.has_tag(&stag(SyntheticTag::Blocking)));
@@ -1521,8 +1491,8 @@ mod test {
         assert!(t2.has_tag(&stag(SyntheticTag::Blocking)));
     }
 
-    #[tokio::test]
-    async fn set_value_modified() {
+    #[test]
+    fn set_value_modified() {
         with_mut_task(
             |task, ops| {
                 // set the modified property to something in the past..
@@ -1536,6 +1506,5 @@ mod test {
                 assert_eq!(task.get_value("modified").unwrap(), "1671820000")
             },
         )
-        .await
     }
 }

--- a/src/taskdb/mod.rs
+++ b/src/taskdb/mod.rs
@@ -2,8 +2,9 @@ use std::collections::HashSet;
 
 use crate::errors::Result;
 use crate::operation::Operation;
+use crate::server::Server;
 use crate::storage::{StorageTxn, TaskMap};
-use crate::{Operations, Server};
+use crate::Operations;
 use uuid::Uuid;
 
 mod apply;
@@ -18,6 +19,11 @@ mod working_set;
 pub(crate) struct TaskDb;
 
 impl TaskDb {
+    /// Create a new TaskDb with the given backend storage
+    pub(crate) fn new() -> TaskDb {
+        TaskDb {}
+    }
+
     /// Apply `operations` to the database in a single transaction.
     ///
     /// The operations will be appended to the list of local operations, and the set of tasks will
@@ -26,6 +32,7 @@ impl TaskDb {
     /// Any operations for which `add_to_working_set` returns true will cause the relevant
     /// task to be added to the working set.
     pub(crate) fn commit_operations<F>(
+        &mut self,
         txn: &mut dyn StorageTxn,
         operations: Operations,
         add_to_working_set: F,
@@ -65,31 +72,42 @@ impl TaskDb {
     }
 
     /// Get all tasks.
-    pub(crate) fn all_tasks(txn: &mut dyn StorageTxn) -> Result<Vec<(Uuid, TaskMap)>> {
+    pub(crate) fn all_tasks(&mut self, txn: &mut dyn StorageTxn) -> Result<Vec<(Uuid, TaskMap)>> {
         txn.all_tasks()
     }
 
     /// Get the UUIDs of all tasks
-    pub(crate) fn all_task_uuids(txn: &mut dyn StorageTxn) -> Result<Vec<Uuid>> {
+    pub(crate) fn all_task_uuids(&mut self, txn: &mut dyn StorageTxn) -> Result<Vec<Uuid>> {
         txn.all_task_uuids()
     }
 
     /// Get the working set
-    pub(crate) fn working_set(txn: &mut dyn StorageTxn) -> Result<Vec<Option<Uuid>>> {
+    pub(crate) fn working_set(&mut self, txn: &mut dyn StorageTxn) -> Result<Vec<Option<Uuid>>> {
         txn.get_working_set()
     }
 
     /// Get a single task, by uuid.
-    pub(crate) fn get_task(txn: &mut dyn StorageTxn, uuid: Uuid) -> Result<Option<TaskMap>> {
+    pub(crate) fn get_task(
+        &mut self,
+        txn: &mut dyn StorageTxn,
+        uuid: Uuid,
+    ) -> Result<Option<TaskMap>> {
         txn.get_task(uuid)
     }
 
     /// Get all pending tasks from the working set
-    pub(crate) fn get_pending_tasks(txn: &mut dyn StorageTxn) -> Result<Vec<(Uuid, TaskMap)>> {
+    pub(crate) fn get_pending_tasks(
+        &mut self,
+        txn: &mut dyn StorageTxn,
+    ) -> Result<Vec<(Uuid, TaskMap)>> {
         txn.get_pending_tasks()
     }
 
-    pub(crate) fn get_task_operations(txn: &mut dyn StorageTxn, uuid: Uuid) -> Result<Operations> {
+    pub(crate) fn get_task_operations(
+        &mut self,
+        txn: &mut dyn StorageTxn,
+        uuid: Uuid,
+    ) -> Result<Operations> {
         txn.get_task_operations(uuid)
     }
 
@@ -98,6 +116,7 @@ impl TaskDb {
     /// are not already in the working set but should be.  The rebuild occurs in a single
     /// trasnsaction against the storage backend.
     pub(crate) fn rebuild_working_set<F>(
+        &mut self,
         txn: &mut dyn StorageTxn,
         in_working_set: F,
         renumber: bool,
@@ -117,8 +136,9 @@ impl TaskDb {
     /// Set this to true on systems more constrained in CPU, memory, or bandwidth than a typical desktop
     /// system
     pub(crate) fn sync(
+        &mut self,
         txn: &mut dyn StorageTxn,
-        server: &mut dyn Server,
+        server: &mut Box<dyn Server>,
         avoid_snapshots: bool,
     ) -> Result<()> {
         sync::sync(server, txn, avoid_snapshots)
@@ -129,7 +149,7 @@ impl TaskDb {
     ///
     /// The operations are returned in the order they were applied. Use
     /// [`commit_reversed_operations`] to "undo" them.
-    pub(crate) fn get_undo_operations(txn: &mut dyn StorageTxn) -> Result<Operations> {
+    pub(crate) fn get_undo_operations(&mut self, txn: &mut dyn StorageTxn) -> Result<Operations> {
         undo::get_undo_operations(txn)
     }
 
@@ -139,6 +159,7 @@ impl TaskDb {
     /// This method only supports reversing operations if they precisely match local operations
     /// that have not yet been synchronized, and will return `false` if this is not the case.
     pub(crate) fn commit_reversed_operations(
+        &mut self,
         txn: &mut dyn StorageTxn,
         undo_ops: Operations,
     ) -> Result<bool> {
@@ -147,7 +168,7 @@ impl TaskDb {
 
     /// Get the number of un-synchronized operations in storage, excluding undo
     /// operations.
-    pub(crate) fn num_operations(txn: &mut dyn StorageTxn) -> Result<usize> {
+    pub(crate) fn num_operations(&mut self, txn: &mut dyn StorageTxn) -> Result<usize> {
         Ok(txn
             .unsynced_operations()?
             .iter()
@@ -156,7 +177,7 @@ impl TaskDb {
     }
 
     /// Get the number of (un-synchronized) undo points in storage.
-    pub(crate) fn num_undo_points(txn: &mut dyn StorageTxn) -> Result<usize> {
+    pub(crate) fn num_undo_points(&mut self, txn: &mut dyn StorageTxn) -> Result<usize> {
         Ok(txn
             .unsynced_operations()?
             .iter()
@@ -167,8 +188,12 @@ impl TaskDb {
     // functions for supporting tests
 
     #[cfg(test)]
-    pub(crate) fn sorted_tasks(txn: &mut dyn StorageTxn) -> Vec<(Uuid, Vec<(String, String)>)> {
-        let mut res: Vec<(Uuid, Vec<(String, String)>)> = TaskDb::all_tasks(txn)
+    pub(crate) fn sorted_tasks(
+        &mut self,
+        txn: &mut dyn StorageTxn,
+    ) -> Vec<(Uuid, Vec<(String, String)>)> {
+        let mut res: Vec<(Uuid, Vec<(String, String)>)> = self
+            .all_tasks(txn)
             .unwrap()
             .iter()
             .map(|(u, t)| {
@@ -185,7 +210,7 @@ impl TaskDb {
     }
 
     #[cfg(test)]
-    pub(crate) fn operations(txn: &mut dyn StorageTxn) -> Vec<Operation> {
+    pub(crate) fn operations(&mut self, txn: &mut dyn StorageTxn) -> Vec<Operation> {
         txn.unsynced_operations().unwrap().to_vec()
     }
 }
@@ -198,9 +223,10 @@ mod tests {
     use pretty_assertions::assert_eq;
     use uuid::Uuid;
 
-    #[tokio::test]
-    async fn commit_operations() -> Result<()> {
-        let storage = InMemoryStorage::new();
+    #[test]
+    fn commit_operations() -> Result<()> {
+        let mut storage = InMemoryStorage::new();
+        let mut db = TaskDb::new();
         let uuid = Uuid::new_v4();
         let now = Utc::now();
         let mut ops = Operations::new();
@@ -213,47 +239,44 @@ mod tests {
             old_value: Some("old".into()),
         });
 
-        storage
-            .txn(move |txn| {
-                TaskDb::commit_operations(txn, ops, |_| false)?;
+        storage.txn(|txn| {
+            db.commit_operations(txn, ops, |_| false)?;
 
-                assert_eq!(
-                    TaskDb::sorted_tasks(txn),
-                    vec![(uuid, vec![("title".into(), "my task".into())])]
-                );
-                assert_eq!(
-                    TaskDb::operations(txn),
-                    vec![
-                        Operation::Create { uuid },
-                        Operation::Update {
-                            uuid,
-                            property: String::from("title"),
-                            value: Some("my task".into()),
-                            timestamp: now,
-                            old_value: Some("old".into()),
-                        },
-                    ]
-                );
-                Ok(())
-            })
-            .await
+            assert_eq!(
+                db.sorted_tasks(txn),
+                vec![(uuid, vec![("title".into(), "my task".into())])]
+            );
+            assert_eq!(
+                db.operations(txn),
+                vec![
+                    Operation::Create { uuid },
+                    Operation::Update {
+                        uuid,
+                        property: String::from("title"),
+                        value: Some("my task".into()),
+                        timestamp: now,
+                        old_value: Some("old".into()),
+                    },
+                ]
+            );
+            Ok(())
+        })
     }
 
-    #[tokio::test]
-    async fn commit_operations_update_working_set() -> Result<()> {
-        let storage = InMemoryStorage::new();
+    #[test]
+    fn commit_operations_update_working_set() -> Result<()> {
+        let mut storage = InMemoryStorage::new();
+        let mut db = TaskDb::new();
         let mut uuids = [Uuid::new_v4(), Uuid::new_v4(), Uuid::new_v4()];
         uuids.sort();
         let [uuid1, uuid2, uuid3] = uuids;
 
         // uuid1 already exists in the working set.
 
-        storage
-            .txn(move |txn| {
-                txn.add_to_working_set(uuid1)?;
-                txn.commit()
-            })
-            .await?;
+        storage.txn(|txn| {
+            txn.add_to_working_set(uuid1)?;
+            txn.commit()
+        })?;
 
         let mut ops = Operations::new();
         ops.push(Operation::Create { uuid: uuid1 });
@@ -263,42 +286,38 @@ mod tests {
         ops.push(Operation::Create { uuid: uuid3 });
 
         // return true for updates to uuid1 or uuid2.
-        let add_to_working_set = move |op: &Operation| match op {
+        let add_to_working_set = |op: &Operation| match op {
             Operation::Create { uuid } => *uuid == uuid1 || *uuid == uuid2,
             _ => false,
         };
-        storage
-            .txn(move |txn| {
-                TaskDb::commit_operations(txn, ops, add_to_working_set)?;
+        storage.txn(|txn| {
+            db.commit_operations(txn, ops, add_to_working_set)?;
 
-                assert_eq!(
-                    TaskDb::sorted_tasks(txn),
-                    vec![(uuid1, vec![]), (uuid2, vec![]), (uuid3, vec![]),]
-                );
-                assert_eq!(
-                    TaskDb::operations(txn),
-                    vec![
-                        Operation::Create { uuid: uuid1 },
-                        Operation::Create { uuid: uuid2 },
-                        Operation::Create { uuid: uuid3 },
-                        Operation::Create { uuid: uuid2 },
-                        Operation::Create { uuid: uuid3 },
-                    ]
-                );
+            assert_eq!(
+                db.sorted_tasks(txn),
+                vec![(uuid1, vec![]), (uuid2, vec![]), (uuid3, vec![]),]
+            );
+            assert_eq!(
+                db.operations(txn),
+                vec![
+                    Operation::Create { uuid: uuid1 },
+                    Operation::Create { uuid: uuid2 },
+                    Operation::Create { uuid: uuid3 },
+                    Operation::Create { uuid: uuid2 },
+                    Operation::Create { uuid: uuid3 },
+                ]
+            );
 
-                // uuid2 was added to the working set, once, and uuid3 was not.
-                assert_eq!(
-                    TaskDb::working_set(txn)?,
-                    vec![None, Some(uuid1), Some(uuid2)],
-                );
-                Ok(())
-            })
-            .await
+            // uuid2 was added to the working set, once, and uuid3 was not.
+            assert_eq!(db.working_set(txn)?, vec![None, Some(uuid1), Some(uuid2)],);
+            Ok(())
+        })
     }
 
-    #[tokio::test]
-    async fn test_num_operations() -> Result<()> {
-        let storage = InMemoryStorage::new();
+    #[test]
+    fn test_num_operations() -> Result<()> {
+        let mut storage = InMemoryStorage::new();
+        let mut db = TaskDb::new();
         let mut ops = Operations::new();
         ops.push(Operation::Create {
             uuid: Uuid::new_v4(),
@@ -307,33 +326,30 @@ mod tests {
         ops.push(Operation::Create {
             uuid: Uuid::new_v4(),
         });
-        storage
-            .txn(move |txn| {
-                TaskDb::commit_operations(txn, ops, |_| false).unwrap();
-                assert_eq!(TaskDb::num_operations(txn).unwrap(), 2);
+        storage.txn(|txn| {
+            db.commit_operations(txn, ops, |_| false).unwrap();
+            assert_eq!(db.num_operations(txn).unwrap(), 2);
 
-                Ok(())
-            })
-            .await
+            Ok(())
+        })
     }
 
-    #[tokio::test]
-    async fn test_num_undo_points() -> Result<()> {
-        let storage = InMemoryStorage::new();
-        storage
-            .txn(|txn| {
-                let mut ops = Operations::new();
-                ops.push(Operation::UndoPoint);
-                TaskDb::commit_operations(txn, ops, |_| false).unwrap();
-                assert_eq!(TaskDb::num_undo_points(txn).unwrap(), 1);
+    #[test]
+    fn test_num_undo_points() -> Result<()> {
+        let mut storage = InMemoryStorage::new();
+        let mut db = TaskDb::new();
+        storage.txn(|txn| {
+            let mut ops = Operations::new();
+            ops.push(Operation::UndoPoint);
+            db.commit_operations(txn, ops, |_| false).unwrap();
+            assert_eq!(db.num_undo_points(txn).unwrap(), 1);
 
-                let mut ops = Operations::new();
-                ops.push(Operation::UndoPoint);
-                TaskDb::commit_operations(txn, ops, |_| false).unwrap();
-                assert_eq!(TaskDb::num_undo_points(txn).unwrap(), 2);
+            let mut ops = Operations::new();
+            ops.push(Operation::UndoPoint);
+            db.commit_operations(txn, ops, |_| false).unwrap();
+            assert_eq!(db.num_undo_points(txn).unwrap(), 2);
 
-                Ok(())
-            })
-            .await
+            Ok(())
+        })
     }
 }

--- a/src/taskdb/mod.rs
+++ b/src/taskdb/mod.rs
@@ -218,14 +218,14 @@ impl TaskDb {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::storage::{InMemoryStorage, Storage};
+    use crate::StorageConfig;
     use chrono::Utc;
     use pretty_assertions::assert_eq;
     use uuid::Uuid;
 
     #[test]
     fn commit_operations() -> Result<()> {
-        let mut storage = InMemoryStorage::new();
+        let mut storage = StorageConfig::InMemory.into_storage().unwrap();
         let mut db = TaskDb::new();
         let uuid = Uuid::new_v4();
         let now = Utc::now();
@@ -239,44 +239,43 @@ mod tests {
             old_value: Some("old".into()),
         });
 
-        storage.txn(|txn| {
-            db.commit_operations(txn, ops, |_| false)?;
+        let mut txn = storage.txn()?;
+        db.commit_operations(txn.as_mut(), ops, |_| false)?;
 
-            assert_eq!(
-                db.sorted_tasks(txn),
-                vec![(uuid, vec![("title".into(), "my task".into())])]
-            );
-            assert_eq!(
-                db.operations(txn),
-                vec![
-                    Operation::Create { uuid },
-                    Operation::Update {
-                        uuid,
-                        property: String::from("title"),
-                        value: Some("my task".into()),
-                        timestamp: now,
-                        old_value: Some("old".into()),
-                    },
-                ]
-            );
-            Ok(())
-        })
+        assert_eq!(
+            db.sorted_tasks(txn.as_mut()),
+            vec![(uuid, vec![("title".into(), "my task".into())])]
+        );
+        assert_eq!(
+            db.operations(txn.as_mut()),
+            vec![
+                Operation::Create { uuid },
+                Operation::Update {
+                    uuid,
+                    property: String::from("title"),
+                    value: Some("my task".into()),
+                    timestamp: now,
+                    old_value: Some("old".into()),
+                },
+            ]
+        );
+        Ok(())
     }
 
     #[test]
     fn commit_operations_update_working_set() -> Result<()> {
-        let mut storage = InMemoryStorage::new();
+        let mut storage = StorageConfig::InMemory.into_storage().unwrap();
         let mut db = TaskDb::new();
         let mut uuids = [Uuid::new_v4(), Uuid::new_v4(), Uuid::new_v4()];
         uuids.sort();
         let [uuid1, uuid2, uuid3] = uuids;
 
         // uuid1 already exists in the working set.
-
-        storage.txn(|txn| {
+        {
+            let mut txn = storage.txn()?;
             txn.add_to_working_set(uuid1)?;
-            txn.commit()
-        })?;
+            txn.commit()?;
+        }
 
         let mut ops = Operations::new();
         ops.push(Operation::Create { uuid: uuid1 });
@@ -290,33 +289,35 @@ mod tests {
             Operation::Create { uuid } => *uuid == uuid1 || *uuid == uuid2,
             _ => false,
         };
-        storage.txn(|txn| {
-            db.commit_operations(txn, ops, add_to_working_set)?;
+        let mut txn = storage.txn()?;
+        db.commit_operations(txn.as_mut(), ops, add_to_working_set)?;
 
-            assert_eq!(
-                db.sorted_tasks(txn),
-                vec![(uuid1, vec![]), (uuid2, vec![]), (uuid3, vec![]),]
-            );
-            assert_eq!(
-                db.operations(txn),
-                vec![
-                    Operation::Create { uuid: uuid1 },
-                    Operation::Create { uuid: uuid2 },
-                    Operation::Create { uuid: uuid3 },
-                    Operation::Create { uuid: uuid2 },
-                    Operation::Create { uuid: uuid3 },
-                ]
-            );
+        assert_eq!(
+            db.sorted_tasks(txn.as_mut()),
+            vec![(uuid1, vec![]), (uuid2, vec![]), (uuid3, vec![]),]
+        );
+        assert_eq!(
+            db.operations(txn.as_mut()),
+            vec![
+                Operation::Create { uuid: uuid1 },
+                Operation::Create { uuid: uuid2 },
+                Operation::Create { uuid: uuid3 },
+                Operation::Create { uuid: uuid2 },
+                Operation::Create { uuid: uuid3 },
+            ]
+        );
 
-            // uuid2 was added to the working set, once, and uuid3 was not.
-            assert_eq!(db.working_set(txn)?, vec![None, Some(uuid1), Some(uuid2)],);
-            Ok(())
-        })
+        // uuid2 was added to the working set, once, and uuid3 was not.
+        assert_eq!(
+            db.working_set(txn.as_mut())?,
+            vec![None, Some(uuid1), Some(uuid2)],
+        );
+        Ok(())
     }
 
     #[test]
     fn test_num_operations() -> Result<()> {
-        let mut storage = InMemoryStorage::new();
+        let mut storage = StorageConfig::InMemory.into_storage().unwrap();
         let mut db = TaskDb::new();
         let mut ops = Operations::new();
         ops.push(Operation::Create {
@@ -326,30 +327,29 @@ mod tests {
         ops.push(Operation::Create {
             uuid: Uuid::new_v4(),
         });
-        storage.txn(|txn| {
-            db.commit_operations(txn, ops, |_| false).unwrap();
-            assert_eq!(db.num_operations(txn).unwrap(), 2);
+        let mut txn = storage.txn()?;
+        db.commit_operations(txn.as_mut(), ops, |_| false).unwrap();
+        assert_eq!(db.num_operations(txn.as_mut()).unwrap(), 2);
 
-            Ok(())
-        })
+        Ok(())
     }
 
     #[test]
     fn test_num_undo_points() -> Result<()> {
-        let mut storage = InMemoryStorage::new();
+        let mut storage = StorageConfig::InMemory.into_storage().unwrap();
         let mut db = TaskDb::new();
-        storage.txn(|txn| {
-            let mut ops = Operations::new();
-            ops.push(Operation::UndoPoint);
-            db.commit_operations(txn, ops, |_| false).unwrap();
-            assert_eq!(db.num_undo_points(txn).unwrap(), 1);
+        let mut txn = storage.txn()?;
 
-            let mut ops = Operations::new();
-            ops.push(Operation::UndoPoint);
-            db.commit_operations(txn, ops, |_| false).unwrap();
-            assert_eq!(db.num_undo_points(txn).unwrap(), 2);
+        let mut ops = Operations::new();
+        ops.push(Operation::UndoPoint);
+        db.commit_operations(txn.as_mut(), ops, |_| false).unwrap();
+        assert_eq!(db.num_undo_points(txn.as_mut()).unwrap(), 1);
 
-            Ok(())
-        })
+        let mut ops = Operations::new();
+        ops.push(Operation::UndoPoint);
+        db.commit_operations(txn.as_mut(), ops, |_| false).unwrap();
+        assert_eq!(db.num_undo_points(txn.as_mut()).unwrap(), 2);
+
+        Ok(())
     }
 }

--- a/src/taskdb/snapshot.rs
+++ b/src/taskdb/snapshot.rs
@@ -111,7 +111,7 @@ pub(super) fn apply_snapshot(
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::storage::{InMemoryStorage, Storage, TaskMap};
+    use crate::{storage::TaskMap, StorageConfig};
     use pretty_assertions::assert_eq;
 
     #[test]
@@ -137,7 +137,7 @@ mod test {
 
     #[test]
     fn test_round_trip() -> Result<()> {
-        let mut storage = InMemoryStorage::new();
+        let mut storage = StorageConfig::InMemory.into_storage().unwrap();
         let version = Uuid::new_v4();
 
         let task1 = (
@@ -153,30 +153,36 @@ mod test {
                 .collect::<TaskMap>(),
         );
 
-        storage.txn(|txn| {
+        {
+            let mut txn = storage.txn()?;
             txn.set_task(task1.0, task1.1.clone())?;
             txn.set_task(task2.0, task2.1.clone())?;
-            txn.commit()
-        })?;
+            txn.commit()?;
+        }
 
-        let snap = storage.txn(|txn| make_snapshot(txn))?;
+        let snap = {
+            let mut txn = storage.txn()?;
+            make_snapshot(txn.as_mut())?
+        };
 
         // apply that snapshot to a fresh bit of fake
-        let mut storage = InMemoryStorage::new();
+        let mut storage = StorageConfig::InMemory.into_storage().unwrap();
+        {
+            let mut txn = storage.txn()?;
+            apply_snapshot(txn.as_mut(), version, &snap)?;
+            txn.commit()?
+        }
 
-        storage.txn(|txn| {
-            apply_snapshot(txn, version, &snap)?;
-            txn.commit()
-        })?;
-
-        storage.txn(|txn| {
+        {
+            let mut txn = storage.txn()?;
             assert_eq!(txn.get_task(task1.0)?, Some(task1.1));
             assert_eq!(txn.get_task(task2.0)?, Some(task2.1));
             assert_eq!(txn.all_tasks()?.len(), 2);
             assert_eq!(txn.base_version()?, version);
             assert_eq!(txn.unsynced_operations()?.len(), 0);
             assert_eq!(txn.get_working_set()?.len(), 1);
-            Ok(())
-        })
+        }
+
+        Ok(())
     }
 }

--- a/src/taskdb/snapshot.rs
+++ b/src/taskdb/snapshot.rs
@@ -135,9 +135,9 @@ mod test {
         Ok(())
     }
 
-    #[tokio::test]
-    async fn test_round_trip() -> Result<()> {
-        let storage = InMemoryStorage::new();
+    #[test]
+    fn test_round_trip() -> Result<()> {
+        let mut storage = InMemoryStorage::new();
         let version = Uuid::new_v4();
 
         let task1 = (
@@ -153,40 +153,30 @@ mod test {
                 .collect::<TaskMap>(),
         );
 
-        let task1_clone = task1.clone();
-        let task2_clone = task2.clone();
-        storage
-            .txn(move |txn| {
-                txn.set_task(task1_clone.0, task1_clone.1.clone())?;
-                txn.set_task(task2_clone.0, task2_clone.1.clone())?;
-                txn.commit()
-            })
-            .await?;
+        storage.txn(|txn| {
+            txn.set_task(task1.0, task1.1.clone())?;
+            txn.set_task(task2.0, task2.1.clone())?;
+            txn.commit()
+        })?;
 
-        let snap = storage.txn(|txn| make_snapshot(txn)).await?;
+        let snap = storage.txn(|txn| make_snapshot(txn))?;
 
         // apply that snapshot to a fresh bit of fake
-        let storage = InMemoryStorage::new();
+        let mut storage = InMemoryStorage::new();
 
-        storage
-            .txn(move |txn| {
-                apply_snapshot(txn, version, &snap)?;
-                txn.commit()
-            })
-            .await?;
+        storage.txn(|txn| {
+            apply_snapshot(txn, version, &snap)?;
+            txn.commit()
+        })?;
 
-        let task1_clone = task1.clone();
-        let task2_clone = task2.clone();
-        storage
-            .txn(move |txn| {
-                assert_eq!(txn.get_task(task1_clone.0)?, Some(task1_clone.1));
-                assert_eq!(txn.get_task(task2_clone.0)?, Some(task2_clone.1));
-                assert_eq!(txn.all_tasks()?.len(), 2);
-                assert_eq!(txn.base_version()?, version);
-                assert_eq!(txn.unsynced_operations()?.len(), 0);
-                assert_eq!(txn.get_working_set()?.len(), 1);
-                Ok(())
-            })
-            .await
+        storage.txn(|txn| {
+            assert_eq!(txn.get_task(task1.0)?, Some(task1.1));
+            assert_eq!(txn.get_task(task2.0)?, Some(task2.1));
+            assert_eq!(txn.all_tasks()?.len(), 2);
+            assert_eq!(txn.base_version()?, version);
+            assert_eq!(txn.unsynced_operations()?.len(), 0);
+            assert_eq!(txn.get_working_set()?.len(), 1);
+            Ok(())
+        })
     }
 }

--- a/src/taskdb/undo.rs
+++ b/src/taskdb/undo.rs
@@ -117,7 +117,7 @@ pub(crate) fn commit_reversed_operations(
 mod tests {
     use super::*;
     use crate::{storage::taskmap_with, taskdb::TaskDb};
-    use crate::{Operation, Operations, StorageConfig};
+    use crate::{Operation, Operations};
     use chrono::Utc;
     use pretty_assertions::assert_eq;
     use uuid::Uuid;
@@ -125,8 +125,7 @@ mod tests {
     #[test]
     #[allow(clippy::vec_init_then_push)]
     fn test_apply_create() -> Result<()> {
-        let mut storage = StorageConfig::InMemory.into_storage().unwrap();
-        let mut db = TaskDb::new();
+        let mut db = TaskDb::new_inmemory();
         let uuid1 = Uuid::new_v4();
         let uuid2 = Uuid::new_v4();
         let timestamp = Utc::now();
@@ -157,10 +156,9 @@ mod tests {
             old_value: Some("v2".into()),
             timestamp,
         });
-        let mut txn = storage.txn()?;
-        db.commit_operations(txn.as_mut(), ops, |_| false)?;
+        db.commit_operations(ops, |_| false)?;
 
-        let db_state = db.sorted_tasks(txn.as_mut());
+        let db_state = db.sorted_tasks();
 
         let mut ops = Operations::new();
         ops.push(Operation::UndoPoint);
@@ -182,67 +180,51 @@ mod tests {
             old_value: Some("v3".into()),
             timestamp,
         });
-        db.commit_operations(txn.as_mut(), ops, |_| false)?;
+        db.commit_operations(ops, |_| false)?;
 
-        assert_eq!(
-            db.operations(txn.as_mut()).len(),
-            9,
-            "{:#?}",
-            db.operations(txn.as_mut())
-        );
+        assert_eq!(db.operations().len(), 9, "{:#?}", db.operations());
 
-        let undo_ops = get_undo_operations(txn.as_mut())?;
+        let undo_ops = get_undo_operations(db.storage.txn()?.as_mut())?;
         assert_eq!(undo_ops.len(), 4, "{:#?}", undo_ops);
-        assert_eq!(&undo_ops[..], &db.operations(txn.as_mut())[5..]);
+        assert_eq!(&undo_ops[..], &db.operations()[5..]);
 
         // Try committing the wrong set of ops.
         assert!(!commit_reversed_operations(
-            txn.as_mut(),
+            db.storage.txn()?.as_mut(),
             undo_ops[1..=2].to_vec(),
         )?);
 
-        assert!(commit_reversed_operations(txn.as_mut(), undo_ops)?);
+        assert!(commit_reversed_operations(
+            db.storage.txn()?.as_mut(),
+            undo_ops
+        )?);
 
         // Note that we've subtracted the length of undo_ops.
-        assert_eq!(
-            db.operations(txn.as_mut()).len(),
-            5,
-            "{:#?}",
-            db.operations(txn.as_mut())
-        );
-        assert_eq!(
-            db.sorted_tasks(txn.as_mut()),
-            db_state,
-            "{:#?}",
-            db.sorted_tasks(txn.as_mut())
-        );
+        assert_eq!(db.operations().len(), 5, "{:#?}", db.operations());
+        assert_eq!(db.sorted_tasks(), db_state, "{:#?}", db.sorted_tasks());
 
         // Note that the number of undo operations is equal to the number of operations in the
         // database here because there are no UndoPoints.
-        let undo_ops = get_undo_operations(txn.as_mut())?;
+        let undo_ops = get_undo_operations(db.storage.txn()?.as_mut())?;
         assert_eq!(undo_ops.len(), 5, "{:#?}", undo_ops);
 
-        assert!(commit_reversed_operations(txn.as_mut(), undo_ops)?);
+        assert!(commit_reversed_operations(
+            db.storage.txn()?.as_mut(),
+            undo_ops
+        )?);
 
         // empty db
-        assert_eq!(
-            db.operations(txn.as_mut()).len(),
-            0,
-            "{:#?}",
-            db.operations(txn.as_mut())
-        );
-        assert_eq!(
-            db.sorted_tasks(txn.as_mut()),
-            vec![],
-            "{:#?}",
-            db.sorted_tasks(txn.as_mut())
-        );
+        assert_eq!(db.operations().len(), 0, "{:#?}", db.operations());
+        assert_eq!(db.sorted_tasks(), vec![], "{:#?}", db.sorted_tasks());
 
-        let undo_ops = get_undo_operations(txn.as_mut())?;
+        let undo_ops = get_undo_operations(db.storage.txn()?.as_mut())?;
         assert_eq!(undo_ops.len(), 0, "{:#?}", undo_ops);
 
         // nothing left to undo, so commit_undo_ops() returns false
-        assert!(!commit_reversed_operations(txn.as_mut(), undo_ops)?);
+        assert!(!commit_reversed_operations(
+            db.storage.txn()?.as_mut(),
+            undo_ops
+        )?);
 
         Ok(())
     }

--- a/src/taskdb/undo.rs
+++ b/src/taskdb/undo.rs
@@ -124,10 +124,11 @@ mod tests {
     use pretty_assertions::assert_eq;
     use uuid::Uuid;
 
-    #[tokio::test]
+    #[test]
     #[allow(clippy::vec_init_then_push)]
-    async fn test_apply_create() -> Result<()> {
-        let storage = InMemoryStorage::new();
+    fn test_apply_create() -> Result<()> {
+        let mut storage = InMemoryStorage::new();
+        let mut db = TaskDb::new();
         let uuid1 = Uuid::new_v4();
         let uuid2 = Uuid::new_v4();
         let timestamp = Utc::now();
@@ -158,94 +159,72 @@ mod tests {
             old_value: Some("v2".into()),
             timestamp,
         });
-        storage
-            .txn(move |txn| {
-                TaskDb::commit_operations(txn, ops, |_| false)?;
+        storage.txn(|txn| {
+            db.commit_operations(txn, ops, |_| false)?;
 
-                let db_state = TaskDb::sorted_tasks(txn);
+            let db_state = db.sorted_tasks(txn);
 
-                let mut ops = Operations::new();
-                ops.push(Operation::UndoPoint);
-                ops.push(Operation::Delete {
-                    uuid: uuid1,
-                    old_task: [("prop".to_string(), "v1".to_string())].into(),
-                });
-                ops.push(Operation::Update {
-                    uuid: uuid2,
-                    property: "prop".into(),
-                    value: None,
-                    old_value: Some("v2".into()),
-                    timestamp,
-                });
-                ops.push(Operation::Update {
-                    uuid: uuid2,
-                    property: "prop2".into(),
-                    value: Some("new-value".into()),
-                    old_value: Some("v3".into()),
-                    timestamp,
-                });
-                TaskDb::commit_operations(txn, ops, |_| false)?;
+            let mut ops = Operations::new();
+            ops.push(Operation::UndoPoint);
+            ops.push(Operation::Delete {
+                uuid: uuid1,
+                old_task: [("prop".to_string(), "v1".to_string())].into(),
+            });
+            ops.push(Operation::Update {
+                uuid: uuid2,
+                property: "prop".into(),
+                value: None,
+                old_value: Some("v2".into()),
+                timestamp,
+            });
+            ops.push(Operation::Update {
+                uuid: uuid2,
+                property: "prop2".into(),
+                value: Some("new-value".into()),
+                old_value: Some("v3".into()),
+                timestamp,
+            });
+            db.commit_operations(txn, ops, |_| false)?;
 
-                assert_eq!(
-                    TaskDb::operations(txn).len(),
-                    9,
-                    "{:#?}",
-                    TaskDb::operations(txn)
-                );
+            assert_eq!(db.operations(txn).len(), 9, "{:#?}", db.operations(txn));
 
-                let undo_ops = get_undo_operations(txn)?;
-                assert_eq!(undo_ops.len(), 4, "{:#?}", undo_ops);
-                assert_eq!(&undo_ops[..], &TaskDb::operations(txn)[5..]);
+            let undo_ops = get_undo_operations(txn)?;
+            assert_eq!(undo_ops.len(), 4, "{:#?}", undo_ops);
+            assert_eq!(&undo_ops[..], &db.operations(txn)[5..]);
 
-                // Try committing the wrong set of ops.
-                assert!(!commit_reversed_operations(txn, undo_ops[1..=2].to_vec(),)?);
+            // Try committing the wrong set of ops.
+            assert!(!commit_reversed_operations(txn, undo_ops[1..=2].to_vec(),)?);
 
-                assert!(commit_reversed_operations(txn, undo_ops)?);
+            assert!(commit_reversed_operations(txn, undo_ops)?);
 
-                // Note that we've subtracted the length of undo_ops.
-                assert_eq!(
-                    TaskDb::operations(txn).len(),
-                    5,
-                    "{:#?}",
-                    TaskDb::operations(txn)
-                );
-                assert_eq!(
-                    TaskDb::sorted_tasks(txn),
-                    db_state,
-                    "{:#?}",
-                    TaskDb::sorted_tasks(txn)
-                );
+            // Note that we've subtracted the length of undo_ops.
+            assert_eq!(db.operations(txn).len(), 5, "{:#?}", db.operations(txn));
+            assert_eq!(
+                db.sorted_tasks(txn),
+                db_state,
+                "{:#?}",
+                db.sorted_tasks(txn)
+            );
 
-                // Note that the number of undo operations is equal to the number of operations in the
-                // database here because there are no UndoPoints.
-                let undo_ops = get_undo_operations(txn)?;
-                assert_eq!(undo_ops.len(), 5, "{:#?}", undo_ops);
+            // Note that the number of undo operations is equal to the number of operations in the
+            // database here because there are no UndoPoints.
+            let undo_ops = get_undo_operations(txn)?;
+            assert_eq!(undo_ops.len(), 5, "{:#?}", undo_ops);
 
-                assert!(commit_reversed_operations(txn, undo_ops)?);
+            assert!(commit_reversed_operations(txn, undo_ops)?);
 
-                // empty db
-                assert_eq!(
-                    TaskDb::operations(txn).len(),
-                    0,
-                    "{:#?}",
-                    TaskDb::operations(txn)
-                );
-                assert_eq!(
-                    TaskDb::sorted_tasks(txn),
-                    vec![],
-                    "{:#?}",
-                    TaskDb::sorted_tasks(txn)
-                );
+            // empty db
+            assert_eq!(db.operations(txn).len(), 0, "{:#?}", db.operations(txn));
+            assert_eq!(db.sorted_tasks(txn), vec![], "{:#?}", db.sorted_tasks(txn));
 
-                let undo_ops = get_undo_operations(txn)?;
-                assert_eq!(undo_ops.len(), 0, "{:#?}", undo_ops);
+            let undo_ops = get_undo_operations(txn)?;
+            assert_eq!(undo_ops.len(), 0, "{:#?}", undo_ops);
 
-                // nothing left to undo, so commit_undo_ops() returns false
-                assert!(!commit_reversed_operations(txn, undo_ops)?);
+            // nothing left to undo, so commit_undo_ops() returns false
+            assert!(!commit_reversed_operations(txn, undo_ops)?);
 
-                Ok(())
-            })
-            .await
+            Ok(())
+        })
     }
 
     #[test]

--- a/src/taskdb/undo.rs
+++ b/src/taskdb/undo.rs
@@ -116,10 +116,8 @@ pub(crate) fn commit_reversed_operations(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::storage::InMemoryStorage;
-    use crate::storage::Storage;
     use crate::{storage::taskmap_with, taskdb::TaskDb};
-    use crate::{Operation, Operations};
+    use crate::{Operation, Operations, StorageConfig};
     use chrono::Utc;
     use pretty_assertions::assert_eq;
     use uuid::Uuid;
@@ -127,7 +125,7 @@ mod tests {
     #[test]
     #[allow(clippy::vec_init_then_push)]
     fn test_apply_create() -> Result<()> {
-        let mut storage = InMemoryStorage::new();
+        let mut storage = StorageConfig::InMemory.into_storage().unwrap();
         let mut db = TaskDb::new();
         let uuid1 = Uuid::new_v4();
         let uuid2 = Uuid::new_v4();
@@ -159,72 +157,94 @@ mod tests {
             old_value: Some("v2".into()),
             timestamp,
         });
-        storage.txn(|txn| {
-            db.commit_operations(txn, ops, |_| false)?;
+        let mut txn = storage.txn()?;
+        db.commit_operations(txn.as_mut(), ops, |_| false)?;
 
-            let db_state = db.sorted_tasks(txn);
+        let db_state = db.sorted_tasks(txn.as_mut());
 
-            let mut ops = Operations::new();
-            ops.push(Operation::UndoPoint);
-            ops.push(Operation::Delete {
-                uuid: uuid1,
-                old_task: [("prop".to_string(), "v1".to_string())].into(),
-            });
-            ops.push(Operation::Update {
-                uuid: uuid2,
-                property: "prop".into(),
-                value: None,
-                old_value: Some("v2".into()),
-                timestamp,
-            });
-            ops.push(Operation::Update {
-                uuid: uuid2,
-                property: "prop2".into(),
-                value: Some("new-value".into()),
-                old_value: Some("v3".into()),
-                timestamp,
-            });
-            db.commit_operations(txn, ops, |_| false)?;
+        let mut ops = Operations::new();
+        ops.push(Operation::UndoPoint);
+        ops.push(Operation::Delete {
+            uuid: uuid1,
+            old_task: [("prop".to_string(), "v1".to_string())].into(),
+        });
+        ops.push(Operation::Update {
+            uuid: uuid2,
+            property: "prop".into(),
+            value: None,
+            old_value: Some("v2".into()),
+            timestamp,
+        });
+        ops.push(Operation::Update {
+            uuid: uuid2,
+            property: "prop2".into(),
+            value: Some("new-value".into()),
+            old_value: Some("v3".into()),
+            timestamp,
+        });
+        db.commit_operations(txn.as_mut(), ops, |_| false)?;
 
-            assert_eq!(db.operations(txn).len(), 9, "{:#?}", db.operations(txn));
+        assert_eq!(
+            db.operations(txn.as_mut()).len(),
+            9,
+            "{:#?}",
+            db.operations(txn.as_mut())
+        );
 
-            let undo_ops = get_undo_operations(txn)?;
-            assert_eq!(undo_ops.len(), 4, "{:#?}", undo_ops);
-            assert_eq!(&undo_ops[..], &db.operations(txn)[5..]);
+        let undo_ops = get_undo_operations(txn.as_mut())?;
+        assert_eq!(undo_ops.len(), 4, "{:#?}", undo_ops);
+        assert_eq!(&undo_ops[..], &db.operations(txn.as_mut())[5..]);
 
-            // Try committing the wrong set of ops.
-            assert!(!commit_reversed_operations(txn, undo_ops[1..=2].to_vec(),)?);
+        // Try committing the wrong set of ops.
+        assert!(!commit_reversed_operations(
+            txn.as_mut(),
+            undo_ops[1..=2].to_vec(),
+        )?);
 
-            assert!(commit_reversed_operations(txn, undo_ops)?);
+        assert!(commit_reversed_operations(txn.as_mut(), undo_ops)?);
 
-            // Note that we've subtracted the length of undo_ops.
-            assert_eq!(db.operations(txn).len(), 5, "{:#?}", db.operations(txn));
-            assert_eq!(
-                db.sorted_tasks(txn),
-                db_state,
-                "{:#?}",
-                db.sorted_tasks(txn)
-            );
+        // Note that we've subtracted the length of undo_ops.
+        assert_eq!(
+            db.operations(txn.as_mut()).len(),
+            5,
+            "{:#?}",
+            db.operations(txn.as_mut())
+        );
+        assert_eq!(
+            db.sorted_tasks(txn.as_mut()),
+            db_state,
+            "{:#?}",
+            db.sorted_tasks(txn.as_mut())
+        );
 
-            // Note that the number of undo operations is equal to the number of operations in the
-            // database here because there are no UndoPoints.
-            let undo_ops = get_undo_operations(txn)?;
-            assert_eq!(undo_ops.len(), 5, "{:#?}", undo_ops);
+        // Note that the number of undo operations is equal to the number of operations in the
+        // database here because there are no UndoPoints.
+        let undo_ops = get_undo_operations(txn.as_mut())?;
+        assert_eq!(undo_ops.len(), 5, "{:#?}", undo_ops);
 
-            assert!(commit_reversed_operations(txn, undo_ops)?);
+        assert!(commit_reversed_operations(txn.as_mut(), undo_ops)?);
 
-            // empty db
-            assert_eq!(db.operations(txn).len(), 0, "{:#?}", db.operations(txn));
-            assert_eq!(db.sorted_tasks(txn), vec![], "{:#?}", db.sorted_tasks(txn));
+        // empty db
+        assert_eq!(
+            db.operations(txn.as_mut()).len(),
+            0,
+            "{:#?}",
+            db.operations(txn.as_mut())
+        );
+        assert_eq!(
+            db.sorted_tasks(txn.as_mut()),
+            vec![],
+            "{:#?}",
+            db.sorted_tasks(txn.as_mut())
+        );
 
-            let undo_ops = get_undo_operations(txn)?;
-            assert_eq!(undo_ops.len(), 0, "{:#?}", undo_ops);
+        let undo_ops = get_undo_operations(txn.as_mut())?;
+        assert_eq!(undo_ops.len(), 0, "{:#?}", undo_ops);
 
-            // nothing left to undo, so commit_undo_ops() returns false
-            assert!(!commit_reversed_operations(txn, undo_ops)?);
+        // nothing left to undo, so commit_undo_ops() returns false
+        assert!(!commit_reversed_operations(txn.as_mut(), undo_ops)?);
 
-            Ok(())
-        })
+        Ok(())
     }
 
     #[test]

--- a/tests/cross-sync.rs
+++ b/tests/cross-sync.rs
@@ -1,14 +1,14 @@
 use chrono::Utc;
 use pretty_assertions::assert_eq;
-use taskchampion::{storage::InMemoryStorage, Operations, Replica, ServerConfig, Status, Uuid};
+use taskchampion::{Operations, Replica, ServerConfig, Status, StorageConfig, Uuid};
 use tempfile::TempDir;
 
 #[test]
 #[cfg(feature = "server-local")]
 fn cross_sync() -> anyhow::Result<()> {
     // set up two replicas, and demonstrate replication between them
-    let mut rep1 = Replica::new(InMemoryStorage::new());
-    let mut rep2 = Replica::new(InMemoryStorage::new());
+    let mut rep1 = Replica::new(StorageConfig::InMemory.into_storage()?);
+    let mut rep2 = Replica::new(StorageConfig::InMemory.into_storage()?);
 
     let tmp_dir = TempDir::new().expect("TempDir failed");
     let server_config = ServerConfig::Local {

--- a/tests/cross-sync.rs
+++ b/tests/cross-sync.rs
@@ -3,9 +3,9 @@ use pretty_assertions::assert_eq;
 use taskchampion::{storage::InMemoryStorage, Operations, Replica, ServerConfig, Status, Uuid};
 use tempfile::TempDir;
 
-#[tokio::test]
+#[test]
 #[cfg(feature = "server-local")]
-async fn cross_sync() -> anyhow::Result<()> {
+fn cross_sync() -> anyhow::Result<()> {
     // set up two replicas, and demonstrate replication between them
     let mut rep1 = Replica::new(InMemoryStorage::new());
     let mut rep2 = Replica::new(InMemoryStorage::new());
@@ -14,17 +14,17 @@ async fn cross_sync() -> anyhow::Result<()> {
     let server_config = ServerConfig::Local {
         server_dir: tmp_dir.path().to_path_buf(),
     };
-    let server = server_config.into_server()?;
+    let mut server = server_config.into_server()?;
 
     let (uuid1, uuid2) = (Uuid::new_v4(), Uuid::new_v4());
     let mut ops = Operations::new();
 
     // add some tasks on rep1
-    let mut t1 = rep1.create_task(uuid1, &mut ops).await?;
+    let mut t1 = rep1.create_task(uuid1, &mut ops)?;
     t1.set_description("test 1".into(), &mut ops)?;
     t1.set_status(Status::Pending, &mut ops)?;
     t1.set_entry(Some(Utc::now()), &mut ops)?;
-    let mut t2 = rep1.create_task(uuid2, &mut ops).await?;
+    let mut t2 = rep1.create_task(uuid2, &mut ops)?;
     t2.set_description("test 2".into(), &mut ops)?;
     t2.set_status(Status::Pending, &mut ops)?;
     t2.set_entry(Some(Utc::now()), &mut ops)?;
@@ -32,20 +32,14 @@ async fn cross_sync() -> anyhow::Result<()> {
     // modify t1
     t1.start(&mut ops)?;
 
-    rep1.commit_operations(ops).await?;
+    rep1.commit_operations(ops)?;
 
-    rep1.sync(server.clone(), false).await?;
-    rep2.sync(server.clone(), false).await?;
+    rep1.sync(&mut server, false)?;
+    rep2.sync(&mut server, false)?;
 
     // those tasks should exist on rep2 now
-    let mut t12 = rep2
-        .get_task(uuid1)
-        .await?
-        .expect("expected task 1 on rep2");
-    let t22 = rep2
-        .get_task(uuid2)
-        .await?
-        .expect("expected task 2 on rep2");
+    let mut t12 = rep2.get_task(uuid1)?.expect("expected task 1 on rep2");
+    let t22 = rep2.get_task(uuid2)?.expect("expected task 2 on rep2");
 
     assert_eq!(t12.get_description(), "test 1");
     assert_eq!(t12.is_active(), true);
@@ -55,49 +49,43 @@ async fn cross_sync() -> anyhow::Result<()> {
     // make non-conflicting changes on the two replicas
     let mut ops = Operations::new();
     t2.set_status(Status::Completed, &mut ops)?;
-    rep1.commit_operations(ops).await?;
+    rep2.commit_operations(ops)?;
 
     let mut ops = Operations::new();
     t12.set_status(Status::Completed, &mut ops)?;
-    rep2.commit_operations(ops).await?;
+    rep2.commit_operations(ops)?;
 
     // sync those changes back and forth
-    rep1.sync(server.clone(), false).await?; // rep1 -> server
-    rep2.sync(server.clone(), false).await?; // server -> rep2, rep2 -> server
-    rep1.sync(server.clone(), false).await?; // server -> rep1
+    rep1.sync(&mut server, false)?; // rep1 -> server
+    rep2.sync(&mut server, false)?; // server -> rep2, rep2 -> server
+    rep1.sync(&mut server, false)?; // server -> rep1
 
-    let t1 = rep1
-        .get_task(uuid1)
-        .await?
-        .expect("expected task 1 on rep1");
+    let t1 = rep1.get_task(uuid1)?.expect("expected task 1 on rep1");
     assert_eq!(t1.get_status(), Status::Completed);
 
-    let mut t22 = rep2
-        .get_task(uuid2)
-        .await?
-        .expect("expected task 2 on rep2");
+    let mut t22 = rep2.get_task(uuid2)?.expect("expected task 2 on rep2");
     assert_eq!(t22.get_status(), Status::Completed);
 
-    rep1.rebuild_working_set(true).await?;
-    rep2.rebuild_working_set(true).await?;
+    rep1.rebuild_working_set(true)?;
+    rep2.rebuild_working_set(true)?;
 
     // Make task 2 pending again, and observe that it is in the working set in both replicas after
     // sync.
     let mut ops = Operations::new();
     t22.set_status(Status::Pending, &mut ops)?;
-    rep2.commit_operations(ops).await?;
+    rep2.commit_operations(ops)?;
 
-    let ws = rep2.working_set().await?;
+    let ws = rep2.working_set()?;
     assert_eq!(ws.by_index(1), Some(uuid2));
 
     // Pending status is not sync'd to rep1 yet.
-    let ws = rep1.working_set().await?;
+    let ws = rep1.working_set()?;
     assert_eq!(ws.by_index(1), None);
 
-    rep2.sync(server.clone(), false).await?;
-    rep1.sync(server.clone(), false).await?;
+    rep2.sync(&mut server, false)?;
+    rep1.sync(&mut server, false)?;
 
-    let ws = rep1.working_set().await?;
+    let ws = rep1.working_set()?;
     assert_eq!(ws.by_index(1), Some(uuid2));
 
     Ok(())

--- a/tests/syncing-proptest.rs
+++ b/tests/syncing-proptest.rs
@@ -1,7 +1,7 @@
 use pretty_assertions::assert_eq;
 use proptest::prelude::*;
 #[cfg(feature = "storage-sqlite")]
-use taskchampion::{storage::InMemoryStorage, Operations, Replica, ServerConfig, TaskData, Uuid};
+use taskchampion::{Operations, Replica, ServerConfig, StorageConfig, TaskData, Uuid};
 use tempfile::TempDir;
 
 #[derive(Debug, Clone)]
@@ -39,10 +39,10 @@ fn multi_replica_sync(action_sequence in actions()) {
         server_dir: tmp_dir.path().to_path_buf(),
     };
     let mut server = server_config.into_server()?;
-    let mut replicas: [Replica<InMemoryStorage>; 3] = [
-        Replica::new(InMemoryStorage::new()),
-        Replica::new(InMemoryStorage::new()),
-        Replica::new(InMemoryStorage::new()),
+    let mut replicas = [
+        Replica::new(StorageConfig::InMemory.into_storage().unwrap()),
+        Replica::new(StorageConfig::InMemory.into_storage().unwrap()),
+        Replica::new(StorageConfig::InMemory.into_storage().unwrap()),
     ];
 
     for (action, rep) in action_sequence {

--- a/tests/syncing-proptest.rs
+++ b/tests/syncing-proptest.rs
@@ -33,62 +33,60 @@ proptest! {
 /// that results in a task being in different states in different replicas. Different tasks
 /// cannot interfere with one another, so this focuses on a single task.
 fn multi_replica_sync(action_sequence in actions()) {
-    tokio::runtime::Runtime::new().unwrap().block_on(async {
-        let tmp_dir = TempDir::new().expect("TempDir failed");
-        let uuid = Uuid::parse_str("83a2f9ef-f455-4195-b92e-a54c161eebfc").unwrap();
-        let server_config = ServerConfig::Local {
-            server_dir: tmp_dir.path().to_path_buf(),
-        };
-        let server = server_config.into_server().unwrap();
-        let mut replicas = [
-            Replica::new(InMemoryStorage::new()),
-            Replica::new(InMemoryStorage::new()),
-            Replica::new(InMemoryStorage::new()),
-        ];
+    let tmp_dir = TempDir::new().expect("TempDir failed");
+    let uuid = Uuid::parse_str("83a2f9ef-f455-4195-b92e-a54c161eebfc").unwrap();
+    let server_config = ServerConfig::Local {
+        server_dir: tmp_dir.path().to_path_buf(),
+    };
+    let mut server = server_config.into_server()?;
+    let mut replicas: [Replica<InMemoryStorage>; 3] = [
+        Replica::new(InMemoryStorage::new()),
+        Replica::new(InMemoryStorage::new()),
+        Replica::new(InMemoryStorage::new()),
+    ];
 
-        for (action, rep) in action_sequence {
-            println!("{:?} on rep {}", action, rep);
+    for (action, rep) in action_sequence {
+        println!("{:?} on rep {}", action, rep);
 
-            let rep = &mut replicas[rep as usize];
-            match action {
-                Action::Create => {
-                    if rep.get_task_data(uuid).await.unwrap().is_none() {
-                        let mut ops = Operations::new();
-                        TaskData::create(uuid, &mut ops);
-                        rep.commit_operations(ops).await.unwrap();
-                    }
-                },
-                Action::Update(p, v) => {
-                    if let Some(mut t) = rep.get_task_data(uuid).await.unwrap() {
-                        let mut ops = Operations::new();
-                        t.update(p, Some(v), &mut ops);
-                        rep.commit_operations(ops).await.unwrap();
-                    }
-                },
-                Action::Delete => {
-                    if let Some(mut t) = rep.get_task_data(uuid).await.unwrap() {
-                        let mut ops = Operations::new();
-                        t.delete(&mut ops);
-                        rep.commit_operations(ops).await.unwrap();
-                    }
-                },
-                Action::Sync => rep.sync(server.clone(), false).await.unwrap(),
-            }
+        let rep = &mut replicas[rep as usize];
+        match action {
+            Action::Create => {
+                if rep.get_task_data(uuid).unwrap().is_none() {
+                    let mut ops = Operations::new();
+                    TaskData::create(uuid, &mut ops);
+                    rep.commit_operations(ops).unwrap();
+                }
+            },
+            Action::Update(p, v) => {
+                if let Some(mut t) = rep.get_task_data(uuid).unwrap() {
+                    let mut ops = Operations::new();
+                    t.update(p, Some(v), &mut ops);
+                    rep.commit_operations(ops).unwrap();
+                }
+            },
+            Action::Delete => {
+                if let Some(mut t) = rep.get_task_data(uuid).unwrap() {
+                    let mut ops = Operations::new();
+                    t.delete(&mut ops);
+                    rep.commit_operations(ops).unwrap();
+                }
+            },
+            Action::Sync => rep.sync(&mut server, false).unwrap(),
         }
+    }
 
-        // Sync all of the replicas, twice, to flush out any un-synced changes.
-        for rep in &mut replicas {
-            rep.sync(server.clone(), false).await.unwrap()
-        }
-        for rep in &mut replicas {
-            rep.sync(server.clone(), false).await.unwrap()
-        }
+    // Sync all of the replicas, twice, to flush out any un-synced changes.
+    for rep in &mut replicas {
+        rep.sync(&mut server, false).unwrap()
+    }
+    for rep in &mut replicas {
+        rep.sync(&mut server, false).unwrap()
+    }
 
-        let t0 = replicas[0].get_task_data(uuid).await.unwrap();
-        let t1 = replicas[1].get_task_data(uuid).await.unwrap();
-        let t2 = replicas[2].get_task_data(uuid).await.unwrap();
-        assert_eq!(t0, t1);
-        assert_eq!(t1, t2);
-    });
+    let t0 = replicas[0].get_task_data(uuid).unwrap();
+    let t1 = replicas[1].get_task_data(uuid).unwrap();
+    let t2 = replicas[2].get_task_data(uuid).unwrap();
+    assert_eq!(t0, t1);
+    assert_eq!(t1, t2);
 }
 }

--- a/tests/update-and-delete-sync.rs
+++ b/tests/update-and-delete-sync.rs
@@ -1,5 +1,5 @@
 use taskchampion::chrono::{TimeZone, Utc};
-use taskchampion::{storage::InMemoryStorage, Operations, Replica, ServerConfig, Status, Uuid};
+use taskchampion::{Operations, Replica, ServerConfig, Status, StorageConfig, Uuid};
 use tempfile::TempDir;
 
 #[test]
@@ -20,8 +20,8 @@ fn update_and_delete_sync_update_first() -> anyhow::Result<()> {
 #[cfg(feature = "server-local")]
 fn update_and_delete_sync(delete_first: bool) -> anyhow::Result<()> {
     // set up two replicas, and demonstrate replication between them
-    let mut rep1 = Replica::new(InMemoryStorage::new());
-    let mut rep2 = Replica::new(InMemoryStorage::new());
+    let mut rep1 = Replica::new(StorageConfig::InMemory.into_storage()?);
+    let mut rep2 = Replica::new(StorageConfig::InMemory.into_storage()?);
 
     let tmp_dir = TempDir::new().expect("TempDir failed");
     let mut server = ServerConfig::Local {

--- a/tests/update-and-delete-sync.rs
+++ b/tests/update-and-delete-sync.rs
@@ -2,29 +2,29 @@ use taskchampion::chrono::{TimeZone, Utc};
 use taskchampion::{storage::InMemoryStorage, Operations, Replica, ServerConfig, Status, Uuid};
 use tempfile::TempDir;
 
-#[tokio::test]
+#[test]
 #[cfg(feature = "server-local")]
-async fn update_and_delete_sync_delete_first() -> anyhow::Result<()> {
-    update_and_delete_sync(true).await
+fn update_and_delete_sync_delete_first() -> anyhow::Result<()> {
+    update_and_delete_sync(true)
 }
 
-#[tokio::test]
+#[test]
 #[cfg(feature = "server-local")]
-async fn update_and_delete_sync_update_first() -> anyhow::Result<()> {
-    update_and_delete_sync(false).await
+fn update_and_delete_sync_update_first() -> anyhow::Result<()> {
+    update_and_delete_sync(false)
 }
 
 /// Test what happens when an update is sync'd into a repo after a task is deleted.
 /// If delete_first, then the deletion is sync'd to the server first; otherwise
 /// the update is sync'd first.  Either way, the task is gone.
 #[cfg(feature = "server-local")]
-async fn update_and_delete_sync(delete_first: bool) -> anyhow::Result<()> {
+fn update_and_delete_sync(delete_first: bool) -> anyhow::Result<()> {
     // set up two replicas, and demonstrate replication between them
     let mut rep1 = Replica::new(InMemoryStorage::new());
     let mut rep2 = Replica::new(InMemoryStorage::new());
 
     let tmp_dir = TempDir::new().expect("TempDir failed");
-    let server = ServerConfig::Local {
+    let mut server = ServerConfig::Local {
         server_dir: tmp_dir.path().to_path_buf(),
     }
     .into_server()?;
@@ -32,53 +32,53 @@ async fn update_and_delete_sync(delete_first: bool) -> anyhow::Result<()> {
     // add a task on rep1, and sync it to rep2
     let mut ops = Operations::new();
     let u = Uuid::new_v4();
-    let mut t = rep1.create_task(u, &mut ops).await?;
+    let mut t = rep1.create_task(u, &mut ops)?;
     t.set_description("test task".into(), &mut ops)?;
     t.set_status(Status::Pending, &mut ops)?;
     t.set_entry(Some(Utc::now()), &mut ops)?;
-    rep1.commit_operations(ops).await?;
+    rep1.commit_operations(ops)?;
 
-    rep1.sync(server.clone(), false).await?;
-    rep2.sync(server.clone(), false).await?;
+    rep1.sync(&mut server, false)?;
+    rep2.sync(&mut server, false)?;
 
     // mark the task as deleted, long in the past, on rep2
     {
         let mut ops = Operations::new();
-        let mut t = rep2.get_task(u).await?.unwrap();
+        let mut t = rep2.get_task(u)?.unwrap();
         t.set_status(Status::Deleted, &mut ops)?;
         t.set_modified(Utc.with_ymd_and_hms(1980, 1, 1, 0, 0, 0).unwrap(), &mut ops)?;
-        rep2.commit_operations(ops).await?;
+        rep2.commit_operations(ops)?;
     }
 
     // sync it back to rep1
-    rep2.sync(server.clone(), false).await?;
-    rep1.sync(server.clone(), false).await?;
+    rep2.sync(&mut server, false)?;
+    rep1.sync(&mut server, false)?;
 
     // expire the task on rep1 and check that it is gone locally
-    rep1.expire_tasks().await?;
-    assert!(rep1.get_task(u).await?.is_none());
+    rep1.expire_tasks()?;
+    assert!(rep1.get_task(u)?.is_none());
 
     // modify the task on rep2
     {
         let mut ops = Operations::new();
-        let mut t = rep2.get_task(u).await?.unwrap();
+        let mut t = rep2.get_task(u)?.unwrap();
         t.set_description("modified".to_string(), &mut ops)?;
-        rep2.commit_operations(ops).await?;
+        rep2.commit_operations(ops)?;
     }
 
     // sync back and forth
     if delete_first {
-        rep1.sync(server.clone(), false).await?;
+        rep1.sync(&mut server, false)?;
     }
-    rep2.sync(server.clone(), false).await?;
-    rep1.sync(server.clone(), false).await?;
+    rep2.sync(&mut server, false)?;
+    rep1.sync(&mut server, false)?;
     if !delete_first {
-        rep2.sync(server.clone(), false).await?;
+        rep2.sync(&mut server, false)?;
     }
 
     // check that the task is gone on both replicas
-    assert!(rep1.get_task(u).await?.is_none());
-    assert!(rep2.get_task(u).await?.is_none());
+    assert!(rep1.get_task(u)?.is_none());
+    assert!(rep2.get_task(u)?.is_none());
 
     Ok(())
 }


### PR DESCRIPTION
This PR reverts the recent `async` refactoring.

After further investigation, the initial approach using `tokio_rusqlite` proved to be unworkable (see issue #599). This revert is a clean course correction to clear the way for a more robust solution.

The new implementation, which uses an actor model to wrap the synchronous `SqliteStorage`, is available for review here: ~[link](https://github.com/geofflittle/taskchampion/pull/1)~ #620.