### PR TITLE
Update README.md to reflect non 0.x status

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,4 +19,3 @@ There are two crates here:
 The Rust API, as defined in [the docs](https://docs.rs/taskchampion/latest/taskchampion/), supports simple creation and manipulation of replicas and the tasks they contain.
 
 The Rust API follows semantic versioning.
-As this is still in the `0.x` phase, so breaking changes may occur but will be indicated with a change to the minor version.


### PR DESCRIPTION
Taskchampion has since left `0.x` versions, so the README can be updated to reflect that 🙂