### PR TITLE
refactor: Make storage async

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,9 +77,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.83"
+version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2664,9 +2664,10 @@ dependencies = [
 
 [[package]]
 name = "taskchampion"
-version = "2.0.4-pre"
+version = "3.0.0-pre"
 dependencies = [
  "anyhow",
+ "async-trait",
  "aws-config",
  "aws-credential-types",
  "aws-sdk-s3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taskchampion"
-version = "2.0.4-pre"
+version = "3.0.0-pre"
 authors = ["Dustin J. Mitchell <dustin@mozilla.com>"]
 description = "Personal task-tracking"
 homepage = "https://gothenburgbitfactory.github.io/taskchampion/"
@@ -25,9 +25,9 @@ sync = ["server-sync", "server-gcp", "server-aws", "server-local"]
 # Support for sync to a server
 server-sync = ["encryption", "dep:ureq", "dep:url"]
 # Support for sync to GCP
-server-gcp = ["cloud", "encryption", "dep:google-cloud-storage", "dep:tokio"]
+server-gcp = ["cloud", "encryption", "dep:google-cloud-storage"]
 # Support for sync to AWS
-server-aws = ["cloud", "encryption", "dep:aws-sdk-s3", "dep:aws-config", "dep:aws-credential-types", "dep:tokio"]
+server-aws = ["cloud", "encryption", "dep:aws-sdk-s3", "dep:aws-config", "dep:aws-credential-types"]
 # Suppport for sync to another SQLite database on the same machine
 server-local = ["storage-sqlite"]
 # Support for all task storage backends
@@ -62,11 +62,12 @@ serde_json = "^1.0"
 serde = { version = "^1.0.147", features = ["derive"] }
 strum = "0.27"
 strum_macros = "0.27"
-tokio = { version = "1", features = ["rt-multi-thread"], optional = true }
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 thiserror = "2.0"
 ureq = { version = "^2.12.1", features = ["tls"], optional = true }
 uuid = { version = "^1.16.0", features = ["serde", "v4"] }
 url = { version = "2", optional = true }
+async-trait = "0.1.89"
 
 [dev-dependencies]
 proptest = "^1.8.0"

--- a/src/crate-doc.md
+++ b/src/crate-doc.md
@@ -18,7 +18,6 @@ Replicas are accessed using the [`Replica`] type.
 # Task Storage
 
 Replicas access the task database via a [storage object](crate::storage::Storage).
-Create a storage object with [`StorageConfig`].
 
 The [`storage`] module supports pluggable storage for a replica's data.
 An implementation is provided, but users of this crate can provide their own implementation as well.
@@ -36,19 +35,19 @@ Several server implementations are included, and users can define their own impl
 ```rust
 # #[cfg(feature = "storage-sqlite")]
 # {
-# use taskchampion::{storage::AccessMode, ServerConfig, Replica, StorageConfig};
+# use taskchampion::{storage::AccessMode, ServerConfig, Replica, SqliteStorage};
 # use tempfile::TempDir;
-# fn main() -> anyhow::Result<()> {
+# async fn main() -> anyhow::Result<()> {
 # let taskdb_dir = TempDir::new()?;
 # let taskdb_dir = taskdb_dir.path().to_path_buf();
 # let server_dir = TempDir::new()?;
 # let server_dir = server_dir.path().to_path_buf();
 // Create a new Replica, storing data on disk.
-let storage = StorageConfig::OnDisk {
+let storage = SqliteStorage::new(
   taskdb_dir,
-  create_if_missing: true,
-  access_mode: AccessMode::ReadWrite,
-}.into_storage()?;
+  AccessMode::ReadWrite,
+  true,
+)?;
 let mut replica = Replica::new(storage);
 
 // Set up a local, on-disk server.
@@ -56,7 +55,7 @@ let server_config = ServerConfig::Local { server_dir };
 let mut server = server_config.into_server()?;
 
 // Sync to that server.
-replica.sync(&mut server, true)?;
+replica.sync(&mut server, true).await?;
 #
 # Ok(())
 # }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "storage-sqlite")]
+use crate::storage::sqlite::ActorMessage;
 use std::io;
 use thiserror::Error;
 
@@ -41,6 +43,10 @@ other_error!(serde_json::Error);
 other_error!(rusqlite::Error);
 #[cfg(feature = "storage-sqlite")]
 other_error!(crate::storage::sqlite::SqliteError);
+#[cfg(feature = "storage-sqlite")]
+other_error!(tokio::sync::oneshot::error::RecvError);
+#[cfg(feature = "storage-sqlite")]
+other_error!(tokio::sync::mpsc::error::SendError<ActorMessage>);
 
 #[cfg(feature = "server-gcp")]
 other_error!(google_cloud_storage::http::Error);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,8 @@ pub use errors::Error;
 pub use operation::{Operation, Operations};
 pub use replica::Replica;
 pub use server::{Server, ServerConfig};
-pub use storage::StorageConfig;
+#[cfg(feature = "storage-sqlite")]
+pub use storage::sqlite::SqliteStorage;
 pub use task::{utc_timestamp, Annotation, Status, Tag, Task, TaskData};
 pub use workingset::WorkingSet;
 

--- a/src/storage/config.rs
+++ b/src/storage/config.rs
@@ -1,49 +1,5 @@
-#[cfg(feature = "storage-sqlite")]
-use super::sqlite::SqliteStorage;
-use super::{inmemory::InMemoryStorage, Storage};
-use crate::errors::Result;
-use std::path::PathBuf;
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AccessMode {
     ReadOnly,
     ReadWrite,
-}
-
-/// The configuration required for a replica's storage.
-#[non_exhaustive]
-pub enum StorageConfig {
-    /// Store the data on disk.  This is the common choice.
-    #[cfg(feature = "storage-sqlite")]
-    OnDisk {
-        /// Path containing the task DB.
-        taskdb_dir: PathBuf,
-
-        /// Create the DB if it does not already exist. This will occur
-        /// even if access_mode is `ReadOnly`.
-        create_if_missing: bool,
-
-        /// Access mode for this database.
-        access_mode: AccessMode,
-    },
-    /// Store the data in memory.  This is only useful for testing.
-    InMemory,
-}
-
-impl StorageConfig {
-    pub fn into_storage(self) -> Result<Box<dyn Storage>> {
-        Ok(match self {
-            #[cfg(feature = "storage-sqlite")]
-            StorageConfig::OnDisk {
-                taskdb_dir,
-                create_if_missing,
-                access_mode,
-            } => Box::new(SqliteStorage::new(
-                taskdb_dir,
-                access_mode,
-                create_if_missing,
-            )?),
-            StorageConfig::InMemory => Box::new(InMemoryStorage::new()),
-        })
-    }
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -4,13 +4,14 @@ This module defines the backend storage used by [`Replica`](crate::Replica).
 It defines a [trait](crate::storage::Storage) for storage implementations, and provides a default
 on-disk implementation as well as an in-memory implementation for testing.
 
-Typical uses of this crate do not interact directly with this module; [`StorageConfig`] is
-sufficient. However, users who wish to implement their own storage backends can implement the
-traits defined here and pass the result to [`Replica`](crate::Replica).
+Typical uses of this crate do not interact directly with this module. However, users who wish to
+implement their own storage backends can implement the traits defined here and pass the result to
+[`Replica`](crate::Replica).
 */
 
 use crate::errors::Result;
 use crate::operation::Operation;
+use async_trait::async_trait;
 use std::collections::HashMap;
 use uuid::Uuid;
 
@@ -20,11 +21,11 @@ mod test;
 mod config;
 
 #[cfg(feature = "storage-sqlite")]
-pub(crate) mod sqlite;
+pub mod sqlite;
 
-pub use config::{AccessMode, StorageConfig};
+pub use config::AccessMode;
 
-mod inmemory;
+pub mod inmemory;
 
 #[doc(hidden)]
 /// For compatibility with 0.6 and earlier, [`Operation`] is re-exported here.
@@ -61,95 +62,97 @@ const DEFAULT_BASE_VERSION: Uuid = crate::server::NIL_VERSION_ID;
 /// A transaction is not visible to other readers until it is committed with
 /// [`crate::storage::StorageTxn::commit`].  Transactions are aborted if they are dropped.
 /// It is safe and performant to drop transactions that did not modify any data without committing.
-pub trait StorageTxn {
+#[async_trait]
+pub trait StorageTxn: Send {
     /// Get an (immutable) task, if it is in the storage
-    fn get_task(&mut self, uuid: Uuid) -> Result<Option<TaskMap>>;
+    async fn get_task(&mut self, uuid: Uuid) -> Result<Option<TaskMap>>;
 
     /// Get a vector of all pending tasks from the working_set
-    fn get_pending_tasks(&mut self) -> Result<Vec<(Uuid, TaskMap)>>;
+    async fn get_pending_tasks(&mut self) -> Result<Vec<(Uuid, TaskMap)>>;
 
     /// Create an (empty) task, only if it does not already exist.  Returns true if
     /// the task was created (did not already exist).
-    fn create_task(&mut self, uuid: Uuid) -> Result<bool>;
+    async fn create_task(&mut self, uuid: Uuid) -> Result<bool>;
 
     /// Set a task, overwriting any existing task.  If the task does not exist, this implicitly
     /// creates it (use `get_task` to check first, if necessary).
-    fn set_task(&mut self, uuid: Uuid, task: TaskMap) -> Result<()>;
+    async fn set_task(&mut self, uuid: Uuid, task: TaskMap) -> Result<()>;
 
     /// Delete a task, if it exists.  Returns true if the task was deleted (already existed)
-    fn delete_task(&mut self, uuid: Uuid) -> Result<bool>;
+    async fn delete_task(&mut self, uuid: Uuid) -> Result<bool>;
 
     /// Get the uuids and bodies of all tasks in the storage, in undefined order.
-    fn all_tasks(&mut self) -> Result<Vec<(Uuid, TaskMap)>>;
+    async fn all_tasks(&mut self) -> Result<Vec<(Uuid, TaskMap)>>;
 
     /// Get the uuids of all tasks in the storage, in undefined order.
-    fn all_task_uuids(&mut self) -> Result<Vec<Uuid>>;
+    async fn all_task_uuids(&mut self) -> Result<Vec<Uuid>>;
 
     /// Get the current base_version for this storage -- the last version synced from the server.
-    fn base_version(&mut self) -> Result<VersionId>;
+    async fn base_version(&mut self) -> Result<VersionId>;
 
     /// Set the current base_version for this storage.
-    fn set_base_version(&mut self, version: VersionId) -> Result<()>;
+    async fn set_base_version(&mut self, version: VersionId) -> Result<()>;
 
     /// Get the set of operations for the given task.
-    fn get_task_operations(&mut self, uuid: Uuid) -> Result<Vec<Operation>>;
+    async fn get_task_operations(&mut self, uuid: Uuid) -> Result<Vec<Operation>>;
 
     /// Get the current set of outstanding operations (operations that have not been synced to the
     /// server yet)
-    fn unsynced_operations(&mut self) -> Result<Vec<Operation>>;
+    async fn unsynced_operations(&mut self) -> Result<Vec<Operation>>;
 
     /// Get the current set of outstanding operations (operations that have not been synced to the
     /// server yet)
-    fn num_unsynced_operations(&mut self) -> Result<usize>;
+    async fn num_unsynced_operations(&mut self) -> Result<usize>;
 
     /// Add an operation to the end of the list of operations in the storage.  Note that this
-    /// merely *stores* the operation; it is up to the TaskDb to apply it.
-    fn add_operation(&mut self, op: Operation) -> Result<()>;
+    //. merely *stores* the operation; it is up to the TaskDb to apply it.
+    async fn add_operation(&mut self, op: Operation) -> Result<()>;
 
     /// Remove an operation from the end of the list of operations in the storage.  The operation
     /// must exactly match the most recent operation, and must not be synced. Note that like
     /// `add_operation` this only affects the list of operations.
-    fn remove_operation(&mut self, op: Operation) -> Result<()>;
+    async fn remove_operation(&mut self, op: Operation) -> Result<()>;
 
     /// A sync has been completed, so all operations should be marked as synced. The storage
     /// may perform additional cleanup at this time.
-    fn sync_complete(&mut self) -> Result<()>;
+    async fn sync_complete(&mut self) -> Result<()>;
 
     /// Get the entire working set, with each task UUID at its appropriate (1-based) index.
     /// Element 0 is always None.
-    fn get_working_set(&mut self) -> Result<Vec<Option<Uuid>>>;
+    async fn get_working_set(&mut self) -> Result<Vec<Option<Uuid>>>;
 
     /// Add a task to the working set and return its (one-based) index.  This index will be one greater
     /// than the highest used index.
-    fn add_to_working_set(&mut self, uuid: Uuid) -> Result<usize>;
+    async fn add_to_working_set(&mut self, uuid: Uuid) -> Result<usize>;
 
     /// Update the working set task at the given index.  This cannot add a new item to the
     /// working set.
-    fn set_working_set_item(&mut self, index: usize, uuid: Option<Uuid>) -> Result<()>;
+    async fn set_working_set_item(&mut self, index: usize, uuid: Option<Uuid>) -> Result<()>;
 
     /// Clear all tasks from the working set in preparation for a renumbering operation.
     /// Note that this is the only way items are removed from the set.
-    fn clear_working_set(&mut self) -> Result<()>;
+    async fn clear_working_set(&mut self) -> Result<()>;
 
     /// Check whether this storage is entirely empty
     #[allow(clippy::wrong_self_convention)] // mut is required here for storage access
-    fn is_empty(&mut self) -> Result<bool> {
+    async fn is_empty(&mut self) -> Result<bool> {
         let mut empty = true;
-        empty = empty && self.all_tasks()?.is_empty();
-        empty = empty && self.get_working_set()? == vec![None];
-        empty = empty && self.base_version()? == Uuid::nil();
-        empty = empty && self.unsynced_operations()?.is_empty();
+        empty = empty && self.all_tasks().await?.is_empty();
+        empty = empty && self.get_working_set().await? == vec![None];
+        empty = empty && self.base_version().await? == Uuid::nil();
+        empty = empty && self.unsynced_operations().await?.is_empty();
         Ok(empty)
     }
 
     /// Commit any changes made in the transaction.  It is an error to call this more than
     /// once.
-    fn commit(&mut self) -> Result<()>;
+    async fn commit(&mut self) -> Result<()>;
 }
 
 /// A trait for objects able to act as task storage.  Most of the interesting behavior is in the
 /// [`crate::storage::StorageTxn`] trait.
-pub trait Storage {
+#[async_trait]
+pub trait Storage: Send {
     /// Begin a transaction
-    fn txn<'a>(&'a mut self) -> Result<Box<dyn StorageTxn + 'a>>;
+    async fn txn<'a>(&'a mut self) -> Result<Box<dyn StorageTxn + Send + 'a>>;
 }

--- a/src/storage/sqlite/mod.rs
+++ b/src/storage/sqlite/mod.rs
@@ -1,0 +1,428 @@
+use crate::errors::{Error, Result};
+use crate::operation::Operation;
+use crate::storage::config::AccessMode;
+use crate::storage::sqlite::inner::SqliteStorageInner;
+use crate::storage::{Storage, StorageTxn, TaskMap, VersionId};
+use async_trait::async_trait;
+use rusqlite::types::FromSql;
+use rusqlite::ToSql;
+use std::path::Path;
+use std::sync::mpsc;
+use std::thread;
+use tokio::sync::oneshot;
+use uuid::Uuid;
+
+mod inner;
+mod schema;
+
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub(crate) enum SqliteError {
+    #[error("SQLite transaction already committted")]
+    TransactionAlreadyCommitted,
+    #[error("Task storage was opened in read-only mode")]
+    ReadOnlyStorage,
+}
+
+/// Newtype to allow implementing `FromSql` for foreign `uuid::Uuid`
+pub(crate) struct StoredUuid(pub(crate) Uuid);
+
+/// Conversion from Uuid stored as a string (rusqlite's uuid feature stores as binary blob)
+impl FromSql for StoredUuid {
+    fn column_result(value: rusqlite::types::ValueRef<'_>) -> rusqlite::types::FromSqlResult<Self> {
+        let u = Uuid::parse_str(value.as_str()?)
+            .map_err(|_| rusqlite::types::FromSqlError::InvalidType)?;
+        Ok(StoredUuid(u))
+    }
+}
+
+/// Store Uuid as string in database
+impl ToSql for StoredUuid {
+    fn to_sql(&self) -> rusqlite::Result<rusqlite::types::ToSqlOutput<'_>> {
+        let s = self.0.to_string();
+        Ok(s.into())
+    }
+}
+
+/// An enum for messages sent to the sync thread actor.
+pub(crate) enum ActorMessage {
+    // Transaction control
+    BeginTxn(oneshot::Sender<Result<mpsc::Sender<TxnMessage>>>),
+}
+
+pub(crate) enum TxnMessage {
+    Commit(oneshot::Sender<Result<()>>),
+    Rollback(oneshot::Sender<Result<()>>),
+
+    // Transactional operations
+    GetTask(Uuid, oneshot::Sender<Result<Option<TaskMap>>>),
+    GetPendingTasks(oneshot::Sender<Result<Vec<(Uuid, TaskMap)>>>),
+    CreateTask(Uuid, oneshot::Sender<Result<bool>>),
+    SetTask(Uuid, TaskMap, oneshot::Sender<Result<()>>),
+    DeleteTask(Uuid, oneshot::Sender<Result<bool>>),
+    AllTasks(oneshot::Sender<Result<Vec<(Uuid, TaskMap)>>>),
+    AllTaskUuids(oneshot::Sender<Result<Vec<Uuid>>>),
+    BaseVersion(oneshot::Sender<Result<VersionId>>),
+    SetBaseVersion(VersionId, oneshot::Sender<Result<()>>),
+    GetTaskOperations(Uuid, oneshot::Sender<Result<Vec<Operation>>>),
+    UnsyncedOperations(oneshot::Sender<Result<Vec<Operation>>>),
+    NumUnsyncedOperations(oneshot::Sender<Result<usize>>),
+    AddOperation(Operation, oneshot::Sender<Result<()>>),
+    RemoveOperation(Operation, oneshot::Sender<Result<()>>),
+    SyncComplete(oneshot::Sender<Result<()>>),
+    GetWorkingSet(oneshot::Sender<Result<Vec<Option<Uuid>>>>),
+    AddToWorkingSet(Uuid, oneshot::Sender<Result<usize>>),
+    SetWorkingSetItem(usize, Option<Uuid>, oneshot::Sender<Result<()>>),
+    ClearWorkingSet(oneshot::Sender<Result<()>>),
+}
+
+/// State owned by the dedicated synchronous thread. It handles the low-level,
+/// sync db ops.
+struct Actor {
+    storage: SqliteStorageInner,
+    receiver: mpsc::Receiver<ActorMessage>,
+}
+
+impl Actor {
+    fn run(&mut self) {
+        // The outer loop waits for a BeginTxn message. If the channel is disconnected,
+        // the thread will exit gracefully.
+        while let Ok(ActorMessage::BeginTxn(reply_sender)) = self.receiver.recv() {
+            let (txn_sender, txn_receiver) = mpsc::channel::<TxnMessage>();
+            match self.storage.txn() {
+                Ok(mut txn) => {
+                    // Send the new transaction channel sender back
+                    if reply_sender.send(Ok(txn_sender)).is_err() {
+                        log::warn!("Client disconnected before transaction could be established");
+                        continue; // Don't handle the txn if the client is gone.
+                    }
+                    Self::handle_transaction(&txn_receiver, &mut txn);
+                }
+                Err(e) => {
+                    // Send the database error back to the caller
+                    log::error!("Could not start SQLite transaction: {e}");
+                    let _ = reply_sender.send(Err(e));
+                }
+            }
+        }
+    }
+
+    /// The inner loop for handling messages within an active transaction.
+    fn handle_transaction(
+        receiver: &mpsc::Receiver<TxnMessage>,
+        txn: &mut crate::storage::sqlite::inner::Txn,
+    ) {
+        while let Ok(msg) = receiver.recv() {
+            match msg {
+                TxnMessage::Commit(resp) => {
+                    let _ = resp.send(txn.commit());
+                    return; // Transaction over, return to the outer loop.
+                }
+                TxnMessage::Rollback(resp) => {
+                    // The sync txn is implicitly rolled back when it's dropped.
+                    let _ = resp.send(Ok(()));
+                    return; // Transaction over, return to the outer loop.
+                }
+                TxnMessage::GetTask(uuid, resp) => {
+                    let _ = resp.send(txn.get_task(uuid));
+                }
+                TxnMessage::GetPendingTasks(resp) => {
+                    let _ = resp.send(txn.get_pending_tasks());
+                }
+                TxnMessage::CreateTask(uuid, resp) => {
+                    let _ = resp.send(txn.create_task(uuid));
+                }
+                TxnMessage::SetTask(uuid, t, resp) => {
+                    let _ = resp.send(txn.set_task(uuid, t));
+                }
+                TxnMessage::DeleteTask(uuid, resp) => {
+                    let _ = resp.send(txn.delete_task(uuid));
+                }
+                TxnMessage::AllTasks(resp) => {
+                    let _ = resp.send(txn.all_tasks());
+                }
+                TxnMessage::AllTaskUuids(resp) => {
+                    let _ = resp.send(txn.all_task_uuids());
+                }
+                TxnMessage::BaseVersion(resp) => {
+                    let _ = resp.send(txn.base_version());
+                }
+                TxnMessage::SetBaseVersion(v, resp) => {
+                    let _ = resp.send(txn.set_base_version(v));
+                }
+                TxnMessage::GetTaskOperations(u, resp) => {
+                    let _ = resp.send(txn.get_task_operations(u));
+                }
+                TxnMessage::UnsyncedOperations(resp) => {
+                    let _ = resp.send(txn.unsynced_operations());
+                }
+                TxnMessage::NumUnsyncedOperations(resp) => {
+                    let _ = resp.send(txn.num_unsynced_operations());
+                }
+                TxnMessage::AddOperation(o, resp) => {
+                    let _ = resp.send(txn.add_operation(o));
+                }
+                TxnMessage::RemoveOperation(o, resp) => {
+                    let _ = resp.send(txn.remove_operation(o));
+                }
+                TxnMessage::SyncComplete(resp) => {
+                    let _ = resp.send(txn.sync_complete());
+                }
+                TxnMessage::GetWorkingSet(resp) => {
+                    let _ = resp.send(txn.get_working_set());
+                }
+                TxnMessage::AddToWorkingSet(u, resp) => {
+                    let _ = resp.send(txn.add_to_working_set(u));
+                }
+                TxnMessage::SetWorkingSetItem(i, u, resp) => {
+                    let _ = resp.send(txn.set_working_set_item(i, u));
+                }
+                TxnMessage::ClearWorkingSet(resp) => {
+                    let _ = resp.send(txn.clear_working_set());
+                }
+            };
+        }
+    }
+}
+
+/// SqliteStorageActor is an async actor wrapper for the sync SqliteStorage.
+#[derive(Clone)]
+pub struct SqliteStorage {
+    sender: mpsc::Sender<ActorMessage>,
+}
+
+impl SqliteStorage {
+    pub fn new<P: AsRef<Path>>(
+        path: P,
+        access_mode: AccessMode,
+        create_if_missing: bool,
+    ) -> Result<Self> {
+        let (sender, receiver) = mpsc::channel();
+        let path = path.as_ref().to_path_buf();
+
+        // Use a sync_channel to block until the thread has initialized.
+        let (init_sender, init_receiver) = mpsc::sync_channel(0);
+
+        thread::spawn(move || {
+            match SqliteStorageInner::new(path, access_mode, create_if_missing) {
+                Ok(storage) => {
+                    // Send Ok back to the caller of `new` and then start the actor loop.
+                    init_sender.send(Ok(())).unwrap();
+                    let mut actor = Actor { storage, receiver };
+                    actor.run();
+                }
+                Err(e) => {
+                    // Send the initialization error back.
+                    init_sender.send(Err(e)).unwrap();
+                }
+            }
+        });
+
+        // Block until the thread sends its initialization result.
+        init_receiver.recv().unwrap()?;
+        Ok(Self { sender })
+    }
+}
+
+#[async_trait]
+impl Storage for SqliteStorage {
+    // Sends the BeginTxn message to the underlying SqliteStorage. Now that the txn has
+    // begun, this async txn obj can be passed around and operated upon, as it
+    // communicates with the underlying sync txn.
+    async fn txn<'a>(&'a mut self) -> Result<Box<dyn StorageTxn + Send + 'a>> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.sender
+            .send(ActorMessage::BeginTxn(reply_tx))
+            .map_err(|e| Error::Other(e.into()))?;
+        let txn_sender = reply_rx.await??;
+        Ok(Box::new(ActorTxn::new(txn_sender)))
+    }
+}
+
+/// An async proxy for a transaction running on the sync actor thread.
+pub(super) struct ActorTxn {
+    sender: mpsc::Sender<TxnMessage>,
+    committed: bool,
+}
+
+impl ActorTxn {
+    fn new(sender: mpsc::Sender<TxnMessage>) -> Self {
+        Self {
+            sender,
+            committed: false,
+        }
+    }
+
+    async fn call<R, F>(&self, f: F) -> Result<R>
+    where
+        F: FnOnce(oneshot::Sender<Result<R>>) -> TxnMessage,
+        R: Send + 'static,
+    {
+        let (tx, rx) = oneshot::channel();
+        self.sender
+            .send(f(tx))
+            .map_err(|e| Error::Other(e.into()))?;
+        rx.await?
+    }
+}
+
+impl Drop for ActorTxn {
+    fn drop(&mut self) {
+        if !self.committed {
+            // If the transaction proxy is dropped without being committed,
+            // we send a Rollback message. We don't need to wait for the response.
+            let (tx, _rx) = oneshot::channel();
+            let _ = self.sender.send(TxnMessage::Rollback(tx));
+        }
+    }
+}
+
+#[async_trait]
+impl StorageTxn for ActorTxn {
+    async fn commit(&mut self) -> Result<()> {
+        let res = self.call(TxnMessage::Commit).await;
+        if res.is_ok() {
+            self.committed = true;
+        }
+        res
+    }
+
+    async fn get_task(&mut self, uuid: Uuid) -> Result<Option<TaskMap>> {
+        self.call(|tx| TxnMessage::GetTask(uuid, tx)).await
+    }
+
+    async fn create_task(&mut self, uuid: Uuid) -> Result<bool> {
+        self.call(|tx| TxnMessage::CreateTask(uuid, tx)).await
+    }
+
+    async fn set_task(&mut self, uuid: Uuid, task: TaskMap) -> Result<()> {
+        self.call(|tx| TxnMessage::SetTask(uuid, task, tx)).await
+    }
+
+    async fn delete_task(&mut self, uuid: Uuid) -> Result<bool> {
+        self.call(|tx| TxnMessage::DeleteTask(uuid, tx)).await
+    }
+
+    async fn get_pending_tasks(&mut self) -> Result<Vec<(Uuid, TaskMap)>> {
+        self.call(TxnMessage::GetPendingTasks).await
+    }
+
+    async fn all_tasks(&mut self) -> Result<Vec<(Uuid, TaskMap)>> {
+        self.call(TxnMessage::AllTasks).await
+    }
+
+    async fn all_task_uuids(&mut self) -> Result<Vec<Uuid>> {
+        self.call(TxnMessage::AllTaskUuids).await
+    }
+
+    async fn base_version(&mut self) -> Result<VersionId> {
+        self.call(TxnMessage::BaseVersion).await
+    }
+
+    async fn set_base_version(&mut self, version: VersionId) -> Result<()> {
+        self.call(|tx| TxnMessage::SetBaseVersion(version, tx))
+            .await
+    }
+
+    async fn get_task_operations(&mut self, uuid: Uuid) -> Result<Vec<Operation>> {
+        self.call(|tx| TxnMessage::GetTaskOperations(uuid, tx))
+            .await
+    }
+
+    async fn unsynced_operations(&mut self) -> Result<Vec<Operation>> {
+        self.call(TxnMessage::UnsyncedOperations).await
+    }
+
+    async fn num_unsynced_operations(&mut self) -> Result<usize> {
+        self.call(TxnMessage::NumUnsyncedOperations).await
+    }
+
+    async fn add_operation(&mut self, op: Operation) -> Result<()> {
+        self.call(|tx| TxnMessage::AddOperation(op, tx)).await
+    }
+
+    async fn remove_operation(&mut self, op: Operation) -> Result<()> {
+        self.call(|tx| TxnMessage::RemoveOperation(op, tx)).await
+    }
+
+    async fn sync_complete(&mut self) -> Result<()> {
+        self.call(TxnMessage::SyncComplete).await
+    }
+
+    async fn get_working_set(&mut self) -> Result<Vec<Option<Uuid>>> {
+        self.call(TxnMessage::GetWorkingSet).await
+    }
+
+    async fn add_to_working_set(&mut self, uuid: Uuid) -> Result<usize> {
+        self.call(|tx| TxnMessage::AddToWorkingSet(uuid, tx)).await
+    }
+
+    async fn set_working_set_item(&mut self, index: usize, uuid: Option<Uuid>) -> Result<()> {
+        self.call(|tx| TxnMessage::SetWorkingSetItem(index, uuid, tx))
+            .await
+    }
+
+    async fn clear_working_set(&mut self) -> Result<()> {
+        self.call(TxnMessage::ClearWorkingSet).await
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::storage::config::AccessMode;
+    use pretty_assertions::assert_eq;
+    use tempfile::TempDir;
+
+    fn storage() -> Result<SqliteStorage> {
+        let tmp_dir = TempDir::new()?;
+        SqliteStorage::new(tmp_dir.path(), AccessMode::ReadWrite, true)
+    }
+
+    #[tokio::test]
+    async fn test_implicit_rollback() -> Result<()> {
+        let mut storage = storage()?;
+        let uuid = Uuid::new_v4();
+
+        // Begin a transaction, create a task, but do not commit.
+        // The transaction will go out of scope, triggering Drop.
+        {
+            let mut txn = storage.txn().await?;
+            assert!(txn.create_task(uuid).await?);
+            // txn is dropped here, which should trigger a rollback message.
+        }
+
+        // Begin a new transaction and verify the task does not exist.
+        let mut txn = storage.txn().await?;
+        let task = txn.get_task(uuid).await?;
+        assert_eq!(task, None, "Task should not exist after implicit rollback");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_init_failure() -> Result<()> {
+        let tmp_dir = TempDir::new()?;
+        let file_path = tmp_dir.path().join("a_file");
+        std::fs::write(&file_path, "I am a file, not a directory")?;
+
+        // Try to create the storage inside a path that is a file, not a directory.
+        // This should cause SqliteStorage::new to fail inside the actor thread.
+        let result = SqliteStorage::new(&file_path, AccessMode::ReadWrite, true);
+        assert!(
+            result.is_err(),
+            "Initialization should fail for an invalid path"
+        );
+
+        // Check for the expected error message propagated from the actor thread.
+        if let Err(Error::Database(msg)) = result {
+            assert!(
+                msg.contains("Cannot create directory"),
+                "Error message should indicate a directory creation problem"
+            );
+        } else {
+            panic!("Expected a Database error");
+        }
+
+        Ok(())
+    }
+}

--- a/src/storage/test.rs
+++ b/src/storage/test.rs
@@ -12,181 +12,181 @@ use uuid::Uuid;
 /// Define a collection of storage tests that apply to all storage implementations.
 macro_rules! storage_tests {
     ($storage:expr) => {
-        #[test]
-        fn get_working_set_empty() -> $crate::errors::Result<()> {
-            $crate::storage::test::get_working_set_empty($storage)
+        #[tokio::test]
+        async fn get_working_set_empty() -> $crate::errors::Result<()> {
+            $crate::storage::test::get_working_set_empty($storage).await
         }
 
-        #[test]
-        fn add_to_working_set() -> $crate::errors::Result<()> {
-            $crate::storage::test::add_to_working_set($storage)
+        #[tokio::test]
+        async fn add_to_working_set() -> $crate::errors::Result<()> {
+            $crate::storage::test::add_to_working_set($storage).await
         }
 
-        #[test]
-        fn clear_working_set() -> $crate::errors::Result<()> {
-            $crate::storage::test::clear_working_set($storage)
+        #[tokio::test]
+        async fn clear_working_set() -> $crate::errors::Result<()> {
+            $crate::storage::test::clear_working_set($storage).await
         }
 
-        #[test]
-        fn drop_transaction() -> $crate::errors::Result<()> {
-            $crate::storage::test::drop_transaction($storage)
+        #[tokio::test]
+        async fn drop_transaction() -> $crate::errors::Result<()> {
+            $crate::storage::test::drop_transaction($storage).await
         }
 
-        #[test]
-        fn create() -> $crate::errors::Result<()> {
-            $crate::storage::test::create($storage)
+        #[tokio::test]
+        async fn create() -> $crate::errors::Result<()> {
+            $crate::storage::test::create($storage).await
         }
 
-        #[test]
-        fn create_exists() -> $crate::errors::Result<()> {
-            $crate::storage::test::create_exists($storage)
+        #[tokio::test]
+        async fn create_exists() -> $crate::errors::Result<()> {
+            $crate::storage::test::create_exists($storage).await
         }
 
-        #[test]
-        fn get_missing() -> $crate::errors::Result<()> {
-            $crate::storage::test::get_missing($storage)
+        #[tokio::test]
+        async fn get_missing() -> $crate::errors::Result<()> {
+            $crate::storage::test::get_missing($storage).await
         }
 
-        #[test]
-        fn set_task() -> $crate::errors::Result<()> {
-            $crate::storage::test::set_task($storage)
+        #[tokio::test]
+        async fn set_task() -> $crate::errors::Result<()> {
+            $crate::storage::test::set_task($storage).await
         }
 
-        #[test]
-        fn delete_task_missing() -> $crate::errors::Result<()> {
-            $crate::storage::test::delete_task_missing($storage)
+        #[tokio::test]
+        async fn delete_task_missing() -> $crate::errors::Result<()> {
+            $crate::storage::test::delete_task_missing($storage).await
         }
 
-        #[test]
-        fn delete_task_exists() -> $crate::errors::Result<()> {
-            $crate::storage::test::delete_task_exists($storage)
+        #[tokio::test]
+        async fn delete_task_exists() -> $crate::errors::Result<()> {
+            $crate::storage::test::delete_task_exists($storage).await
         }
 
-        #[test]
-        fn all_tasks_empty() -> $crate::errors::Result<()> {
-            $crate::storage::test::all_tasks_empty($storage)
+        #[tokio::test]
+        async fn all_tasks_empty() -> $crate::errors::Result<()> {
+            $crate::storage::test::all_tasks_empty($storage).await
         }
 
-        #[test]
-        fn all_tasks_and_uuids() -> $crate::errors::Result<()> {
-            $crate::storage::test::all_tasks_and_uuids($storage)
+        #[tokio::test]
+        async fn all_tasks_and_uuids() -> $crate::errors::Result<()> {
+            $crate::storage::test::all_tasks_and_uuids($storage).await
         }
 
-        #[test]
-        fn base_version_default() -> Result<()> {
-            $crate::storage::test::base_version_default($storage)
+        #[tokio::test]
+        async fn base_version_default() -> Result<()> {
+            $crate::storage::test::base_version_default($storage).await
         }
 
-        #[test]
-        fn base_version_setting() -> Result<()> {
-            $crate::storage::test::base_version_setting($storage)
+        #[tokio::test]
+        async fn base_version_setting() -> Result<()> {
+            $crate::storage::test::base_version_setting($storage).await
         }
 
-        #[test]
-        fn unsynced_operations() -> Result<()> {
-            $crate::storage::test::unsynced_operations($storage)
+        #[tokio::test]
+        async fn unsynced_operations() -> Result<()> {
+            $crate::storage::test::unsynced_operations($storage).await
         }
 
-        #[test]
-        fn remove_operations() -> Result<()> {
-            $crate::storage::test::remove_operations($storage)
+        #[tokio::test]
+        async fn remove_operations() -> Result<()> {
+            $crate::storage::test::remove_operations($storage).await
         }
 
-        #[test]
-        fn task_operations() -> Result<()> {
-            $crate::storage::test::task_operations($storage)
+        #[tokio::test]
+        async fn task_operations() -> Result<()> {
+            $crate::storage::test::task_operations($storage).await
         }
 
-        #[test]
-        fn sync_complete() -> Result<()> {
-            $crate::storage::test::sync_complete($storage)
+        #[tokio::test]
+        async fn sync_complete() -> Result<()> {
+            $crate::storage::test::sync_complete($storage).await
         }
 
-        #[test]
-        fn set_working_set_item() -> Result<()> {
-            $crate::storage::test::set_working_set_item($storage)
+        #[tokio::test]
+        async fn set_working_set_item() -> Result<()> {
+            $crate::storage::test::set_working_set_item($storage).await
         }
     };
 }
 pub(crate) use storage_tests;
 
-pub(super) fn get_working_set_empty(mut storage: impl Storage) -> Result<()> {
+pub(super) async fn get_working_set_empty(mut storage: impl Storage) -> Result<()> {
     {
-        let mut txn = storage.txn()?;
-        let ws = txn.get_working_set()?;
+        let mut txn = storage.txn().await?;
+        let ws = txn.get_working_set().await?;
         assert_eq!(ws, vec![None]);
     }
 
     Ok(())
 }
 
-pub(super) fn add_to_working_set(mut storage: impl Storage) -> Result<()> {
+pub(super) async fn add_to_working_set(mut storage: impl Storage) -> Result<()> {
     let uuid1 = Uuid::new_v4();
     let uuid2 = Uuid::new_v4();
 
     {
-        let mut txn = storage.txn()?;
-        txn.add_to_working_set(uuid1)?;
-        txn.add_to_working_set(uuid2)?;
-        txn.commit()?;
+        let mut txn = storage.txn().await?;
+        txn.add_to_working_set(uuid1).await?;
+        txn.add_to_working_set(uuid2).await?;
+        txn.commit().await?;
     }
 
     {
-        let mut txn = storage.txn()?;
-        let ws = txn.get_working_set()?;
+        let mut txn = storage.txn().await?;
+        let ws = txn.get_working_set().await?;
         assert_eq!(ws, vec![None, Some(uuid1), Some(uuid2)]);
     }
 
     Ok(())
 }
 
-pub(super) fn clear_working_set(mut storage: impl Storage) -> Result<()> {
+pub(super) async fn clear_working_set(mut storage: impl Storage) -> Result<()> {
     let uuid1 = Uuid::new_v4();
     let uuid2 = Uuid::new_v4();
 
     {
-        let mut txn = storage.txn()?;
-        txn.add_to_working_set(uuid1)?;
-        txn.add_to_working_set(uuid2)?;
-        txn.commit()?;
+        let mut txn = storage.txn().await?;
+        txn.add_to_working_set(uuid1).await?;
+        txn.add_to_working_set(uuid2).await?;
+        txn.commit().await?;
     }
 
     {
-        let mut txn = storage.txn()?;
-        txn.clear_working_set()?;
-        txn.add_to_working_set(uuid2)?;
-        txn.add_to_working_set(uuid1)?;
-        txn.commit()?;
+        let mut txn = storage.txn().await?;
+        txn.clear_working_set().await?;
+        txn.add_to_working_set(uuid2).await?;
+        txn.add_to_working_set(uuid1).await?;
+        txn.commit().await?;
     }
 
     {
-        let mut txn = storage.txn()?;
-        let ws = txn.get_working_set()?;
+        let mut txn = storage.txn().await?;
+        let ws = txn.get_working_set().await?;
         assert_eq!(ws, vec![None, Some(uuid2), Some(uuid1)]);
     }
 
     Ok(())
 }
 
-pub(super) fn drop_transaction(mut storage: impl Storage) -> Result<()> {
+pub(super) async fn drop_transaction(mut storage: impl Storage) -> Result<()> {
     let uuid1 = Uuid::new_v4();
     let uuid2 = Uuid::new_v4();
 
     {
-        let mut txn = storage.txn()?;
-        assert!(txn.create_task(uuid1)?);
-        txn.commit()?;
+        let mut txn = storage.txn().await?;
+        assert!(txn.create_task(uuid1).await?);
+        txn.commit().await?;
     }
 
     {
-        let mut txn = storage.txn()?;
-        assert!(txn.create_task(uuid2)?);
+        let mut txn = storage.txn().await?;
+        assert!(txn.create_task(uuid2).await?);
         std::mem::drop(txn); // Unnecessary explicit drop of transaction
     }
 
     {
-        let mut txn = storage.txn()?;
-        let uuids = txn.all_task_uuids()?;
+        let mut txn = storage.txn().await?;
+        let uuids = txn.all_task_uuids().await?;
 
         assert_eq!(uuids, [uuid1]);
     }
@@ -194,56 +194,57 @@ pub(super) fn drop_transaction(mut storage: impl Storage) -> Result<()> {
     Ok(())
 }
 
-pub(super) fn create(mut storage: impl Storage) -> Result<()> {
+pub(super) async fn create(mut storage: impl Storage) -> Result<()> {
     let uuid = Uuid::new_v4();
     {
-        let mut txn = storage.txn()?;
-        assert!(txn.create_task(uuid)?);
-        txn.commit()?;
+        let mut txn = storage.txn().await?;
+        assert!(txn.create_task(uuid).await?);
+        txn.commit().await?;
     }
     {
-        let mut txn = storage.txn()?;
-        let task = txn.get_task(uuid)?;
+        let mut txn = storage.txn().await?;
+        let task = txn.get_task(uuid).await?;
         assert_eq!(task, Some(taskmap_with(vec![])));
     }
     Ok(())
 }
 
-pub(super) fn create_exists(mut storage: impl Storage) -> Result<()> {
+pub(super) async fn create_exists(mut storage: impl Storage) -> Result<()> {
     let uuid = Uuid::new_v4();
     {
-        let mut txn = storage.txn()?;
-        assert!(txn.create_task(uuid)?);
-        txn.commit()?;
+        let mut txn = storage.txn().await?;
+        assert!(txn.create_task(uuid).await?);
+        txn.commit().await?;
     }
     {
-        let mut txn = storage.txn()?;
-        assert!(!txn.create_task(uuid)?);
-        txn.commit()?;
+        let mut txn = storage.txn().await?;
+        assert!(!txn.create_task(uuid).await?);
+        txn.commit().await?;
     }
     Ok(())
 }
 
-pub(super) fn get_missing(mut storage: impl Storage) -> Result<()> {
+pub(super) async fn get_missing(mut storage: impl Storage) -> Result<()> {
     let uuid = Uuid::new_v4();
     {
-        let mut txn = storage.txn()?;
-        let task = txn.get_task(uuid)?;
+        let mut txn = storage.txn().await?;
+        let task = txn.get_task(uuid).await?;
         assert_eq!(task, None);
     }
     Ok(())
 }
 
-pub(super) fn set_task(mut storage: impl Storage) -> Result<()> {
+pub(super) async fn set_task(mut storage: impl Storage) -> Result<()> {
     let uuid = Uuid::new_v4();
     {
-        let mut txn = storage.txn()?;
-        txn.set_task(uuid, taskmap_with(vec![("k".to_string(), "v".to_string())]))?;
-        txn.commit()?;
+        let mut txn = storage.txn().await?;
+        txn.set_task(uuid, taskmap_with(vec![("k".to_string(), "v".to_string())]))
+            .await?;
+        txn.commit().await?;
     }
     {
-        let mut txn = storage.txn()?;
-        let task = txn.get_task(uuid)?;
+        let mut txn = storage.txn().await?;
+        let task = txn.get_task(uuid).await?;
         assert_eq!(
             task,
             Some(taskmap_with(vec![("k".to_string(), "v".to_string())]))
@@ -252,58 +253,60 @@ pub(super) fn set_task(mut storage: impl Storage) -> Result<()> {
     Ok(())
 }
 
-pub(super) fn delete_task_missing(mut storage: impl Storage) -> Result<()> {
+pub(super) async fn delete_task_missing(mut storage: impl Storage) -> Result<()> {
     let uuid = Uuid::new_v4();
     {
-        let mut txn = storage.txn()?;
-        assert!(!txn.delete_task(uuid)?);
+        let mut txn = storage.txn().await?;
+        assert!(!txn.delete_task(uuid).await?);
     }
     Ok(())
 }
 
-pub(super) fn delete_task_exists(mut storage: impl Storage) -> Result<()> {
+pub(super) async fn delete_task_exists(mut storage: impl Storage) -> Result<()> {
     let uuid = Uuid::new_v4();
     {
-        let mut txn = storage.txn()?;
-        assert!(txn.create_task(uuid)?);
-        txn.commit()?;
+        let mut txn = storage.txn().await?;
+        assert!(txn.create_task(uuid).await?);
+        txn.commit().await?;
     }
     {
-        let mut txn = storage.txn()?;
-        assert!(txn.delete_task(uuid)?);
+        let mut txn = storage.txn().await?;
+        assert!(txn.delete_task(uuid).await?);
     }
     Ok(())
 }
 
-pub(super) fn all_tasks_empty(mut storage: impl Storage) -> Result<()> {
+pub(super) async fn all_tasks_empty(mut storage: impl Storage) -> Result<()> {
     {
-        let mut txn = storage.txn()?;
-        let tasks = txn.all_tasks()?;
+        let mut txn = storage.txn().await?;
+        let tasks = txn.all_tasks().await?;
         assert_eq!(tasks, vec![]);
     }
     Ok(())
 }
 
-pub(super) fn all_tasks_and_uuids(mut storage: impl Storage) -> Result<()> {
+pub(super) async fn all_tasks_and_uuids(mut storage: impl Storage) -> Result<()> {
     let uuid1 = Uuid::new_v4();
     let uuid2 = Uuid::new_v4();
     {
-        let mut txn = storage.txn()?;
-        assert!(txn.create_task(uuid1)?);
+        let mut txn = storage.txn().await?;
+        assert!(txn.create_task(uuid1).await?);
         txn.set_task(
             uuid1,
             taskmap_with(vec![("num".to_string(), "1".to_string())]),
-        )?;
-        assert!(txn.create_task(uuid2)?);
+        )
+        .await?;
+        assert!(txn.create_task(uuid2).await?);
         txn.set_task(
             uuid2,
             taskmap_with(vec![("num".to_string(), "2".to_string())]),
-        )?;
-        txn.commit()?;
+        )
+        .await?;
+        txn.commit().await?;
     }
     {
-        let mut txn = storage.txn()?;
-        let mut tasks = txn.all_tasks()?;
+        let mut txn = storage.txn().await?;
+        let mut tasks = txn.all_tasks().await?;
 
         // order is nondeterministic, so sort by uuid
         tasks.sort_by(|a, b| a.0.cmp(&b.0));
@@ -323,8 +326,8 @@ pub(super) fn all_tasks_and_uuids(mut storage: impl Storage) -> Result<()> {
         assert_eq!(tasks, exp);
     }
     {
-        let mut txn = storage.txn()?;
-        let mut uuids = txn.all_task_uuids()?;
+        let mut txn = storage.txn().await?;
+        let mut uuids = txn.all_task_uuids().await?;
         uuids.sort();
 
         let mut exp = vec![uuid1, uuid2];
@@ -335,45 +338,45 @@ pub(super) fn all_tasks_and_uuids(mut storage: impl Storage) -> Result<()> {
     Ok(())
 }
 
-pub(super) fn base_version_default(mut storage: impl Storage) -> Result<()> {
+pub(super) async fn base_version_default(mut storage: impl Storage) -> Result<()> {
     {
-        let mut txn = storage.txn()?;
-        assert_eq!(txn.base_version()?, DEFAULT_BASE_VERSION);
+        let mut txn = storage.txn().await?;
+        assert_eq!(txn.base_version().await?, DEFAULT_BASE_VERSION);
     }
     Ok(())
 }
 
-pub(super) fn base_version_setting(mut storage: impl Storage) -> Result<()> {
+pub(super) async fn base_version_setting(mut storage: impl Storage) -> Result<()> {
     let u = Uuid::new_v4();
     {
-        let mut txn = storage.txn()?;
-        txn.set_base_version(u)?;
-        txn.commit()?;
+        let mut txn = storage.txn().await?;
+        txn.set_base_version(u).await?;
+        txn.commit().await?;
     }
     {
-        let mut txn = storage.txn()?;
-        assert_eq!(txn.base_version()?, u);
+        let mut txn = storage.txn().await?;
+        assert_eq!(txn.base_version().await?, u);
     }
     Ok(())
 }
 
-pub(super) fn unsynced_operations(mut storage: impl Storage) -> Result<()> {
+pub(super) async fn unsynced_operations(mut storage: impl Storage) -> Result<()> {
     let uuid1 = Uuid::new_v4();
     let uuid2 = Uuid::new_v4();
     let uuid3 = Uuid::new_v4();
 
     // create some operations
     {
-        let mut txn = storage.txn()?;
-        txn.add_operation(Operation::Create { uuid: uuid1 })?;
-        txn.add_operation(Operation::Create { uuid: uuid2 })?;
-        txn.commit()?;
+        let mut txn = storage.txn().await?;
+        txn.add_operation(Operation::Create { uuid: uuid1 }).await?;
+        txn.add_operation(Operation::Create { uuid: uuid2 }).await?;
+        txn.commit().await?;
     }
 
     // read them back
     {
-        let mut txn = storage.txn()?;
-        let ops = txn.unsynced_operations()?;
+        let mut txn = storage.txn().await?;
+        let ops = txn.unsynced_operations().await?;
         assert_eq!(
             ops,
             vec![
@@ -382,31 +385,32 @@ pub(super) fn unsynced_operations(mut storage: impl Storage) -> Result<()> {
             ]
         );
 
-        assert_eq!(txn.num_unsynced_operations()?, 2);
+        assert_eq!(txn.num_unsynced_operations().await?, 2);
     }
 
     // Sync them.
     {
-        let mut txn = storage.txn()?;
-        txn.sync_complete()?;
-        txn.commit()?;
+        let mut txn = storage.txn().await?;
+        txn.sync_complete().await?;
+        txn.commit().await?;
     }
 
     // create some more operations (to test adding operations after sync)
     {
-        let mut txn = storage.txn()?;
-        txn.add_operation(Operation::Create { uuid: uuid3 })?;
+        let mut txn = storage.txn().await?;
+        txn.add_operation(Operation::Create { uuid: uuid3 }).await?;
         txn.add_operation(Operation::Delete {
             uuid: uuid3,
             old_task: TaskMap::new(),
-        })?;
-        txn.commit()?;
+        })
+        .await?;
+        txn.commit().await?;
     }
 
     // read them back
     {
-        let mut txn = storage.txn()?;
-        let ops = txn.unsynced_operations()?;
+        let mut txn = storage.txn().await?;
+        let ops = txn.unsynced_operations().await?;
         assert_eq!(
             ops,
             vec![
@@ -417,30 +421,31 @@ pub(super) fn unsynced_operations(mut storage: impl Storage) -> Result<()> {
                 },
             ]
         );
-        assert_eq!(txn.num_unsynced_operations()?, 2);
+        assert_eq!(txn.num_unsynced_operations().await?, 2);
     }
 
     // Remove the right one
     {
-        let mut txn = storage.txn()?;
+        let mut txn = storage.txn().await?;
         txn.remove_operation(Operation::Delete {
             uuid: uuid3,
             old_task: TaskMap::new(),
-        })?;
-        txn.commit()?;
+        })
+        .await?;
+        txn.commit().await?;
     }
 
     // read the remaining op back
     {
-        let mut txn = storage.txn()?;
-        let ops = txn.unsynced_operations()?;
+        let mut txn = storage.txn().await?;
+        let ops = txn.unsynced_operations().await?;
         assert_eq!(ops, vec![Operation::Create { uuid: uuid3 },]);
-        assert_eq!(txn.num_unsynced_operations()?, 1);
+        assert_eq!(txn.num_unsynced_operations().await?, 1);
     }
     Ok(())
 }
 
-pub(super) fn remove_operations(mut storage: impl Storage) -> Result<()> {
+pub(super) async fn remove_operations(mut storage: impl Storage) -> Result<()> {
     let uuid1 = Uuid::new_v4();
     let uuid2 = Uuid::new_v4();
     let uuid3 = Uuid::new_v4();
@@ -448,61 +453,65 @@ pub(super) fn remove_operations(mut storage: impl Storage) -> Result<()> {
 
     // Create some tasks and operations.
     {
-        let mut txn = storage.txn()?;
+        let mut txn = storage.txn().await?;
 
-        txn.create_task(uuid1)?;
-        txn.create_task(uuid2)?;
-        txn.create_task(uuid3)?;
+        txn.create_task(uuid1).await?;
+        txn.create_task(uuid2).await?;
+        txn.create_task(uuid3).await?;
 
-        txn.add_operation(Operation::Create { uuid: uuid1 })?;
-        txn.add_operation(Operation::Create { uuid: uuid2 })?;
-        txn.add_operation(Operation::Create { uuid: uuid3 })?;
-        txn.commit()?;
+        txn.add_operation(Operation::Create { uuid: uuid1 }).await?;
+        txn.add_operation(Operation::Create { uuid: uuid2 }).await?;
+        txn.add_operation(Operation::Create { uuid: uuid3 }).await?;
+        txn.commit().await?;
     }
 
     // Remove the uuid3 operation.
     {
-        let mut txn = storage.txn()?;
-        txn.remove_operation(Operation::Create { uuid: uuid3 })?;
-        assert_eq!(txn.num_unsynced_operations()?, 2);
-        txn.commit()?;
+        let mut txn = storage.txn().await?;
+        txn.remove_operation(Operation::Create { uuid: uuid3 })
+            .await?;
+        assert_eq!(txn.num_unsynced_operations().await?, 2);
+        txn.commit().await?;
     }
 
     // Remove a nonexistent operation
     {
-        let mut txn = storage.txn()?;
+        let mut txn = storage.txn().await?;
         assert!(txn
             .remove_operation(Operation::Create { uuid: uuid4 })
+            .await
             .is_err());
     }
 
     // Remove an operation that is not most recent.
     {
-        let mut txn = storage.txn()?;
+        let mut txn = storage.txn().await?;
         assert!(txn
             .remove_operation(Operation::Create { uuid: uuid1 })
+            .await
             .is_err());
     }
 
     // Mark operations as synced.
     {
-        let mut txn = storage.txn()?;
-        txn.sync_complete()?;
-        txn.commit()?;
+        let mut txn = storage.txn().await?;
+        txn.sync_complete().await?;
+        txn.commit().await?;
     }
 
     // Try to remove the synced operation.
     {
-        let mut txn = storage.txn()?;
+        let mut txn = storage.txn().await?;
         assert!(txn
             .remove_operation(Operation::Create { uuid: uuid2 })
+            .await
             .is_err());
     }
 
     Ok(())
 }
 
-pub(super) fn task_operations(mut storage: impl Storage) -> Result<()> {
+pub(super) async fn task_operations(mut storage: impl Storage) -> Result<()> {
     let uuid1 = Uuid::new_v4();
     let uuid2 = Uuid::new_v4();
     let uuid3 = Uuid::new_v4();
@@ -510,49 +519,53 @@ pub(super) fn task_operations(mut storage: impl Storage) -> Result<()> {
 
     // Create some tasks and operations.
     {
-        let mut txn = storage.txn()?;
+        let mut txn = storage.txn().await?;
 
-        txn.create_task(uuid1)?;
-        txn.create_task(uuid2)?;
-        txn.create_task(uuid3)?;
+        txn.create_task(uuid1).await?;
+        txn.create_task(uuid2).await?;
+        txn.create_task(uuid3).await?;
 
-        txn.add_operation(Operation::UndoPoint)?;
-        txn.add_operation(Operation::Create { uuid: uuid1 })?;
-        txn.add_operation(Operation::Create { uuid: uuid1 })?;
-        txn.add_operation(Operation::UndoPoint)?;
+        txn.add_operation(Operation::UndoPoint).await?;
+        txn.add_operation(Operation::Create { uuid: uuid1 }).await?;
+        txn.add_operation(Operation::Create { uuid: uuid1 }).await?;
+        txn.add_operation(Operation::UndoPoint).await?;
         txn.add_operation(Operation::Delete {
             uuid: uuid2,
             old_task: TaskMap::new(),
-        })?;
+        })
+        .await?;
         txn.add_operation(Operation::Update {
             uuid: uuid3,
             property: "p".into(),
             old_value: None,
             value: Some("P".into()),
             timestamp: now,
-        })?;
+        })
+        .await?;
         txn.add_operation(Operation::Delete {
             uuid: uuid3,
             old_task: TaskMap::new(),
-        })?;
+        })
+        .await?;
 
-        txn.commit()?;
+        txn.commit().await?;
     }
 
     // remove the last operation to verify it doesn't appear
     {
-        let mut txn = storage.txn()?;
+        let mut txn = storage.txn().await?;
         txn.remove_operation(Operation::Delete {
             uuid: uuid3,
             old_task: TaskMap::new(),
-        })?;
-        txn.commit()?;
+        })
+        .await?;
+        txn.commit().await?;
     }
 
     // read them back
     {
-        let mut txn = storage.txn()?;
-        let ops = txn.get_task_operations(uuid1)?;
+        let mut txn = storage.txn().await?;
+        let ops = txn.get_task_operations(uuid1).await?;
         assert_eq!(
             ops,
             vec![
@@ -560,7 +573,7 @@ pub(super) fn task_operations(mut storage: impl Storage) -> Result<()> {
                 Operation::Create { uuid: uuid1 },
             ]
         );
-        let ops = txn.get_task_operations(uuid2)?;
+        let ops = txn.get_task_operations(uuid2).await?;
         assert_eq!(
             ops,
             vec![Operation::Delete {
@@ -568,7 +581,7 @@ pub(super) fn task_operations(mut storage: impl Storage) -> Result<()> {
                 old_task: TaskMap::new()
             }]
         );
-        let ops = txn.get_task_operations(uuid3)?;
+        let ops = txn.get_task_operations(uuid3).await?;
         assert_eq!(
             ops,
             vec![Operation::Update {
@@ -583,132 +596,133 @@ pub(super) fn task_operations(mut storage: impl Storage) -> Result<()> {
 
     // Sync and verify the task operations still exist.
     {
-        let mut txn = storage.txn()?;
+        let mut txn = storage.txn().await?;
 
-        txn.sync_complete()?;
+        txn.sync_complete().await?;
 
-        let ops = txn.get_task_operations(uuid1)?;
+        let ops = txn.get_task_operations(uuid1).await?;
         assert_eq!(ops.len(), 2);
-        let ops = txn.get_task_operations(uuid2)?;
+        let ops = txn.get_task_operations(uuid2).await?;
         assert_eq!(ops.len(), 1);
-        let ops = txn.get_task_operations(uuid3)?;
+        let ops = txn.get_task_operations(uuid3).await?;
         assert_eq!(ops.len(), 1);
     }
 
     Ok(())
 }
 
-pub(super) fn sync_complete(mut storage: impl Storage) -> Result<()> {
+pub(super) async fn sync_complete(mut storage: impl Storage) -> Result<()> {
     let uuid1 = Uuid::new_v4();
     let uuid2 = Uuid::new_v4();
 
     // Create some tasks and operations.
     {
-        let mut txn = storage.txn()?;
+        let mut txn = storage.txn().await?;
 
-        txn.create_task(uuid1)?;
-        txn.create_task(uuid2)?;
+        txn.create_task(uuid1).await?;
+        txn.create_task(uuid2).await?;
 
-        txn.add_operation(Operation::Create { uuid: uuid1 })?;
-        txn.add_operation(Operation::Create { uuid: uuid2 })?;
+        txn.add_operation(Operation::Create { uuid: uuid1 }).await?;
+        txn.add_operation(Operation::Create { uuid: uuid2 }).await?;
 
-        txn.commit()?;
+        txn.commit().await?;
     }
 
     // Sync and verify the task operations still exist.
     {
-        let mut txn = storage.txn()?;
+        let mut txn = storage.txn().await?;
 
-        txn.sync_complete()?;
+        txn.sync_complete().await?;
 
-        let ops = txn.get_task_operations(uuid1)?;
+        let ops = txn.get_task_operations(uuid1).await?;
         assert_eq!(ops.len(), 1);
-        let ops = txn.get_task_operations(uuid2)?;
+        let ops = txn.get_task_operations(uuid2).await?;
         assert_eq!(ops.len(), 1);
     }
 
     // Delete uuid2.
     {
-        let mut txn = storage.txn()?;
+        let mut txn = storage.txn().await?;
 
-        txn.delete_task(uuid2)?;
+        txn.delete_task(uuid2).await?;
         txn.add_operation(Operation::Delete {
             uuid: uuid2,
             old_task: TaskMap::new(),
-        })?;
+        })
+        .await?;
 
-        txn.commit()?;
+        txn.commit().await?;
     }
 
     // Sync and verify that uuid1's operations still exist, but uuid2's do not.
     {
-        let mut txn = storage.txn()?;
+        let mut txn = storage.txn().await?;
 
-        txn.sync_complete()?;
+        txn.sync_complete().await?;
 
-        let ops = txn.get_task_operations(uuid1)?;
+        let ops = txn.get_task_operations(uuid1).await?;
         assert_eq!(ops.len(), 1);
-        let ops = txn.get_task_operations(uuid2)?;
+        let ops = txn.get_task_operations(uuid2).await?;
         assert_eq!(ops.len(), 0);
     }
 
     Ok(())
 }
 
-pub(super) fn set_working_set_item(mut storage: impl Storage) -> Result<()> {
+pub(super) async fn set_working_set_item(mut storage: impl Storage) -> Result<()> {
     let uuid1 = Uuid::new_v4();
     let uuid2 = Uuid::new_v4();
 
     {
-        let mut txn = storage.txn()?;
-        txn.add_to_working_set(uuid1)?;
-        txn.add_to_working_set(uuid2)?;
-        txn.commit()?;
+        let mut txn = storage.txn().await?;
+        txn.add_to_working_set(uuid1).await?;
+        txn.add_to_working_set(uuid2).await?;
+        txn.commit().await?;
     }
 
     {
-        let mut txn = storage.txn()?;
-        let ws = txn.get_working_set()?;
+        let mut txn = storage.txn().await?;
+        let ws = txn.get_working_set().await?;
         assert_eq!(ws, vec![None, Some(uuid1), Some(uuid2)]);
     }
 
     // Clear one item
     {
-        let mut txn = storage.txn()?;
-        txn.set_working_set_item(1, None)?;
-        txn.commit()?;
+        let mut txn = storage.txn().await?;
+        txn.set_working_set_item(1, None).await?;
+        txn.commit().await?;
     }
 
     {
-        let mut txn = storage.txn()?;
-        let ws = txn.get_working_set()?;
+        let mut txn = storage.txn().await?;
+        let ws = txn.get_working_set().await?;
         assert_eq!(ws, vec![None, None, Some(uuid2)]);
     }
 
     // Override item
     {
-        let mut txn = storage.txn()?;
-        txn.set_working_set_item(2, Some(uuid1))?;
-        txn.commit()?;
+        let mut txn = storage.txn().await?;
+        txn.set_working_set_item(2, Some(uuid1)).await?;
+        txn.commit().await?;
     }
 
     {
-        let mut txn = storage.txn()?;
-        let ws = txn.get_working_set()?;
+        let mut txn = storage.txn().await?;
+        let ws = txn.get_working_set().await?;
         assert_eq!(ws, vec![None, None, Some(uuid1)]);
     }
 
     // Set the last item to None
     {
-        let mut txn = storage.txn()?;
-        txn.set_working_set_item(1, Some(uuid1))?;
-        txn.set_working_set_item(2, None)?;
-        txn.commit()?;
+        let mut txn = storage.txn().await?;
+        txn.set_working_set_item(1, Some(uuid1)).await?;
+        txn.set_working_set_item(2, None).await?;
+        txn.commit().await?;
     }
 
     {
-        let mut txn = storage.txn()?;
-        let ws = txn.get_working_set()?;
+        let mut txn = storage.txn().await?;
+        let ws = txn.get_working_set().await?;
         // Note no trailing `None`.
         assert_eq!(ws, vec![None, Some(uuid1)]);
     }

--- a/src/task/task.rs
+++ b/src/task/task.rs
@@ -584,7 +584,7 @@ impl Task {
 #[allow(deprecated)]
 mod test {
     use super::*;
-    use crate::Replica;
+    use crate::{storage::inmemory::InMemoryStorage, Replica};
     use pretty_assertions::assert_eq;
     use std::collections::HashSet;
 
@@ -595,14 +595,14 @@ mod test {
     // Test task mutation by modifying a task and checking the assertions both on the
     // modified task and on a re-loaded task after the operations are committed. Then,
     // apply the same operations again and check that the result is the same.
-    fn with_mut_task<MODIFY: Fn(&mut Task, &mut Operations), ASSERT: Fn(&Task)>(
+    async fn with_mut_task<MODIFY: Fn(&mut Task, &mut Operations), ASSERT: Fn(&Task)>(
         modify: MODIFY,
         assert: ASSERT,
     ) {
-        let mut replica = Replica::new_inmemory();
+        let mut replica = Replica::new(InMemoryStorage::new());
         let mut ops = Operations::new();
         let uuid = Uuid::new_v4();
-        let mut task = replica.create_task(uuid, &mut ops).unwrap();
+        let mut task = replica.create_task(uuid, &mut ops).await.unwrap();
 
         // Modify the task
         modify(&mut task, &mut ops);
@@ -610,10 +610,10 @@ mod test {
         // Check assertions about the task before committing it.
         assert(&task);
         println!("commiting operations from first call to modify function");
-        replica.commit_operations(ops).unwrap();
+        replica.commit_operations(ops).await.unwrap();
 
         // Check assertions on task loaded from storage
-        let mut task = replica.get_task(uuid).unwrap().unwrap();
+        let mut task = replica.get_task(uuid).await.unwrap().unwrap();
         assert(&task);
 
         // Apply the operations again, checking that they do not fail.
@@ -623,10 +623,10 @@ mod test {
         // Changes should still be as expected before commit.
         assert(&task);
         println!("commiting operations from second call to modify function");
-        replica.commit_operations(ops).unwrap();
+        replica.commit_operations(ops).await.unwrap();
 
         // Changes should still be as expected when loaded from storage.
-        let task = replica.get_task(uuid).unwrap().unwrap();
+        let task = replica.get_task(uuid).await.unwrap().unwrap();
         assert(&task);
     }
 
@@ -838,24 +838,25 @@ mod test {
         assert_eq!(task.get_due(), None);
     }
 
-    #[test]
-    fn test_due_new_task() {
-        with_mut_task(|_task, _ops| {}, |task| assert_eq!(task.get_due(), None));
+    #[tokio::test]
+    async fn test_due_new_task() {
+        with_mut_task(|_task, _ops| {}, |task| assert_eq!(task.get_due(), None)).await;
     }
 
-    #[test]
-    fn test_add_due() {
+    #[tokio::test]
+    async fn test_add_due() {
         let test_time = Utc.with_ymd_and_hms(2033, 1, 1, 0, 0, 0).unwrap();
         with_mut_task(
             |task, ops| {
                 task.set_due(Some(test_time), ops).unwrap();
             },
             |task| assert_eq!(task.get_due(), Some(test_time)),
-        );
+        )
+        .await;
     }
 
-    #[test]
-    fn test_remove_due() {
+    #[tokio::test]
+    async fn test_remove_due() {
         with_mut_task(
             |task, ops| {
                 task.data.update("due", Some("some-time".into()), ops);
@@ -865,7 +866,8 @@ mod test {
             |task| {
                 assert!(!task.data.has("due"));
             },
-        );
+        )
+        .await;
     }
 
     #[test]
@@ -914,8 +916,8 @@ mod test {
         );
     }
 
-    #[test]
-    fn test_add_annotation() {
+    #[tokio::test]
+    async fn test_add_annotation() {
         with_mut_task(
             |task, ops| {
                 task.add_annotation(
@@ -931,11 +933,12 @@ mod test {
                 let k = "annotation_1635301900";
                 assert_eq!(task.data.get(k).unwrap(), "right message".to_owned());
             },
-        );
+        )
+        .await;
     }
 
-    #[test]
-    fn test_add_annotation_overwrite() {
+    #[tokio::test]
+    async fn test_add_annotation_overwrite() {
         with_mut_task(
             |task, ops| {
                 task.add_annotation(
@@ -959,11 +962,12 @@ mod test {
                 let k = "annotation_1635301900";
                 assert_eq!(task.data.get(k).unwrap(), "right message 2".to_owned());
             },
-        );
+        )
+        .await;
     }
 
-    #[test]
-    fn test_remove_annotation() {
+    #[tokio::test]
+    async fn test_remove_annotation() {
         with_mut_task(
             |task, ops| {
                 task.data
@@ -983,11 +987,12 @@ mod test {
                 anns.sort();
                 assert_eq!(anns, vec![]);
             },
-        );
+        )
+        .await;
     }
 
-    #[test]
-    fn test_set_get_priority() {
+    #[tokio::test]
+    async fn test_set_get_priority() {
         with_mut_task(
             |task, ops| {
                 task.set_priority("H".into(), ops).unwrap();
@@ -995,21 +1000,23 @@ mod test {
             |task| {
                 assert_eq!(task.get_priority(), "H");
             },
-        );
+        )
+        .await;
     }
 
-    #[test]
-    fn test_get_priority_new_task() {
+    #[tokio::test]
+    async fn test_get_priority_new_task() {
         with_mut_task(
             |_task, _ops| {},
             |task| {
                 assert_eq!(task.get_priority(), "");
             },
-        );
+        )
+        .await;
     }
 
-    #[test]
-    fn test_set_status_pending() {
+    #[tokio::test]
+    async fn test_set_status_pending() {
         with_mut_task(
             |task, ops| {
                 task.data.update("status", Some("completed".into()), ops);
@@ -1023,11 +1030,12 @@ mod test {
                 assert!(task.has_tag(&stag(SyntheticTag::Pending)));
                 assert!(!task.has_tag(&stag(SyntheticTag::Completed)));
             },
-        );
+        )
+        .await;
     }
 
-    #[test]
-    fn test_set_status_recurring() {
+    #[tokio::test]
+    async fn test_set_status_recurring() {
         with_mut_task(
             |task, ops| {
                 task.data.update("status", Some("completed".into()), ops);
@@ -1040,11 +1048,12 @@ mod test {
                 assert!(!task.has_tag(&stag(SyntheticTag::Pending))); // recurring is not +PENDING
                 assert!(!task.has_tag(&stag(SyntheticTag::Completed)));
             },
-        );
+        )
+        .await;
     }
 
-    #[test]
-    fn test_set_status_completed() {
+    #[tokio::test]
+    async fn test_set_status_completed() {
         with_mut_task(
             |task, ops| {
                 task.set_status(Status::Completed, ops).unwrap();
@@ -1055,11 +1064,12 @@ mod test {
                 assert!(!task.has_tag(&stag(SyntheticTag::Pending)));
                 assert!(task.has_tag(&stag(SyntheticTag::Completed)));
             },
-        );
+        )
+        .await;
     }
 
-    #[test]
-    fn test_set_status_deleted() {
+    #[tokio::test]
+    async fn test_set_status_deleted() {
         with_mut_task(
             |task, ops| {
                 task.set_status(Status::Deleted, ops).unwrap();
@@ -1070,11 +1080,12 @@ mod test {
                 assert!(!task.has_tag(&stag(SyntheticTag::Pending)));
                 assert!(!task.has_tag(&stag(SyntheticTag::Completed)));
             },
-        );
+        )
+        .await;
     }
 
-    #[test]
-    fn test_set_get_value() {
+    #[tokio::test]
+    async fn test_set_get_value() {
         let property = "property-name";
         with_mut_task(
             |task, ops| {
@@ -1083,11 +1094,12 @@ mod test {
             |task| {
                 assert_eq!(task.get_value(property), Some("value"));
             },
-        );
+        )
+        .await;
     }
 
-    #[test]
-    fn test_set_get_value_none() {
+    #[tokio::test]
+    async fn test_set_get_value_none() {
         let property = "property-name";
         with_mut_task(
             |task, ops| {
@@ -1097,11 +1109,12 @@ mod test {
             |task| {
                 assert_eq!(task.get_value(property), None);
             },
-        );
+        )
+        .await;
     }
 
-    #[test]
-    fn test_start() {
+    #[tokio::test]
+    async fn test_start() {
         with_mut_task(
             |task, ops| {
                 task.start(ops).unwrap();
@@ -1109,11 +1122,12 @@ mod test {
             |task| {
                 assert!(task.data.has("start"));
             },
-        );
+        )
+        .await;
     }
 
-    #[test]
-    fn test_stop() {
+    #[tokio::test]
+    async fn test_stop() {
         with_mut_task(
             |task, ops| {
                 task.data.update("start", Some("right now".into()), ops);
@@ -1122,11 +1136,12 @@ mod test {
             |task| {
                 assert!(!task.data.has("start"));
             },
-        );
+        )
+        .await;
     }
 
-    #[test]
-    fn test_done() {
+    #[tokio::test]
+    async fn test_done() {
         with_mut_task(
             |task, ops| {
                 task.done(ops).unwrap();
@@ -1136,11 +1151,12 @@ mod test {
                 assert!(task.data.has("end"));
                 assert!(task.has_tag(&stag(SyntheticTag::Completed)));
             },
-        );
+        )
+        .await;
     }
 
-    #[test]
-    fn test_delete() {
+    #[tokio::test]
+    async fn test_delete() {
         with_mut_task(
             |task, ops| {
                 #[allow(deprecated)]
@@ -1151,11 +1167,12 @@ mod test {
                 assert!(task.data.has("end"));
                 assert!(!task.has_tag(&stag(SyntheticTag::Completed)));
             },
-        );
+        )
+        .await;
     }
 
-    #[test]
-    fn test_add_tags() {
+    #[tokio::test]
+    async fn test_add_tags() {
         with_mut_task(
             |task, ops| {
                 task.add_tag(&utag("abc"), ops).unwrap();
@@ -1164,11 +1181,12 @@ mod test {
                 assert!(task.data.has("tag_abc"));
                 assert!(task.has_tag(&utag("abc")));
             },
-        );
+        )
+        .await;
     }
 
-    #[test]
-    fn test_remove_tags() {
+    #[tokio::test]
+    async fn test_remove_tags() {
         with_mut_task(
             |task, ops| {
                 task.data.update("tag_abc", Some("x".into()), ops);
@@ -1177,7 +1195,8 @@ mod test {
             |task| {
                 assert!(!task.data.has("tag_abc"));
             },
-        );
+        )
+        .await;
     }
 
     #[test]
@@ -1282,8 +1301,8 @@ mod test {
         assert_eq!(task.get_user_defined_attribute("bugzilla.url"), None);
     }
 
-    #[test]
-    fn test_set_uda() {
+    #[tokio::test]
+    async fn test_set_uda() {
         with_mut_task(
             |task, ops| {
                 task.set_uda("jira", "url", "h://y", ops).unwrap();
@@ -1298,10 +1317,11 @@ mod test {
                 );
             },
         )
+        .await
     }
 
-    #[test]
-    fn test_set_legacy_uda() {
+    #[tokio::test]
+    async fn test_set_legacy_uda() {
         with_mut_task(
             |task, ops| {
                 task.set_legacy_uda("jira.url", "h://y", ops).unwrap();
@@ -1316,10 +1336,11 @@ mod test {
                 );
             },
         )
+        .await
     }
 
-    #[test]
-    fn test_set_user_defined_attribute() {
+    #[tokio::test]
+    async fn test_set_user_defined_attribute() {
         with_mut_task(
             |task, ops| {
                 task.set_user_defined_attribute("jira.url", "h://y", ops)
@@ -1336,10 +1357,11 @@ mod test {
                 );
             },
         )
+        .await
     }
 
-    #[test]
-    fn test_set_uda_invalid() {
+    #[tokio::test]
+    async fn test_set_uda_invalid() {
         with_mut_task(
             |task, ops| {
                 assert!(task.set_uda("", "modified", "123", ops).is_err());
@@ -1355,10 +1377,11 @@ mod test {
             },
             |_task| {},
         )
+        .await
     }
 
-    #[test]
-    fn test_remove_uda() {
+    #[tokio::test]
+    async fn test_remove_uda() {
         with_mut_task(
             |task, ops| {
                 task.data.update("github.id", Some("123".into()), ops);
@@ -1369,10 +1392,11 @@ mod test {
                 assert_eq!(udas, vec![]);
             },
         )
+        .await
     }
 
-    #[test]
-    fn test_remove_legacy_uda() {
+    #[tokio::test]
+    async fn test_remove_legacy_uda() {
         with_mut_task(
             |task, ops| {
                 task.data.update("githubid", Some("123".into()), ops);
@@ -1383,10 +1407,11 @@ mod test {
                 assert_eq!(udas, vec![]);
             },
         )
+        .await
     }
 
-    #[test]
-    fn test_remove_user_defined_attribute() {
+    #[tokio::test]
+    async fn test_remove_user_defined_attribute() {
         with_mut_task(
             |task, ops| {
                 task.data.update("githubid", Some("123".into()), ops);
@@ -1397,10 +1422,11 @@ mod test {
                 assert_eq!(udas, vec![]);
             },
         )
+        .await
     }
 
-    #[test]
-    fn test_remove_uda_invalid() {
+    #[tokio::test]
+    async fn test_remove_uda_invalid() {
         with_mut_task(
             |task, ops| {
                 assert!(task.remove_uda("", "modified", ops).is_err());
@@ -1412,10 +1438,11 @@ mod test {
             },
             |_task| {},
         )
+        .await
     }
 
-    #[test]
-    fn test_dependencies_one() {
+    #[tokio::test]
+    async fn test_dependencies_one() {
         let dep1 = Uuid::new_v4();
         with_mut_task(
             |task, ops| {
@@ -1426,10 +1453,11 @@ mod test {
                 assert!(deps.contains(&dep1));
             },
         )
+        .await
     }
 
-    #[test]
-    fn test_dependencies_two() {
+    #[tokio::test]
+    async fn test_dependencies_two() {
         let dep1 = Uuid::new_v4();
         let dep2 = Uuid::new_v4();
         with_mut_task(
@@ -1443,10 +1471,11 @@ mod test {
                 assert!(deps.contains(&dep2));
             },
         )
+        .await
     }
 
-    #[test]
-    fn test_dependencies_removed() {
+    #[tokio::test]
+    async fn test_dependencies_removed() {
         let dep1 = Uuid::new_v4();
         let dep2 = Uuid::new_v4();
         with_mut_task(
@@ -1461,28 +1490,29 @@ mod test {
                 assert!(!deps.contains(&dep2));
             },
         )
+        .await
     }
 
-    #[test]
-    fn dependencies_tags() {
-        let mut rep = Replica::new_inmemory();
+    #[tokio::test]
+    async fn dependencies_tags() {
+        let mut rep = Replica::new(InMemoryStorage::new());
         let mut ops = Operations::new();
         let (uuid1, uuid2) = (Uuid::new_v4(), Uuid::new_v4());
 
-        let mut t1 = rep.create_task(uuid1, &mut ops).unwrap();
+        let mut t1 = rep.create_task(uuid1, &mut ops).await.unwrap();
         t1.set_status(Status::Pending, &mut ops).unwrap();
         t1.add_dependency(uuid2, &mut ops).unwrap();
 
-        let mut t2 = rep.create_task(uuid2, &mut ops).unwrap();
+        let mut t2 = rep.create_task(uuid2, &mut ops).await.unwrap();
         t2.set_status(Status::Pending, &mut ops).unwrap();
 
-        rep.commit_operations(ops).unwrap();
+        rep.commit_operations(ops).await.unwrap();
 
         // force-refresh depmap
-        rep.dependency_map(true).unwrap();
+        rep.dependency_map(true).await.unwrap();
 
-        let t1 = rep.get_task(uuid1).unwrap().unwrap();
-        let t2 = rep.get_task(uuid2).unwrap().unwrap();
+        let t1 = rep.get_task(uuid1).await.unwrap().unwrap();
+        let t2 = rep.get_task(uuid2).await.unwrap().unwrap();
         assert!(t1.has_tag(&stag(SyntheticTag::Blocked)));
         assert!(!t1.has_tag(&stag(SyntheticTag::Unblocked)));
         assert!(!t1.has_tag(&stag(SyntheticTag::Blocking)));
@@ -1491,8 +1521,8 @@ mod test {
         assert!(t2.has_tag(&stag(SyntheticTag::Blocking)));
     }
 
-    #[test]
-    fn set_value_modified() {
+    #[tokio::test]
+    async fn set_value_modified() {
         with_mut_task(
             |task, ops| {
                 // set the modified property to something in the past..
@@ -1506,5 +1536,6 @@ mod test {
                 assert_eq!(task.get_value("modified").unwrap(), "1671820000")
             },
         )
+        .await
     }
 }

--- a/src/taskdb/apply.rs
+++ b/src/taskdb/apply.rs
@@ -13,12 +13,15 @@ use uuid::Uuid;
 /// If the operation does not make sense in the current state, it is ignored.
 ///
 /// The transaction is not committed.
-pub(super) fn apply_operations(txn: &mut dyn StorageTxn, operations: &Operations) -> Result<()> {
+pub(super) async fn apply_operations(
+    txn: &mut dyn StorageTxn,
+    operations: &Operations,
+) -> Result<()> {
     // A cache of TaskMaps updated in this sequence of operations, but for which `txn.set_task` has
     // not yet been called.
     let mut tasks: HashMap<Uuid, Option<TaskMap>> = HashMap::new();
 
-    fn get_cache<'t>(
+    async fn get_cache<'t>(
         uuid: Uuid,
         tasks: &'t mut HashMap<Uuid, Option<TaskMap>>,
         txn: &mut dyn StorageTxn,
@@ -26,14 +29,14 @@ pub(super) fn apply_operations(txn: &mut dyn StorageTxn, operations: &Operations
         match tasks.entry(uuid) {
             Entry::Occupied(occupied_entry) => Ok(occupied_entry.into_mut().as_mut()),
             Entry::Vacant(vacant_entry) => {
-                let task = txn.get_task(uuid)?;
+                let task = txn.get_task(uuid).await?;
                 Ok(vacant_entry.insert(task).as_mut())
             }
         }
     }
 
     // Call `txn.set_task` for this task, if necessary, and remove from the cache.
-    fn flush_cache(
+    async fn flush_cache(
         uuid: Uuid,
         tasks: &mut HashMap<Uuid, Option<TaskMap>>,
         txn: &mut dyn StorageTxn,
@@ -41,7 +44,7 @@ pub(super) fn apply_operations(txn: &mut dyn StorageTxn, operations: &Operations
         if let Entry::Occupied(occupied_entry) = tasks.entry(uuid) {
             let v = occupied_entry.remove();
             if let Some(taskmap) = v {
-                txn.set_task(uuid, taskmap)?;
+                txn.set_task(uuid, taskmap).await?;
             }
         }
         Ok(())
@@ -53,12 +56,12 @@ pub(super) fn apply_operations(txn: &mut dyn StorageTxn, operations: &Operations
                 // The create_task method will do nothing if the task exists. If it was cached
                 // as not existing, clear that information. If it had cached updates, then there
                 // is no harm flushing those updates now.
-                flush_cache(*uuid, &mut tasks, txn)?;
-                txn.create_task(*uuid)?;
+                flush_cache(*uuid, &mut tasks, txn).await?;
+                txn.create_task(*uuid).await?;
             }
             Operation::Delete { uuid, .. } => {
                 // The delete_task method will do nothing if the task does not exist.
-                txn.delete_task(*uuid)?;
+                txn.delete_task(*uuid).await?;
                 // The task now unconditionally does not exist. If there was a pending
                 // `txn.set_task`, it can safely be skipped.
                 tasks.insert(*uuid, None);
@@ -69,7 +72,7 @@ pub(super) fn apply_operations(txn: &mut dyn StorageTxn, operations: &Operations
                 value,
                 ..
             } => {
-                let task = get_cache(*uuid, &mut tasks, txn)?;
+                let task = get_cache(*uuid, &mut tasks, txn).await?;
                 // If the task does not exist, do nothing.
                 if let Some(task) = task {
                     if let Some(v) = value {
@@ -85,23 +88,23 @@ pub(super) fn apply_operations(txn: &mut dyn StorageTxn, operations: &Operations
 
     // Flush any remaining tasks in the cache.
     while let Some((uuid, _)) = tasks.iter().next() {
-        flush_cache(*uuid, &mut tasks, txn)?;
+        flush_cache(*uuid, &mut tasks, txn).await?;
     }
 
     Ok(())
 }
 
 /// Apply a [`SyncOp`] to the TaskDb's set of tasks (without recording it in the list of operations)
-pub(super) fn apply_op(txn: &mut dyn StorageTxn, op: &SyncOp) -> Result<()> {
+pub(super) async fn apply_op(txn: &mut dyn StorageTxn, op: &SyncOp) -> Result<()> {
     match op {
         SyncOp::Create { uuid } => {
             // insert if the task does not already exist
-            if !txn.create_task(*uuid)? {
+            if !txn.create_task(*uuid).await? {
                 return Err(Error::Database(format!("Task {} already exists", uuid)));
             }
         }
         SyncOp::Delete { ref uuid } => {
-            if !txn.delete_task(*uuid)? {
+            if !txn.delete_task(*uuid).await? {
                 return Err(Error::Database(format!("Task {} does not exist", uuid)));
             }
         }
@@ -112,12 +115,12 @@ pub(super) fn apply_op(txn: &mut dyn StorageTxn, op: &SyncOp) -> Result<()> {
             timestamp: _,
         } => {
             // update if this task exists, otherwise ignore
-            if let Some(mut task) = txn.get_task(*uuid)? {
+            if let Some(mut task) = txn.get_task(*uuid).await? {
                 match value {
                     Some(ref val) => task.insert(property.to_string(), val.clone()),
                     None => task.remove(property),
                 };
-                txn.set_task(*uuid, task)?;
+                txn.set_task(*uuid, task).await?;
             } else {
                 return Err(Error::Database(format!("Task {} does not exist", uuid)));
             }
@@ -131,66 +134,69 @@ pub(super) fn apply_op(txn: &mut dyn StorageTxn, op: &SyncOp) -> Result<()> {
 mod tests {
     #![allow(clippy::vec_init_then_push)]
     use super::*;
-    use crate::storage::{taskmap_with, TaskMap};
+    use crate::storage::inmemory::InMemoryStorage;
+    use crate::storage::{taskmap_with, Storage, TaskMap};
     use crate::taskdb::TaskDb;
     use chrono::Utc;
     use pretty_assertions::assert_eq;
     use std::collections::HashMap;
     use uuid::Uuid;
 
-    #[test]
-    fn apply_operations_create() -> Result<()> {
-        let mut db = TaskDb::new_inmemory();
+    #[tokio::test]
+    async fn apply_operations_create() -> Result<()> {
+        let mut db = TaskDb::new(InMemoryStorage::new());
         let uuid = Uuid::new_v4();
         let mut ops = Operations::new();
         ops.push(Operation::Create { uuid });
 
         {
-            let mut txn = db.storage.txn()?;
-            apply_operations(txn.as_mut(), &ops)?;
-            txn.commit()?;
+            let mut txn = db.storage.txn().await?;
+            apply_operations(txn.as_mut(), &ops).await?;
+            txn.commit().await?;
         }
 
-        assert_eq!(db.sorted_tasks(), vec![(uuid, vec![]),]);
+        assert_eq!(db.sorted_tasks().await, vec![(uuid, vec![])]);
         Ok(())
     }
 
-    #[test]
-    fn apply_operations_create_exists() -> Result<()> {
-        let mut db = TaskDb::new_inmemory();
+    #[tokio::test]
+    async fn apply_operations_create_exists() -> Result<()> {
+        let mut db = TaskDb::new(InMemoryStorage::new());
         let uuid = Uuid::new_v4();
         {
-            let mut txn = db.storage.txn()?;
-            txn.create_task(uuid)?;
-            txn.set_task(uuid, taskmap_with(vec![("foo".into(), "bar".into())]))?;
-            txn.commit()?;
+            let mut txn = db.storage.txn().await?;
+            txn.create_task(uuid).await?;
+            txn.set_task(uuid, taskmap_with(vec![("foo".into(), "bar".into())]))
+                .await?;
+            txn.commit().await?;
         }
 
         {
             let mut ops = Operations::new();
             ops.push(Operation::Create { uuid });
-            let mut txn = db.storage.txn()?;
-            apply_operations(txn.as_mut(), &ops)?;
-            txn.commit()?;
+            let mut txn = db.storage.txn().await?;
+            apply_operations(txn.as_mut(), &ops).await?;
+            txn.commit().await?;
         }
 
         assert_eq!(
-            db.sorted_tasks(),
+            db.sorted_tasks().await,
             vec![(uuid, vec![("foo".into(), "bar".into())])]
         );
         Ok(())
     }
 
-    #[test]
-    fn apply_operations_create_exists_update() -> Result<()> {
-        let mut db = TaskDb::new_inmemory();
+    #[tokio::test]
+    async fn apply_operations_create_exists_update() -> Result<()> {
+        let mut db = TaskDb::new(InMemoryStorage::new());
         let now = Utc::now();
         let uuid = Uuid::new_v4();
         {
-            let mut txn = db.storage.txn()?;
-            txn.create_task(uuid)?;
-            txn.set_task(uuid, taskmap_with(vec![("foo".into(), "bar".into())]))?;
-            txn.commit()?;
+            let mut txn = db.storage.txn().await?;
+            txn.create_task(uuid).await?;
+            txn.set_task(uuid, taskmap_with(vec![("foo".into(), "bar".into())]))
+                .await?;
+            txn.commit().await?;
         }
 
         {
@@ -203,13 +209,13 @@ mod tests {
                 timestamp: now,
                 old_value: None,
             });
-            let mut txn = db.storage.txn()?;
-            apply_operations(txn.as_mut(), &ops)?;
-            txn.commit()?;
+            let mut txn = db.storage.txn().await?;
+            apply_operations(txn.as_mut(), &ops).await?;
+            txn.commit().await?;
         }
 
         assert_eq!(
-            db.sorted_tasks(),
+            db.sorted_tasks().await,
             vec![(
                 uuid,
                 vec![
@@ -221,9 +227,9 @@ mod tests {
         Ok(())
     }
 
-    #[test]
-    fn apply_operations_create_update() -> Result<()> {
-        let mut db = TaskDb::new_inmemory();
+    #[tokio::test]
+    async fn apply_operations_create_update() -> Result<()> {
+        let mut db = TaskDb::new(InMemoryStorage::new());
         let uuid = Uuid::new_v4();
         let now = Utc::now();
         let mut ops = Operations::new();
@@ -237,21 +243,21 @@ mod tests {
         });
 
         {
-            let mut txn = db.storage.txn()?;
-            apply_operations(txn.as_mut(), &ops)?;
-            txn.commit()?;
+            let mut txn = db.storage.txn().await?;
+            apply_operations(txn.as_mut(), &ops).await?;
+            txn.commit().await?;
         }
 
         assert_eq!(
-            db.sorted_tasks(),
+            db.sorted_tasks().await,
             vec![(uuid, vec![("title".into(), "my task".into())])]
         );
         Ok(())
     }
 
-    #[test]
-    fn apply_operations_create_update_delete_prop() -> Result<()> {
-        let mut db = TaskDb::new_inmemory();
+    #[tokio::test]
+    async fn apply_operations_create_update_delete_prop() -> Result<()> {
+        let mut db = TaskDb::new(InMemoryStorage::new());
         let uuid = Uuid::new_v4();
         let now = Utc::now();
         let mut ops = Operations::new();
@@ -279,21 +285,21 @@ mod tests {
         });
 
         {
-            let mut txn = db.storage.txn()?;
-            apply_operations(txn.as_mut(), &ops)?;
-            txn.commit()?;
+            let mut txn = db.storage.txn().await?;
+            apply_operations(txn.as_mut(), &ops).await?;
+            txn.commit().await?;
         }
 
         assert_eq!(
-            db.sorted_tasks(),
+            db.sorted_tasks().await,
             vec![(uuid, vec![("priority".into(), "H".into())])]
         );
         Ok(())
     }
 
-    #[test]
-    fn apply_operations_update_does_not_exist() -> Result<()> {
-        let mut db = TaskDb::new_inmemory();
+    #[tokio::test]
+    async fn apply_operations_update_does_not_exist() -> Result<()> {
+        let mut db = TaskDb::new(InMemoryStorage::new());
         let uuid = Uuid::new_v4();
         let now = Utc::now();
         let mut ops = Operations::new();
@@ -306,18 +312,18 @@ mod tests {
         });
 
         {
-            let mut txn = db.storage.txn()?;
-            apply_operations(txn.as_mut(), &ops)?;
-            txn.commit()?;
+            let mut txn = db.storage.txn().await?;
+            apply_operations(txn.as_mut(), &ops).await?;
+            txn.commit().await?;
         }
 
-        assert_eq!(db.sorted_tasks(), vec![]);
+        assert_eq!(db.sorted_tasks().await, vec![]);
         Ok(())
     }
 
-    #[test]
-    fn apply_operations_delete_then_update() -> Result<()> {
-        let mut db = TaskDb::new_inmemory();
+    #[tokio::test]
+    async fn apply_operations_delete_then_update() -> Result<()> {
+        let mut db = TaskDb::new(InMemoryStorage::new());
         let uuid = Uuid::new_v4();
         let now = Utc::now();
         let mut ops = Operations::new();
@@ -342,18 +348,18 @@ mod tests {
         });
 
         {
-            let mut txn = db.storage.txn()?;
-            apply_operations(txn.as_mut(), &ops)?;
-            txn.commit()?;
+            let mut txn = db.storage.txn().await?;
+            apply_operations(txn.as_mut(), &ops).await?;
+            txn.commit().await?;
         }
 
-        assert_eq!(db.sorted_tasks(), vec![]);
+        assert_eq!(db.sorted_tasks().await, vec![]);
         Ok(())
     }
 
-    #[test]
-    fn apply_operations_several_tasks() -> Result<()> {
-        let mut db = TaskDb::new_inmemory();
+    #[tokio::test]
+    async fn apply_operations_several_tasks() -> Result<()> {
+        let mut db = TaskDb::new(InMemoryStorage::new());
         let mut uuids = [Uuid::new_v4(), Uuid::new_v4()];
         uuids.sort();
         let now = Utc::now();
@@ -376,13 +382,13 @@ mod tests {
         });
 
         {
-            let mut txn = db.storage.txn()?;
-            apply_operations(txn.as_mut(), &ops)?;
-            txn.commit()?;
+            let mut txn = db.storage.txn().await?;
+            apply_operations(txn.as_mut(), &ops).await?;
+            txn.commit().await?;
         }
 
         assert_eq!(
-            db.sorted_tasks(),
+            db.sorted_tasks().await,
             vec![
                 (uuids[0], vec![("p".into(), "1".into())]),
                 (uuids[1], vec![("p".into(), "2".into())])
@@ -391,9 +397,9 @@ mod tests {
         Ok(())
     }
 
-    #[test]
-    fn apply_operations_create_delete() -> Result<()> {
-        let mut db = TaskDb::new_inmemory();
+    #[tokio::test]
+    async fn apply_operations_create_delete() -> Result<()> {
+        let mut db = TaskDb::new(InMemoryStorage::new());
         let uuid = Uuid::new_v4();
         let now = Utc::now();
         let mut ops = Operations::new();
@@ -411,18 +417,18 @@ mod tests {
         });
 
         {
-            let mut txn = db.storage.txn()?;
-            apply_operations(txn.as_mut(), &ops)?;
-            txn.commit()?;
+            let mut txn = db.storage.txn().await?;
+            apply_operations(txn.as_mut(), &ops).await?;
+            txn.commit().await?;
         }
 
-        assert_eq!(db.sorted_tasks(), vec![]);
+        assert_eq!(db.sorted_tasks().await, vec![]);
         Ok(())
     }
 
-    #[test]
-    fn apply_operations_delete_not_present() -> Result<()> {
-        let mut db = TaskDb::new_inmemory();
+    #[tokio::test]
+    async fn apply_operations_delete_not_present() -> Result<()> {
+        let mut db = TaskDb::new(InMemoryStorage::new());
         let uuid = Uuid::new_v4();
         let mut ops = Operations::new();
         ops.push(Operation::Delete {
@@ -431,69 +437,69 @@ mod tests {
         });
 
         {
-            let mut txn = db.storage.txn()?;
-            apply_operations(txn.as_mut(), &ops)?;
-            txn.commit()?;
+            let mut txn = db.storage.txn().await?;
+            apply_operations(txn.as_mut(), &ops).await?;
+            txn.commit().await?;
         }
 
-        assert_eq!(db.sorted_tasks(), vec![]);
+        assert_eq!(db.sorted_tasks().await, vec![]);
         Ok(())
     }
 
-    #[test]
-    fn test_apply_create() -> Result<()> {
-        let mut db = TaskDb::new_inmemory();
+    #[tokio::test]
+    async fn test_apply_create() -> Result<()> {
+        let mut db = TaskDb::new(InMemoryStorage::new());
         let uuid = Uuid::new_v4();
         let op = SyncOp::Create { uuid };
 
         {
-            let mut txn = db.storage.txn()?;
-            apply_op(txn.as_mut(), &op)?;
-            txn.commit()?;
+            let mut txn = db.storage.txn().await?;
+            apply_op(txn.as_mut(), &op).await?;
+            txn.commit().await?;
         }
 
-        assert_eq!(db.sorted_tasks(), vec![(uuid, vec![]),]);
+        assert_eq!(db.sorted_tasks().await, vec![(uuid, vec![])]);
         Ok(())
     }
 
-    #[test]
-    fn test_apply_create_exists() -> Result<()> {
-        let mut db = TaskDb::new_inmemory();
+    #[tokio::test]
+    async fn test_apply_create_exists() -> Result<()> {
+        let mut db = TaskDb::new(InMemoryStorage::new());
         let uuid = Uuid::new_v4();
         {
-            let mut txn = db.storage.txn()?;
-            txn.create_task(uuid)?;
+            let mut txn = db.storage.txn().await?;
+            txn.create_task(uuid).await?;
             let mut taskmap = TaskMap::new();
             taskmap.insert("foo".into(), "bar".into());
-            txn.set_task(uuid, taskmap)?;
-            txn.commit()?;
+            txn.set_task(uuid, taskmap).await?;
+            txn.commit().await?;
         }
 
         let op = SyncOp::Create { uuid };
         {
-            let mut txn = db.storage.txn()?;
-            assert!(apply_op(txn.as_mut(), &op).is_err());
+            let mut txn = db.storage.txn().await?;
+            assert!(apply_op(txn.as_mut(), &op).await.is_err());
         }
 
         // create did not delete the old task..
         assert_eq!(
-            db.sorted_tasks(),
+            db.sorted_tasks().await,
             vec![(uuid, vec![("foo".into(), "bar".into())])]
         );
         Ok(())
     }
 
-    #[test]
-    fn test_apply_create_update() -> Result<()> {
-        let mut db = TaskDb::new_inmemory();
+    #[tokio::test]
+    async fn test_apply_create_update() -> Result<()> {
+        let mut db = TaskDb::new(InMemoryStorage::new());
         let uuid = Uuid::new_v4();
         let now = Utc::now();
         let op1 = SyncOp::Create { uuid };
 
         {
-            let mut txn = db.storage.txn()?;
-            apply_op(txn.as_mut(), &op1)?;
-            txn.commit()?;
+            let mut txn = db.storage.txn().await?;
+            apply_op(txn.as_mut(), &op1).await?;
+            txn.commit().await?;
         }
 
         let op2 = SyncOp::Update {
@@ -503,29 +509,29 @@ mod tests {
             timestamp: now,
         };
         {
-            let mut txn = db.storage.txn()?;
-            apply_op(txn.as_mut(), &op2)?;
-            txn.commit()?;
+            let mut txn = db.storage.txn().await?;
+            apply_op(txn.as_mut(), &op2).await?;
+            txn.commit().await?;
         }
 
         assert_eq!(
-            db.sorted_tasks(),
+            db.sorted_tasks().await,
             vec![(uuid, vec![("title".into(), "my task".into())])]
         );
 
         Ok(())
     }
 
-    #[test]
-    fn test_apply_create_update_delete_prop() -> Result<()> {
-        let mut db = TaskDb::new_inmemory();
+    #[tokio::test]
+    async fn test_apply_create_update_delete_prop() -> Result<()> {
+        let mut db = TaskDb::new(InMemoryStorage::new());
         let uuid = Uuid::new_v4();
         let now = Utc::now();
         let op1 = SyncOp::Create { uuid };
         {
-            let mut txn = db.storage.txn()?;
-            apply_op(txn.as_mut(), &op1)?;
-            txn.commit()?;
+            let mut txn = db.storage.txn().await?;
+            apply_op(txn.as_mut(), &op1).await?;
+            txn.commit().await?;
         }
 
         let op2 = SyncOp::Update {
@@ -535,9 +541,9 @@ mod tests {
             timestamp: now,
         };
         {
-            let mut txn = db.storage.txn()?;
-            apply_op(txn.as_mut(), &op2)?;
-            txn.commit()?;
+            let mut txn = db.storage.txn().await?;
+            apply_op(txn.as_mut(), &op2).await?;
+            txn.commit().await?;
         }
 
         let op3 = SyncOp::Update {
@@ -547,9 +553,9 @@ mod tests {
             timestamp: now,
         };
         {
-            let mut txn = db.storage.txn()?;
-            apply_op(txn.as_mut(), &op3)?;
-            txn.commit()?;
+            let mut txn = db.storage.txn().await?;
+            apply_op(txn.as_mut(), &op3).await?;
+            txn.commit().await?;
         }
 
         let op4 = SyncOp::Update {
@@ -559,9 +565,9 @@ mod tests {
             timestamp: now,
         };
         {
-            let mut txn = db.storage.txn()?;
-            apply_op(txn.as_mut(), &op4)?;
-            txn.commit()?;
+            let mut txn = db.storage.txn().await?;
+            apply_op(txn.as_mut(), &op4).await?;
+            txn.commit().await?;
         }
 
         let mut exp = HashMap::new();
@@ -569,16 +575,16 @@ mod tests {
         task.insert(String::from("priority"), String::from("H"));
         exp.insert(uuid, task);
         assert_eq!(
-            db.sorted_tasks(),
+            db.sorted_tasks().await,
             vec![(uuid, vec![("priority".into(), "H".into())])]
         );
 
         Ok(())
     }
 
-    #[test]
-    fn test_apply_update_does_not_exist() -> Result<()> {
-        let mut db = TaskDb::new_inmemory();
+    #[tokio::test]
+    async fn test_apply_update_does_not_exist() -> Result<()> {
+        let mut db = TaskDb::new(InMemoryStorage::new());
         let uuid = Uuid::new_v4();
         let op = SyncOp::Update {
             uuid,
@@ -587,28 +593,28 @@ mod tests {
             timestamp: Utc::now(),
         };
         {
-            let mut txn = db.storage.txn()?;
+            let mut txn = db.storage.txn().await?;
             assert_eq!(
-                apply_op(txn.as_mut(), &op).err().unwrap().to_string(),
+                apply_op(txn.as_mut(), &op).await.err().unwrap().to_string(),
                 format!("Task Database Error: Task {} does not exist", uuid)
             );
-            txn.commit()?;
+            txn.commit().await?;
         }
 
         Ok(())
     }
 
-    #[test]
-    fn test_apply_create_delete() -> Result<()> {
-        let mut db = TaskDb::new_inmemory();
+    #[tokio::test]
+    async fn test_apply_create_delete() -> Result<()> {
+        let mut db = TaskDb::new(InMemoryStorage::new());
         let uuid = Uuid::new_v4();
         let now = Utc::now();
 
         let op1 = SyncOp::Create { uuid };
         {
-            let mut txn = db.storage.txn()?;
-            apply_op(txn.as_mut(), &op1)?;
-            txn.commit()?;
+            let mut txn = db.storage.txn().await?;
+            apply_op(txn.as_mut(), &op1).await?;
+            txn.commit().await?;
         }
 
         let op2 = SyncOp::Update {
@@ -618,34 +624,34 @@ mod tests {
             timestamp: now,
         };
         {
-            let mut txn = db.storage.txn()?;
-            apply_op(txn.as_mut(), &op2)?;
-            txn.commit()?;
+            let mut txn = db.storage.txn().await?;
+            apply_op(txn.as_mut(), &op2).await?;
+            txn.commit().await?;
         }
 
         let op3 = SyncOp::Delete { uuid };
         {
-            let mut txn = db.storage.txn()?;
-            apply_op(txn.as_mut(), &op3)?;
-            txn.commit()?;
+            let mut txn = db.storage.txn().await?;
+            apply_op(txn.as_mut(), &op3).await?;
+            txn.commit().await?;
         }
 
-        assert_eq!(db.sorted_tasks(), vec![]);
+        assert_eq!(db.sorted_tasks().await, vec![]);
         let mut old_task = TaskMap::new();
         old_task.insert("priority".into(), "H".into());
 
         Ok(())
     }
 
-    #[test]
-    fn test_apply_delete_not_present() -> Result<()> {
-        let mut db = TaskDb::new_inmemory();
+    #[tokio::test]
+    async fn test_apply_delete_not_present() -> Result<()> {
+        let mut db = TaskDb::new(InMemoryStorage::new());
         let uuid = Uuid::new_v4();
         let op = SyncOp::Delete { uuid };
         {
-            let mut txn = db.storage.txn()?;
-            assert!(apply_op(txn.as_mut(), &op).is_err());
-            txn.commit()?;
+            let mut txn = db.storage.txn().await?;
+            assert!(apply_op(txn.as_mut(), &op).await.is_err());
+            txn.commit().await?;
         }
 
         Ok(())

--- a/src/taskdb/mod.rs
+++ b/src/taskdb/mod.rs
@@ -16,20 +16,14 @@ mod working_set;
 /// A TaskDb is the backend for a replica.  It manages the storage, operations, synchronization,
 /// and so on, and all the invariants that come with it.  It leaves the meaning of particular task
 /// properties to the replica and task implementations.
-pub(crate) struct TaskDb {
-    storage: Box<dyn Storage>,
+pub(crate) struct TaskDb<S: Storage> {
+    storage: S,
 }
 
-impl TaskDb {
+impl<S: Storage> TaskDb<S> {
     /// Create a new TaskDb with the given backend storage
-    pub(crate) fn new(storage: Box<dyn Storage>) -> TaskDb {
+    pub(crate) fn new(storage: S) -> TaskDb<S> {
         TaskDb { storage }
-    }
-
-    #[cfg(test)]
-    pub(crate) fn new_inmemory() -> TaskDb {
-        use crate::StorageConfig;
-        TaskDb::new(StorageConfig::InMemory.into_storage().unwrap())
     }
 
     /// Apply `operations` to the database in a single transaction.
@@ -39,7 +33,7 @@ impl TaskDb {
     ///
     /// Any operations for which `add_to_working_set` returns true will cause the relevant
     /// task to be added to the working set.
-    pub(crate) fn commit_operations<F>(
+    pub(crate) async fn commit_operations<F>(
         &mut self,
         operations: Operations,
         add_to_working_set: F,
@@ -47,8 +41,8 @@ impl TaskDb {
     where
         F: Fn(&Operation) -> bool,
     {
-        let mut txn = self.storage.txn()?;
-        apply::apply_operations(txn.as_mut(), &operations)?;
+        let mut txn = self.storage.txn().await?;
+        apply::apply_operations(txn.as_mut(), &operations).await?;
 
         // Calculate the task(s) to add to the working set.
         let mut to_add = Vec::new();
@@ -62,67 +56,75 @@ impl TaskDb {
                 }
             }
         }
-        let mut working_set: HashSet<Uuid> =
-            txn.get_working_set()?.iter().filter_map(|u| *u).collect();
+        let mut working_set: HashSet<Uuid> = txn
+            .get_working_set()
+            .await?
+            .iter()
+            .filter_map(|u| *u)
+            .collect();
         for uuid in to_add {
             // Double-check that we are not adding a task to the working-set twice.
             if !working_set.contains(&uuid) {
-                txn.add_to_working_set(uuid)?;
+                txn.add_to_working_set(uuid).await?;
                 working_set.insert(uuid);
             }
         }
 
         for operation in operations {
-            txn.add_operation(operation)?;
+            txn.add_operation(operation).await?;
         }
 
-        txn.commit()
+        txn.commit().await
     }
 
     /// Get all tasks.
-    pub(crate) fn all_tasks(&mut self) -> Result<Vec<(Uuid, TaskMap)>> {
-        let mut txn = self.storage.txn()?;
-        txn.all_tasks()
+    pub(crate) async fn all_tasks(&mut self) -> Result<Vec<(Uuid, TaskMap)>> {
+        let mut txn = self.storage.txn().await?;
+        txn.all_tasks().await
     }
 
     /// Get the UUIDs of all tasks
-    pub(crate) fn all_task_uuids(&mut self) -> Result<Vec<Uuid>> {
-        let mut txn = self.storage.txn()?;
-        txn.all_task_uuids()
+    pub(crate) async fn all_task_uuids(&mut self) -> Result<Vec<Uuid>> {
+        let mut txn = self.storage.txn().await?;
+        txn.all_task_uuids().await
     }
 
     /// Get the working set
-    pub(crate) fn working_set(&mut self) -> Result<Vec<Option<Uuid>>> {
-        let mut txn = self.storage.txn()?;
-        txn.get_working_set()
+    pub(crate) async fn working_set(&mut self) -> Result<Vec<Option<Uuid>>> {
+        let mut txn = self.storage.txn().await?;
+        txn.get_working_set().await
     }
 
     /// Get a single task, by uuid.
-    pub(crate) fn get_task(&mut self, uuid: Uuid) -> Result<Option<TaskMap>> {
-        let mut txn = self.storage.txn()?;
-        txn.get_task(uuid)
+    pub(crate) async fn get_task(&mut self, uuid: Uuid) -> Result<Option<TaskMap>> {
+        let mut txn = self.storage.txn().await?;
+        txn.get_task(uuid).await
     }
 
     /// Get all pending tasks from the working set
-    pub(crate) fn get_pending_tasks(&mut self) -> Result<Vec<(Uuid, TaskMap)>> {
-        let mut txn = self.storage.txn()?;
-        txn.get_pending_tasks()
+    pub(crate) async fn get_pending_tasks(&mut self) -> Result<Vec<(Uuid, TaskMap)>> {
+        let mut txn = self.storage.txn().await?;
+        txn.get_pending_tasks().await
     }
 
-    pub(crate) fn get_task_operations(&mut self, uuid: Uuid) -> Result<Operations> {
-        let mut txn = self.storage.txn()?;
-        txn.get_task_operations(uuid)
+    pub(crate) async fn get_task_operations(&mut self, uuid: Uuid) -> Result<Operations> {
+        let mut txn = self.storage.txn().await?;
+        txn.get_task_operations(uuid).await
     }
 
     /// Rebuild the working set using a function to identify tasks that should be in the set.  This
     /// renumbers the existing working-set tasks to eliminate gaps, and also adds any tasks that
     /// are not already in the working set but should be.  The rebuild occurs in a single
     /// trasnsaction against the storage backend.
-    pub(crate) fn rebuild_working_set<F>(&mut self, in_working_set: F, renumber: bool) -> Result<()>
+    pub(crate) async fn rebuild_working_set<F>(
+        &mut self,
+        in_working_set: F,
+        renumber: bool,
+    ) -> Result<()>
     where
         F: Fn(&TaskMap) -> bool,
     {
-        working_set::rebuild(self.storage.txn()?.as_mut(), in_working_set, renumber)
+        working_set::rebuild(self.storage.txn().await?.as_mut(), in_working_set, renumber).await
     }
 
     /// Sync to the given server, pulling remote changes and pushing local changes.
@@ -133,13 +135,13 @@ impl TaskDb {
     ///
     /// Set this to true on systems more constrained in CPU, memory, or bandwidth than a typical desktop
     /// system
-    pub(crate) fn sync(
+    pub(crate) async fn sync(
         &mut self,
         server: &mut Box<dyn Server>,
         avoid_snapshots: bool,
     ) -> Result<()> {
-        let mut txn = self.storage.txn()?;
-        sync::sync(server, txn.as_mut(), avoid_snapshots)
+        let mut txn = self.storage.txn().await?;
+        sync::sync(server, txn.as_mut(), avoid_snapshots).await
     }
 
     /// Return the operations back to and including the last undo point, or since the last sync if
@@ -147,9 +149,9 @@ impl TaskDb {
     ///
     /// The operations are returned in the order they were applied. Use
     /// [`commit_reversed_operations`] to "undo" them.
-    pub(crate) fn get_undo_operations(&mut self) -> Result<Operations> {
-        let mut txn = self.storage.txn()?;
-        undo::get_undo_operations(txn.as_mut())
+    pub(crate) async fn get_undo_operations(&mut self) -> Result<Operations> {
+        let mut txn = self.storage.txn().await?;
+        undo::get_undo_operations(txn.as_mut()).await
     }
 
     /// Commit the reverse of the given operations, beginning with the last operation in the given
@@ -157,27 +159,32 @@ impl TaskDb {
     ///
     /// This method only supports reversing operations if they precisely match local operations
     /// that have not yet been synchronized, and will return `false` if this is not the case.
-    pub(crate) fn commit_reversed_operations(&mut self, undo_ops: Operations) -> Result<bool> {
-        let mut txn = self.storage.txn()?;
-        undo::commit_reversed_operations(txn.as_mut(), undo_ops)
+    pub(crate) async fn commit_reversed_operations(
+        &mut self,
+        undo_ops: Operations,
+    ) -> Result<bool> {
+        let mut txn = self.storage.txn().await?;
+        undo::commit_reversed_operations(txn.as_mut(), undo_ops).await
     }
 
     /// Get the number of un-synchronized operations in storage, excluding undo
     /// operations.
-    pub(crate) fn num_operations(&mut self) -> Result<usize> {
-        let mut txn = self.storage.txn().unwrap();
+    pub(crate) async fn num_operations(&mut self) -> Result<usize> {
+        let mut txn = self.storage.txn().await?;
         Ok(txn
-            .unsynced_operations()?
+            .unsynced_operations()
+            .await?
             .iter()
             .filter(|o| !o.is_undo_point())
             .count())
     }
 
     /// Get the number of (un-synchronized) undo points in storage.
-    pub(crate) fn num_undo_points(&mut self) -> Result<usize> {
-        let mut txn = self.storage.txn().unwrap();
+    pub(crate) async fn num_undo_points(&mut self) -> Result<usize> {
+        let mut txn = self.storage.txn().await?;
         Ok(txn
-            .unsynced_operations()?
+            .unsynced_operations()
+            .await?
             .iter()
             .filter(|o| o.is_undo_point())
             .count())
@@ -186,9 +193,10 @@ impl TaskDb {
     // functions for supporting tests
 
     #[cfg(test)]
-    pub(crate) fn sorted_tasks(&mut self) -> Vec<(Uuid, Vec<(String, String)>)> {
+    pub(crate) async fn sorted_tasks(&mut self) -> Vec<(Uuid, Vec<(String, String)>)> {
         let mut res: Vec<(Uuid, Vec<(String, String)>)> = self
             .all_tasks()
+            .await
             .unwrap()
             .iter()
             .map(|(u, t)| {
@@ -205,22 +213,24 @@ impl TaskDb {
     }
 
     #[cfg(test)]
-    pub(crate) fn operations(&mut self) -> Vec<Operation> {
-        let mut txn = self.storage.txn().unwrap();
-        txn.unsynced_operations().unwrap().to_vec()
+    pub(crate) async fn operations(&mut self) -> Vec<Operation> {
+        let mut txn = self.storage.txn().await.unwrap();
+        txn.unsynced_operations().await.unwrap().to_vec()
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use crate::storage::inmemory::InMemoryStorage;
+
     use super::*;
     use chrono::Utc;
     use pretty_assertions::assert_eq;
     use uuid::Uuid;
 
-    #[test]
-    fn commit_operations() -> Result<()> {
-        let mut db = TaskDb::new_inmemory();
+    #[tokio::test]
+    async fn commit_operations() -> Result<()> {
+        let mut db = TaskDb::new(InMemoryStorage::new());
         let uuid = Uuid::new_v4();
         let now = Utc::now();
         let mut ops = Operations::new();
@@ -233,14 +243,14 @@ mod tests {
             old_value: Some("old".into()),
         });
 
-        db.commit_operations(ops, |_| false)?;
+        db.commit_operations(ops, |_| false).await?;
 
         assert_eq!(
-            db.sorted_tasks(),
+            db.sorted_tasks().await,
             vec![(uuid, vec![("title".into(), "my task".into())])]
         );
         assert_eq!(
-            db.operations(),
+            db.operations().await,
             vec![
                 Operation::Create { uuid },
                 Operation::Update {
@@ -255,18 +265,18 @@ mod tests {
         Ok(())
     }
 
-    #[test]
-    fn commit_operations_update_working_set() -> Result<()> {
-        let mut db = TaskDb::new_inmemory();
+    #[tokio::test]
+    async fn commit_operations_update_working_set() -> Result<()> {
+        let mut db = TaskDb::new(InMemoryStorage::new());
         let mut uuids = [Uuid::new_v4(), Uuid::new_v4(), Uuid::new_v4()];
         uuids.sort();
         let [uuid1, uuid2, uuid3] = uuids;
 
         // uuid1 already exists in the working set.
         {
-            let mut txn = db.storage.txn()?;
-            txn.add_to_working_set(uuid1)?;
-            txn.commit()?;
+            let mut txn = db.storage.txn().await?;
+            txn.add_to_working_set(uuid1).await?;
+            txn.commit().await?;
         }
 
         let mut ops = Operations::new();
@@ -281,14 +291,14 @@ mod tests {
             Operation::Create { uuid } => *uuid == uuid1 || *uuid == uuid2,
             _ => false,
         };
-        db.commit_operations(ops, add_to_working_set)?;
+        db.commit_operations(ops, add_to_working_set).await?;
 
         assert_eq!(
-            db.sorted_tasks(),
+            db.sorted_tasks().await,
             vec![(uuid1, vec![]), (uuid2, vec![]), (uuid3, vec![]),]
         );
         assert_eq!(
-            db.operations(),
+            db.operations().await,
             vec![
                 Operation::Create { uuid: uuid1 },
                 Operation::Create { uuid: uuid2 },
@@ -299,13 +309,16 @@ mod tests {
         );
 
         // uuid2 was added to the working set, once, and uuid3 was not.
-        assert_eq!(db.working_set()?, vec![None, Some(uuid1), Some(uuid2)],);
+        assert_eq!(
+            db.working_set().await?,
+            vec![None, Some(uuid1), Some(uuid2)],
+        );
         Ok(())
     }
 
-    #[test]
-    fn test_num_operations() {
-        let mut db = TaskDb::new_inmemory();
+    #[tokio::test]
+    async fn test_num_operations() {
+        let mut db = TaskDb::new(InMemoryStorage::new());
         let mut ops = Operations::new();
         ops.push(Operation::Create {
             uuid: Uuid::new_v4(),
@@ -314,21 +327,21 @@ mod tests {
         ops.push(Operation::Create {
             uuid: Uuid::new_v4(),
         });
-        db.commit_operations(ops, |_| false).unwrap();
-        assert_eq!(db.num_operations().unwrap(), 2);
+        db.commit_operations(ops, |_| false).await.unwrap();
+        assert_eq!(db.num_operations().await.unwrap(), 2);
     }
 
-    #[test]
-    fn test_num_undo_points() {
-        let mut db = TaskDb::new_inmemory();
+    #[tokio::test]
+    async fn test_num_undo_points() {
+        let mut db = TaskDb::new(InMemoryStorage::new());
         let mut ops = Operations::new();
         ops.push(Operation::UndoPoint);
-        db.commit_operations(ops, |_| false).unwrap();
-        assert_eq!(db.num_undo_points().unwrap(), 1);
+        db.commit_operations(ops, |_| false).await.unwrap();
+        assert_eq!(db.num_undo_points().await.unwrap(), 1);
 
         let mut ops = Operations::new();
         ops.push(Operation::UndoPoint);
-        db.commit_operations(ops, |_| false).unwrap();
-        assert_eq!(db.num_undo_points().unwrap(), 2);
+        db.commit_operations(ops, |_| false).await.unwrap();
+        assert_eq!(db.num_undo_points().await.unwrap(), 2);
     }
 }

--- a/tests/cross-sync.rs
+++ b/tests/cross-sync.rs
@@ -1,14 +1,15 @@
 use chrono::Utc;
 use pretty_assertions::assert_eq;
-use taskchampion::{Operations, Replica, ServerConfig, Status, StorageConfig, Uuid};
+use taskchampion::storage::inmemory::InMemoryStorage;
+use taskchampion::{Operations, Replica, ServerConfig, Status, Uuid};
 use tempfile::TempDir;
 
-#[test]
+#[tokio::test]
 #[cfg(feature = "server-local")]
-fn cross_sync() -> anyhow::Result<()> {
+async fn cross_sync() -> anyhow::Result<()> {
     // set up two replicas, and demonstrate replication between them
-    let mut rep1 = Replica::new(StorageConfig::InMemory.into_storage()?);
-    let mut rep2 = Replica::new(StorageConfig::InMemory.into_storage()?);
+    let mut rep1 = Replica::new(InMemoryStorage::new());
+    let mut rep2 = Replica::new(InMemoryStorage::new());
 
     let tmp_dir = TempDir::new().expect("TempDir failed");
     let server_config = ServerConfig::Local {
@@ -20,11 +21,11 @@ fn cross_sync() -> anyhow::Result<()> {
     let mut ops = Operations::new();
 
     // add some tasks on rep1
-    let mut t1 = rep1.create_task(uuid1, &mut ops)?;
+    let mut t1 = rep1.create_task(uuid1, &mut ops).await?;
     t1.set_description("test 1".into(), &mut ops)?;
     t1.set_status(Status::Pending, &mut ops)?;
     t1.set_entry(Some(Utc::now()), &mut ops)?;
-    let mut t2 = rep1.create_task(uuid2, &mut ops)?;
+    let mut t2 = rep1.create_task(uuid2, &mut ops).await?;
     t2.set_description("test 2".into(), &mut ops)?;
     t2.set_status(Status::Pending, &mut ops)?;
     t2.set_entry(Some(Utc::now()), &mut ops)?;
@@ -32,14 +33,20 @@ fn cross_sync() -> anyhow::Result<()> {
     // modify t1
     t1.start(&mut ops)?;
 
-    rep1.commit_operations(ops)?;
+    rep1.commit_operations(ops).await?;
 
-    rep1.sync(&mut server, false)?;
-    rep2.sync(&mut server, false)?;
+    rep1.sync(&mut server, false).await?;
+    rep2.sync(&mut server, false).await?;
 
     // those tasks should exist on rep2 now
-    let mut t12 = rep2.get_task(uuid1)?.expect("expected task 1 on rep2");
-    let t22 = rep2.get_task(uuid2)?.expect("expected task 2 on rep2");
+    let mut t12 = rep2
+        .get_task(uuid1)
+        .await?
+        .expect("expected task 1 on rep2");
+    let t22 = rep2
+        .get_task(uuid2)
+        .await?
+        .expect("expected task 2 on rep2");
 
     assert_eq!(t12.get_description(), "test 1");
     assert_eq!(t12.is_active(), true);
@@ -49,43 +56,49 @@ fn cross_sync() -> anyhow::Result<()> {
     // make non-conflicting changes on the two replicas
     let mut ops = Operations::new();
     t2.set_status(Status::Completed, &mut ops)?;
-    rep2.commit_operations(ops)?;
+    rep1.commit_operations(ops).await?;
 
     let mut ops = Operations::new();
     t12.set_status(Status::Completed, &mut ops)?;
-    rep2.commit_operations(ops)?;
+    rep2.commit_operations(ops).await?;
 
     // sync those changes back and forth
-    rep1.sync(&mut server, false)?; // rep1 -> server
-    rep2.sync(&mut server, false)?; // server -> rep2, rep2 -> server
-    rep1.sync(&mut server, false)?; // server -> rep1
+    rep1.sync(&mut server, false).await?; // rep1 -> server
+    rep2.sync(&mut server, false).await?; // server -> rep2, rep2 -> server
+    rep1.sync(&mut server, false).await?; // server -> rep1
 
-    let t1 = rep1.get_task(uuid1)?.expect("expected task 1 on rep1");
+    let t1 = rep1
+        .get_task(uuid1)
+        .await?
+        .expect("expected task 1 on rep1");
     assert_eq!(t1.get_status(), Status::Completed);
 
-    let mut t22 = rep2.get_task(uuid2)?.expect("expected task 2 on rep2");
+    let mut t22 = rep2
+        .get_task(uuid2)
+        .await?
+        .expect("expected task 2 on rep2");
     assert_eq!(t22.get_status(), Status::Completed);
 
-    rep1.rebuild_working_set(true)?;
-    rep2.rebuild_working_set(true)?;
+    rep1.rebuild_working_set(true).await?;
+    rep2.rebuild_working_set(true).await?;
 
     // Make task 2 pending again, and observe that it is in the working set in both replicas after
     // sync.
     let mut ops = Operations::new();
     t22.set_status(Status::Pending, &mut ops)?;
-    rep2.commit_operations(ops)?;
+    rep2.commit_operations(ops).await?;
 
-    let ws = rep2.working_set()?;
+    let ws = rep2.working_set().await?;
     assert_eq!(ws.by_index(1), Some(uuid2));
 
     // Pending status is not sync'd to rep1 yet.
-    let ws = rep1.working_set()?;
+    let ws = rep1.working_set().await?;
     assert_eq!(ws.by_index(1), None);
 
-    rep2.sync(&mut server, false)?;
-    rep1.sync(&mut server, false)?;
+    rep2.sync(&mut server, false).await?;
+    rep1.sync(&mut server, false).await?;
 
-    let ws = rep1.working_set()?;
+    let ws = rep1.working_set().await?;
     assert_eq!(ws.by_index(1), Some(uuid2));
 
     Ok(())

--- a/tests/syncing-proptest.rs
+++ b/tests/syncing-proptest.rs
@@ -1,7 +1,9 @@
+#![cfg(feature = "server-local")]
+
 use pretty_assertions::assert_eq;
 use proptest::prelude::*;
-#[cfg(feature = "storage-sqlite")]
-use taskchampion::{Operations, Replica, ServerConfig, StorageConfig, TaskData, Uuid};
+use taskchampion::storage::inmemory::InMemoryStorage;
+use taskchampion::{Operations, Replica, ServerConfig, TaskData, Uuid};
 use tempfile::TempDir;
 
 #[derive(Debug, Clone)]
@@ -27,7 +29,6 @@ fn actions() -> impl Strategy<Value = Vec<(Action, u8)>> {
 
 proptest! {
 #[test]
-#[cfg(feature = "storage-sqlite")]
 /// Check that various sequences of operations on mulitple db's do not get the db's into an
 /// incompatible state.  The main concern here is that there might be a sequence of operations
 /// that results in a task being in different states in different replicas. Different tasks
@@ -38,55 +39,61 @@ fn multi_replica_sync(action_sequence in actions()) {
     let server_config = ServerConfig::Local {
         server_dir: tmp_dir.path().to_path_buf(),
     };
-    let mut server = server_config.into_server()?;
+    let mut server = server_config.into_server().unwrap();
     let mut replicas = [
-        Replica::new(StorageConfig::InMemory.into_storage().unwrap()),
-        Replica::new(StorageConfig::InMemory.into_storage().unwrap()),
-        Replica::new(StorageConfig::InMemory.into_storage().unwrap()),
+        Replica::new(InMemoryStorage::new()),
+        Replica::new(InMemoryStorage::new()),
+        Replica::new(InMemoryStorage::new()),
     ];
 
-    for (action, rep) in action_sequence {
-        println!("{:?} on rep {}", action, rep);
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(async {
+            for (action, rep) in action_sequence {
+                println!("{:?} on rep {}", action, rep);
 
-        let rep = &mut replicas[rep as usize];
-        match action {
-            Action::Create => {
-                if rep.get_task_data(uuid).unwrap().is_none() {
-                    let mut ops = Operations::new();
-                    TaskData::create(uuid, &mut ops);
-                    rep.commit_operations(ops).unwrap();
+                let rep = &mut replicas[rep as usize];
+                match action {
+                    Action::Create => {
+                        if rep.get_task_data(uuid).await.unwrap().is_none() {
+                            let mut ops = Operations::new();
+                            TaskData::create(uuid, &mut ops);
+                            rep.commit_operations(ops).await.unwrap();
+                        }
+                    }
+                    Action::Update(p, v) => {
+                        if let Some(mut t) = rep.get_task_data(uuid).await.unwrap() {
+                            let mut ops = Operations::new();
+                            t.update(p, Some(v), &mut ops);
+                            rep.commit_operations(ops).await.unwrap();
+                        }
+                    }
+                    Action::Delete => {
+                        if let Some(mut t) = rep.get_task_data(uuid).await.unwrap() {
+                            let mut ops = Operations::new();
+                            t.delete(&mut ops);
+                            rep.commit_operations(ops).await.unwrap();
+                        }
+                    }
+                    Action::Sync => rep.sync(&mut server, false).await.unwrap(),
                 }
-            },
-            Action::Update(p, v) => {
-                if let Some(mut t) = rep.get_task_data(uuid).unwrap() {
-                    let mut ops = Operations::new();
-                    t.update(p, Some(v), &mut ops);
-                    rep.commit_operations(ops).unwrap();
-                }
-            },
-            Action::Delete => {
-                if let Some(mut t) = rep.get_task_data(uuid).unwrap() {
-                    let mut ops = Operations::new();
-                    t.delete(&mut ops);
-                    rep.commit_operations(ops).unwrap();
-                }
-            },
-            Action::Sync => rep.sync(&mut server, false).unwrap(),
-        }
-    }
+            }
 
-    // Sync all of the replicas, twice, to flush out any un-synced changes.
-    for rep in &mut replicas {
-        rep.sync(&mut server, false).unwrap()
-    }
-    for rep in &mut replicas {
-        rep.sync(&mut server, false).unwrap()
-    }
+            // Sync all of the replicas, twice, to flush out any un-synced changes.
+            for rep in &mut replicas {
+                rep.sync(&mut server, false).await.unwrap()
+            }
+            for rep in &mut replicas {
+                rep.sync(&mut server, false).await.unwrap()
+            }
 
-    let t0 = replicas[0].get_task_data(uuid).unwrap();
-    let t1 = replicas[1].get_task_data(uuid).unwrap();
-    let t2 = replicas[2].get_task_data(uuid).unwrap();
-    assert_eq!(t0, t1);
-    assert_eq!(t1, t2);
+            let t0 = replicas[0].get_task_data(uuid).await.unwrap();
+            let t1 = replicas[1].get_task_data(uuid).await.unwrap();
+            let t2 = replicas[2].get_task_data(uuid).await.unwrap();
+            assert_eq!(t0, t1);
+            assert_eq!(t1, t2);
+        });
 }
 }

--- a/tests/update-and-delete-sync.rs
+++ b/tests/update-and-delete-sync.rs
@@ -1,27 +1,27 @@
+#![cfg(feature = "server-local")]
+
 use taskchampion::chrono::{TimeZone, Utc};
-use taskchampion::{Operations, Replica, ServerConfig, Status, StorageConfig, Uuid};
+use taskchampion::storage::inmemory::InMemoryStorage;
+use taskchampion::{Operations, Replica, ServerConfig, Status, Uuid};
 use tempfile::TempDir;
 
-#[test]
-#[cfg(feature = "server-local")]
-fn update_and_delete_sync_delete_first() -> anyhow::Result<()> {
-    update_and_delete_sync(true)
+#[tokio::test]
+async fn update_and_delete_sync_delete_first() -> anyhow::Result<()> {
+    update_and_delete_sync(true).await
 }
 
-#[test]
-#[cfg(feature = "server-local")]
-fn update_and_delete_sync_update_first() -> anyhow::Result<()> {
-    update_and_delete_sync(false)
+#[tokio::test]
+async fn update_and_delete_sync_update_first() -> anyhow::Result<()> {
+    update_and_delete_sync(false).await
 }
 
 /// Test what happens when an update is sync'd into a repo after a task is deleted.
 /// If delete_first, then the deletion is sync'd to the server first; otherwise
 /// the update is sync'd first.  Either way, the task is gone.
-#[cfg(feature = "server-local")]
-fn update_and_delete_sync(delete_first: bool) -> anyhow::Result<()> {
+async fn update_and_delete_sync(delete_first: bool) -> anyhow::Result<()> {
     // set up two replicas, and demonstrate replication between them
-    let mut rep1 = Replica::new(StorageConfig::InMemory.into_storage()?);
-    let mut rep2 = Replica::new(StorageConfig::InMemory.into_storage()?);
+    let mut rep1 = Replica::new(InMemoryStorage::new());
+    let mut rep2 = Replica::new(InMemoryStorage::new());
 
     let tmp_dir = TempDir::new().expect("TempDir failed");
     let mut server = ServerConfig::Local {
@@ -32,53 +32,53 @@ fn update_and_delete_sync(delete_first: bool) -> anyhow::Result<()> {
     // add a task on rep1, and sync it to rep2
     let mut ops = Operations::new();
     let u = Uuid::new_v4();
-    let mut t = rep1.create_task(u, &mut ops)?;
+    let mut t = rep1.create_task(u, &mut ops).await?;
     t.set_description("test task".into(), &mut ops)?;
     t.set_status(Status::Pending, &mut ops)?;
     t.set_entry(Some(Utc::now()), &mut ops)?;
-    rep1.commit_operations(ops)?;
+    rep1.commit_operations(ops).await?;
 
-    rep1.sync(&mut server, false)?;
-    rep2.sync(&mut server, false)?;
+    rep1.sync(&mut server, false).await?;
+    rep2.sync(&mut server, false).await?;
 
     // mark the task as deleted, long in the past, on rep2
     {
         let mut ops = Operations::new();
-        let mut t = rep2.get_task(u)?.unwrap();
+        let mut t = rep2.get_task(u).await?.unwrap();
         t.set_status(Status::Deleted, &mut ops)?;
         t.set_modified(Utc.with_ymd_and_hms(1980, 1, 1, 0, 0, 0).unwrap(), &mut ops)?;
-        rep2.commit_operations(ops)?;
+        rep2.commit_operations(ops).await?;
     }
 
     // sync it back to rep1
-    rep2.sync(&mut server, false)?;
-    rep1.sync(&mut server, false)?;
+    rep2.sync(&mut server, false).await?;
+    rep1.sync(&mut server, false).await?;
 
     // expire the task on rep1 and check that it is gone locally
-    rep1.expire_tasks()?;
-    assert!(rep1.get_task(u)?.is_none());
+    rep1.expire_tasks().await?;
+    assert!(rep1.get_task(u).await?.is_none());
 
     // modify the task on rep2
     {
         let mut ops = Operations::new();
-        let mut t = rep2.get_task(u)?.unwrap();
+        let mut t = rep2.get_task(u).await?.unwrap();
         t.set_description("modified".to_string(), &mut ops)?;
-        rep2.commit_operations(ops)?;
+        rep2.commit_operations(ops).await?;
     }
 
     // sync back and forth
     if delete_first {
-        rep1.sync(&mut server, false)?;
+        rep1.sync(&mut server, false).await?;
     }
-    rep2.sync(&mut server, false)?;
-    rep1.sync(&mut server, false)?;
+    rep2.sync(&mut server, false).await?;
+    rep1.sync(&mut server, false).await?;
     if !delete_first {
-        rep2.sync(&mut server, false)?;
+        rep2.sync(&mut server, false).await?;
     }
 
     // check that the task is gone on both replicas
-    assert!(rep1.get_task(u)?.is_none());
-    assert!(rep2.get_task(u)?.is_none());
+    assert!(rep1.get_task(u).await?.is_none());
+    assert!(rep2.get_task(u).await?.is_none());
 
     Ok(())
 }


### PR DESCRIPTION
This PR converts the `Storage` layer and `Replica` API to be fully `async`, making the library non-blocking and compatible with async Rust runtimes.

The synchronous `rusqlite` backend is adapted for the async API by introducing `SqliteStorageActor`. This wrapper uses the actor model, running all database operations on a dedicated background thread and communicating via message passing.

### Breaking API Changes

* **Async Methods:** Most methods on `Replica` and `StorageTxn` are now `async` and must be `.await`ed.
* **`StorageConfig` Removed:** Storage implementations must be constructed directly.
    * **Before:** `Replica::new(StorageConfig::OnDisk { ... }.into_storage()?)`
    * **After:** `Replica::new(SqliteStorageActor::new(...)?)`
* **Generic `Replica`:** The `Replica` struct is now generic over its storage type (`Replica<S: Storage>`) instead of using a trait object.