### PR TITLE
Add serde Serialize and Deserialize to Task and TaskData

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,8 @@ cloud = []
 bundled = ["rusqlite/bundled"]
 # use native CA roots, instead of bundled
 tls-native-roots = ["ureq/native-certs"]
+# Expose serde::{Serialize, Deserialize} for crate types.
+serde = []
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,10 @@ bundled = ["rusqlite/bundled"]
 # use native CA roots, instead of bundled
 tls-native-roots = ["ureq/native-certs"]
 # Expose serde::{Serialize, Deserialize} for crate types.
-serde = []
+# Note: Task's depmap will be copied to allow for freestanding deserialization.
+# This means that after Deserialization this data will not be de-duplicated.
+# See also: https://serde.rs/feature-flags.html#rc
+serde = ["serde/rc"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/depmap.rs
+++ b/src/depmap.rs
@@ -5,6 +5,7 @@ use uuid::Uuid;
 /// This information requires a scan of the working set to generate, so it is
 /// typically calculated once and re-used.
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DependencyMap {
     /// Edges of the dependency graph.  If (a, b) is in this array, then task a depends on task b.
     edges: Vec<(Uuid, Uuid)>,

--- a/src/task/data.rs
+++ b/src/task/data.rs
@@ -15,6 +15,7 @@ use uuid::Uuid;
 /// See the documentation for [`crate::Replica`] for background on the `ops` arguments to methods
 /// on this type.
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TaskData {
     uuid: Uuid,
     taskmap: TaskMap,

--- a/src/task/task.rs
+++ b/src/task/task.rs
@@ -26,6 +26,7 @@ use uuid::Uuid;
 /// See the documentation for [`crate::Replica`] for background on the `ops` arguments to methods
 /// on this type.
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Task {
     // The underlying task data.
     data: TaskData,


### PR DESCRIPTION
As per the suggestion in #624 I actually noticed that with `serde`'s `rc` feature we can get this quite easily.

I'm not 100% sure if this is in line with the crate's philosophy, but it seems to me that at least having the traits implemented for `TaskData` makes sense from a perspective of the library's ease of use.

Closes #624 