### PR TITLE
fix: Scope tokio dependency to relevant features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,15 +25,15 @@ sync = ["server-sync", "server-gcp", "server-aws", "server-local"]
 # Support for sync to a server
 server-sync = ["encryption", "dep:ureq", "dep:url"]
 # Support for sync to GCP
-server-gcp = ["cloud", "encryption", "dep:google-cloud-storage"]
+server-gcp = ["cloud", "encryption", "dep:google-cloud-storage", "dep:tokio"]
 # Support for sync to AWS
-server-aws = ["cloud", "encryption", "dep:aws-sdk-s3", "dep:aws-config", "dep:aws-credential-types"]
+server-aws = ["cloud", "encryption", "dep:aws-sdk-s3", "dep:aws-config", "dep:aws-credential-types", "dep:tokio"]
 # Suppport for sync to another SQLite database on the same machine
 server-local = ["storage-sqlite"]
 # Support for all task storage backends
 storage = ["storage-sqlite"]
 # Support for SQLite task storage
-storage-sqlite = ["dep:rusqlite"]
+storage-sqlite = ["dep:rusqlite", "dep:tokio"]
 # (private) Support for sync protocol encryption
 encryption = ["dep:ring"]
 # (private) Generic support for cloud sync
@@ -62,7 +62,7 @@ serde_json = "^1.0"
 serde = { version = "^1.0.147", features = ["derive"] }
 strum = "0.27"
 strum_macros = "0.27"
-tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros"], optional = true }
 thiserror = "2.0"
 ureq = { version = "^2.12.1", features = ["tls"], optional = true }
 uuid = { version = "^1.16.0", features = ["serde", "v4"] }


### PR DESCRIPTION
This allows e.g. depending on TaskChampion with `default_features = false` and being able to operate on the types directly.

This may be useful when e.g. consuming TaskChampion-shaped data from an API.

It also makes it possible to build `TaskChampion` for WASM targets, as long as [the notes for `uuid` are followed](https://docs.rs/uuid/latest/uuid/#webassembly).

(As per my comment in #626 🙂)