### PR TITLE
refactor: Make `Server` async

### DIFF
--- a/src/crate-doc.md
+++ b/src/crate-doc.md
@@ -52,7 +52,7 @@ let mut replica = Replica::new(storage);
 
 // Set up a local, on-disk server.
 let server_config = ServerConfig::Local { server_dir };
-let mut server = server_config.into_server()?;
+let mut server = server_config.into_server().await?;
 
 // Sync to that server.
 replica.sync(&mut server, true).await?;

--- a/src/server/cloud/aws.rs
+++ b/src/server/cloud/aws.rs
@@ -1,5 +1,6 @@
 use super::service::{validate_object_name, ObjectInfo, Service};
-use crate::errors::Result;
+use crate::{errors::Result, server::cloud::iter::AsyncObjectIterator};
+use async_trait::async_trait;
 use aws_config::{
     meta::region::RegionProviderChain, profile::ProfileFileCredentialsProvider, BehaviorVersion,
     Region,
@@ -10,13 +11,10 @@ use aws_sdk_s3::{
     error::ProvideErrorMetadata,
     operation::{get_object::GetObjectOutput, list_objects_v2::ListObjectsV2Output},
 };
-use std::future::Future;
-use tokio::runtime::Runtime;
 
 /// A [`Service`] implementation based on the Google Cloud Storage service.
 pub(in crate::server) struct AwsService {
     client: s3::Client,
-    rt: Runtime,
     bucket: String,
 }
 
@@ -62,48 +60,41 @@ pub enum AwsCredentials {
 }
 
 impl AwsService {
-    pub(in crate::server) fn new(
+    pub(in crate::server) async fn new(
         region: String,
         bucket: String,
         creds: AwsCredentials,
     ) -> Result<Self> {
-        let rt = Runtime::new()?;
-
-        let config =
-            rt.block_on(async {
-                let mut config_provider = aws_config::defaults(BehaviorVersion::v2024_03_28());
-                match creds {
-                    AwsCredentials::AccessKey {
-                        access_key_id,
-                        secret_access_key,
-                    } => {
-                        config_provider = config_provider.credentials_provider(
-                            Credentials::from_keys(access_key_id, secret_access_key, None),
-                        );
-                    }
-                    AwsCredentials::Profile { profile_name } => {
-                        config_provider = config_provider.credentials_provider(
-                            ProfileFileCredentialsProvider::builder()
-                                .profile_name(profile_name)
-                                .build(),
-                        );
-                    }
-                    AwsCredentials::Default => {
-                        // Just use the default.
-                    }
-                }
-                config_provider
-                    .region(RegionProviderChain::first_try(Region::new(region)))
-                    .load()
-                    .await
-            });
+        let mut config_provider = aws_config::defaults(BehaviorVersion::v2024_03_28());
+        match creds {
+            AwsCredentials::AccessKey {
+                access_key_id,
+                secret_access_key,
+            } => {
+                config_provider = config_provider.credentials_provider(Credentials::from_keys(
+                    access_key_id,
+                    secret_access_key,
+                    None,
+                ));
+            }
+            AwsCredentials::Profile { profile_name } => {
+                config_provider = config_provider.credentials_provider(
+                    ProfileFileCredentialsProvider::builder()
+                        .profile_name(profile_name)
+                        .build(),
+                );
+            }
+            AwsCredentials::Default => {
+                // Just use the default.
+            }
+        }
+        let config = config_provider
+            .region(RegionProviderChain::first_try(Region::new(region)))
+            .load()
+            .await;
 
         let client = s3::client::Client::new(&config);
-        Ok(Self { client, rt, bucket })
-    }
-
-    fn block_on<T, F: Future<Output = Result<T>>>(&self, fut: F) -> Result<T> {
-        self.rt.block_on(fut)
+        Ok(Self { client, bucket })
     }
 }
 
@@ -134,56 +125,51 @@ async fn get_body(get_res: GetObjectOutput) -> Result<Vec<u8>> {
     Ok(get_res.body.collect().await?.to_vec())
 }
 
+#[async_trait]
 impl Service for AwsService {
-    fn put(&mut self, name: &str, value: &[u8]) -> Result<()> {
-        self.block_on(async {
-            validate_object_name(name);
-            self.client
-                .put_object()
-                .bucket(self.bucket.clone())
-                .key(name)
-                .body(value.to_vec().into())
-                .send()
-                .await
-                .map_err(aws_err)?;
-            Ok(())
-        })
+    async fn put(&mut self, name: &str, value: &[u8]) -> Result<()> {
+        validate_object_name(name);
+        self.client
+            .put_object()
+            .bucket(self.bucket.clone())
+            .key(name)
+            .body(value.to_vec().into())
+            .send()
+            .await
+            .map_err(aws_err)?;
+        Ok(())
     }
 
-    fn get(&mut self, name: &str) -> Result<Option<Vec<u8>>> {
-        self.block_on(async {
-            validate_object_name(name);
-            let Some(get_res) = if_key_exists(
-                self.client
-                    .get_object()
-                    .bucket(self.bucket.clone())
-                    .key(name)
-                    .send()
-                    .await
-                    .map_err(aws_err),
-            )?
-            else {
-                return Ok(None);
-            };
-            Ok(Some(get_body(get_res).await?))
-        })
-    }
-
-    fn del(&mut self, name: &str) -> Result<()> {
-        self.block_on(async {
-            validate_object_name(name);
+    async fn get(&mut self, name: &str) -> Result<Option<Vec<u8>>> {
+        validate_object_name(name);
+        let Some(get_res) = if_key_exists(
             self.client
-                .delete_object()
+                .get_object()
                 .bucket(self.bucket.clone())
                 .key(name)
                 .send()
                 .await
-                .map_err(aws_err)?;
-            Ok(())
-        })
+                .map_err(aws_err),
+        )?
+        else {
+            return Ok(None);
+        };
+        Ok(Some(get_body(get_res).await?))
     }
 
-    fn list<'a>(&'a mut self, prefix: &str) -> Box<dyn Iterator<Item = Result<ObjectInfo>> + 'a> {
+    async fn del(&mut self, name: &str) -> Result<()> {
+        validate_object_name(name);
+        self.client
+            .delete_object()
+            .bucket(self.bucket.clone())
+            .key(name)
+            .send()
+            .await
+            .map_err(aws_err)?;
+        Ok(())
+    }
+
+    async fn list<'a>(&'a mut self, prefix: &'a str) -> Box<dyn AsyncObjectIterator + Send + 'a> {
         validate_object_name(prefix);
         Box::new(ObjectIterator {
             service: self,
@@ -193,98 +179,96 @@ impl Service for AwsService {
         })
     }
 
-    fn compare_and_swap(
+    async fn compare_and_swap(
         &mut self,
         name: &str,
         existing_value: Option<Vec<u8>>,
         new_value: Vec<u8>,
     ) -> Result<bool> {
-        self.block_on(async {
-            validate_object_name(name);
-            let get_res = if_key_exists(
-                self.client
-                    .get_object()
-                    .bucket(self.bucket.clone())
-                    .key(name)
-                    .send()
-                    .await
-                    .map_err(aws_err),
-            )?;
-
-            // Check the expectation and gather the e_tag for the existing value.
-            let e_tag;
-            if let Some(get_res) = get_res {
-                // If a value was not expected but one exists, that expectation has not been met.
-                let Some(existing_value) = existing_value else {
-                    return Ok(false);
-                };
-                e_tag = get_res.e_tag.clone();
-                let body = get_body(get_res).await?;
-                if body != existing_value {
-                    return Ok(false);
-                }
-            } else {
-                // If a value was expected but none exists, that expectation has not been met.
-                if existing_value.is_some() {
-                    return Ok(false);
-                }
-                e_tag = None;
-            };
-
-            // When testing, an object named "$pfx-racing-delete" is deleted between get_object and
-            // put_object.
-            #[cfg(test)]
-            if name.ends_with("-racing-delete") {
-                println!("deleting object {name}");
-                self.client
-                    .delete_object()
-                    .bucket(self.bucket.clone())
-                    .key(name)
-                    .send()
-                    .await
-                    .map_err(aws_err)?;
-            }
-
-            // When testing, if the object is named "$pfx-racing-put" then the value "CHANGED" is
-            // written to it between get_object and put_object.
-            #[cfg(test)]
-            if name.ends_with("-racing-put") {
-                println!("changing object {name}");
-                self.client
-                    .put_object()
-                    .bucket(self.bucket.clone())
-                    .key(name)
-                    .body(b"CHANGED".to_vec().into())
-                    .send()
-                    .await
-                    .map_err(aws_err)?;
-            }
-
-            // Try to put the object, using an appropriate conditional.
-            let mut put_builder = self.client.put_object();
-            if let Some(e_tag) = e_tag {
-                put_builder = put_builder.if_match(e_tag);
-            } else {
-                put_builder = put_builder.if_none_match("*");
-            }
-            match put_builder
+        validate_object_name(name);
+        let get_res = if_key_exists(
+            self.client
+                .get_object()
                 .bucket(self.bucket.clone())
                 .key(name)
-                .body(new_value.to_vec().into())
                 .send()
                 .await
-                .map_err(aws_err)
-            {
-                Ok(_) => Ok(true),
-                // If the key disappears, S3 returns 404.
-                Err(err) if err.code() == Some("NoSuchKey") => Ok(false),
-                // PreconditionFailed occurs if the file changed unexpectedly
-                Err(err) if err.code() == Some("PreconditionFailed") => Ok(false),
-                // Docs describe this as a "conflicting operation" with no further details.
-                Err(err) if err.code() == Some("ConditionalRequestConflict") => Ok(false),
-                Err(e) => Err(e.into()),
+                .map_err(aws_err),
+        )?;
+
+        // Check the expectation and gather the e_tag for the existing value.
+        let e_tag;
+        if let Some(get_res) = get_res {
+            // If a value was not expected but one exists, that expectation has not been met.
+            let Some(existing_value) = existing_value else {
+                return Ok(false);
+            };
+            e_tag = get_res.e_tag.clone();
+            let body = get_body(get_res).await?;
+            if body != existing_value {
+                return Ok(false);
             }
-        })
+        } else {
+            // If a value was expected but none exists, that expectation has not been met.
+            if existing_value.is_some() {
+                return Ok(false);
+            }
+            e_tag = None;
+        };
+
+        // When testing, an object named "$pfx-racing-delete" is deleted between get_object and
+        // put_object.
+        #[cfg(test)]
+        if name.ends_with("-racing-delete") {
+            println!("deleting object {name}");
+            self.client
+                .delete_object()
+                .bucket(self.bucket.clone())
+                .key(name)
+                .send()
+                .await
+                .map_err(aws_err)?;
+        }
+
+        // When testing, if the object is named "$pfx-racing-put" then the value "CHANGED" is
+        // written to it between get_object and put_object.
+        #[cfg(test)]
+        if name.ends_with("-racing-put") {
+            println!("changing object {name}");
+            self.client
+                .put_object()
+                .bucket(self.bucket.clone())
+                .key(name)
+                .body(b"CHANGED".to_vec().into())
+                .send()
+                .await
+                .map_err(aws_err)?;
+        }
+
+        // Try to put the object, using an appropriate conditional.
+        let mut put_builder = self.client.put_object();
+        if let Some(e_tag) = e_tag {
+            put_builder = put_builder.if_match(e_tag);
+        } else {
+            put_builder = put_builder.if_none_match("*");
+        }
+        match put_builder
+            .bucket(self.bucket.clone())
+            .key(name)
+            .body(new_value.to_vec().into())
+            .send()
+            .await
+            .map_err(aws_err)
+        {
+            Ok(_) => Ok(true),
+            // If the key disappears, S3 returns 404.
+            Err(err) if err.code() == Some("NoSuchKey") => Ok(false),
+            // PreconditionFailed occurs if the file changed unexpectedly
+            Err(err) if err.code() == Some("PreconditionFailed") => Ok(false),
+            // Docs describe this as a "conflicting operation" with no further details.
+            Err(err) if err.code() == Some("ConditionalRequestConflict") => Ok(false),
+            Err(e) => Err(e.into()),
+        }
     }
 }
 
@@ -299,22 +283,22 @@ struct ObjectIterator<'a> {
 }
 
 impl ObjectIterator<'_> {
-    fn fetch_batch(&mut self) -> Result<()> {
+    async fn fetch_batch(&mut self) -> Result<()> {
         let mut continuation_token = None;
         if let Some(ref resp) = self.last_response {
             continuation_token.clone_from(&resp.next_continuation_token);
         }
-        self.last_response = None;
-        self.last_response = Some(self.service.block_on(async {
-            // Use the default max_keys in production, but a smaller value in testing so
-            // we can test the pagination.
-            #[cfg(test)]
-            let max_keys = Some(8);
-            #[cfg(not(test))]
-            let max_keys = None;
 
-            Ok(self
-                .service
+        // Use the default max_keys in production, but a smaller value in testing so
+        // we can test the pagination.
+        #[cfg(test)]
+        let max_keys = Some(8);
+        #[cfg(not(test))]
+        let max_keys = None;
+
+        self.last_response = None;
+        self.last_response = Some(
+            self.service
                 .client
                 .list_objects_v2()
                 .bucket(self.service.bucket.clone())
@@ -323,19 +307,19 @@ impl ObjectIterator<'_> {
                 .set_continuation_token(continuation_token)
                 .send()
                 .await
-                .map_err(aws_err)?)
-        })?);
+                .map_err(aws_err)?,
+        );
         self.next_index = 0;
         Ok(())
     }
 }
 
-impl Iterator for ObjectIterator<'_> {
-    type Item = Result<ObjectInfo>;
-    fn next(&mut self) -> Option<Self::Item> {
+#[async_trait]
+impl AsyncObjectIterator for ObjectIterator<'_> {
+    async fn next(&mut self) -> Option<Result<ObjectInfo>> {
         // If the iterator is just starting, fetch the first response.
         if self.last_response.is_none() {
-            if let Err(e) = self.fetch_batch() {
+            if let Err(e) = self.fetch_batch().await {
                 return Some(Err(e));
             }
         }
@@ -356,10 +340,10 @@ impl Iterator for ObjectIterator<'_> {
                     }));
                 } else if result.next_continuation_token.is_some() {
                     // Fetch the next page and try again.
-                    if let Err(e) = self.fetch_batch() {
+                    if let Err(e) = self.fetch_batch().await {
                         return Some(Err(e));
                     }
-                    return self.next();
+                    return self.next().await;
                 }
             }
         }
@@ -386,7 +370,7 @@ mod tests {
     /// When the environment variables are not set, this returns false and the test does not run.
     /// Note that the Rust test runner will still show "ok" for the test, as there is no way to
     /// indicate anything else.
-    fn make_service() -> Option<AwsService> {
+    async fn make_service() -> Option<AwsService> {
         let fail_if_not_set = std::env::var("AWS_FAIL_IF_NOT_SET").is_ok();
         let Ok(region) = std::env::var("AWS_TEST_REGION") else {
             if fail_if_not_set {
@@ -425,9 +409,10 @@ mod tests {
                     secret_access_key,
                 },
             )
+            .await
             .unwrap(),
         )
     }
 
-    crate::server::cloud::test::service_tests!(make_service());
+    crate::server::cloud::test::service_tests!(make_service().await);
 }

--- a/src/server/cloud/iter.rs
+++ b/src/server/cloud/iter.rs
@@ -1,0 +1,27 @@
+use crate::{errors::Result, server::cloud::service::ObjectInfo};
+use async_trait::async_trait;
+
+#[async_trait]
+pub(crate) trait AsyncObjectIterator {
+    async fn next(&mut self) -> Option<Result<ObjectInfo>>;
+}
+
+#[cfg(test)]
+// This struct takes a synchronous iterator `I` and adapts it for async.
+pub(crate) struct SyncIteratorWrapper<I>
+where
+    I: Iterator<Item = Result<ObjectInfo>> + Send,
+{
+    pub inner: I,
+}
+
+#[cfg(test)]
+#[async_trait]
+impl<I> AsyncObjectIterator for SyncIteratorWrapper<I>
+where
+    I: Iterator<Item = Result<ObjectInfo>> + Send + Sync,
+{
+    async fn next(&mut self) -> Option<Result<ObjectInfo>> {
+        self.inner.next()
+    }
+}

--- a/src/server/cloud/mod.rs
+++ b/src/server/cloud/mod.rs
@@ -7,6 +7,7 @@
 * chain of versions, even if multiple replicas attempt to sync at the same time.
 */
 
+mod iter;
 mod server;
 mod service;
 

--- a/src/server/cloud/server.rs
+++ b/src/server/cloud/server.rs
@@ -5,11 +5,20 @@ use crate::server::{
     AddVersionResult, GetVersionResult, HistorySegment, Server, Snapshot, SnapshotUrgency,
     VersionId,
 };
+use async_trait::async_trait;
 use ring::rand;
 use std::collections::{HashMap, HashSet};
+#[cfg(test)]
+use std::future::Future;
+#[cfg(test)]
+use std::pin::Pin;
 #[cfg(not(test))]
 use std::time::{SystemTime, UNIX_EPOCH};
 use uuid::Uuid;
+
+#[cfg(test)]
+type InterceptFn<S> =
+    Box<dyn for<'a> FnOnce(&'a mut S) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>> + Send>;
 
 /// Implement the Server trait for a cloud service implemented by [`Service`].
 ///
@@ -68,7 +77,7 @@ pub(in crate::server) struct CloudServer<SVC: Service> {
     /// For testing, a function that is called in the middle of `add_version` to simulate
     /// a concurrent change in the service.
     #[cfg(test)]
-    add_version_intercept: Option<fn(service: &mut SVC)>,
+    add_version_intercept: Option<InterceptFn<SVC>>,
 }
 
 const LATEST: &str = "latest";
@@ -82,8 +91,11 @@ fn version_to_bytes(v: VersionId) -> Vec<u8> {
 }
 
 impl<SVC: Service> CloudServer<SVC> {
-    pub(in crate::server) fn new(mut service: SVC, encryption_secret: Vec<u8>) -> Result<Self> {
-        let salt = Self::get_salt(&mut service)?;
+    pub(in crate::server) async fn new(
+        mut service: SVC,
+        encryption_secret: Vec<u8>,
+    ) -> Result<Self> {
+        let salt = Self::get_salt(&mut service).await?;
         let cryptor = Cryptor::new(salt, &encryption_secret.into())?;
         Ok(Self {
             service,
@@ -95,13 +107,15 @@ impl<SVC: Service> CloudServer<SVC> {
     }
 
     /// Get the salt value stored in the service, creating a new random one if necessary.
-    fn get_salt(service: &mut SVC) -> Result<Vec<u8>> {
+    async fn get_salt(service: &mut SVC) -> Result<Vec<u8>> {
         const SALT_NAME: &str = "salt";
         loop {
-            if let Some(salt) = service.get(SALT_NAME)? {
+            if let Some(salt) = service.get(SALT_NAME).await? {
                 return Ok(salt);
             }
-            service.compare_and_swap(SALT_NAME, None, Cryptor::gen_salt()?)?;
+            service
+                .compare_and_swap(SALT_NAME, None, Cryptor::gen_salt()?)
+                .await?;
         }
     }
 
@@ -161,8 +175,8 @@ impl<SVC: Service> CloudServer<SVC> {
 
     /// Get the version from "latest", or None if the object does not exist. This always fetches a fresh
     /// value from storage.
-    fn get_latest(&mut self) -> Result<Option<VersionId>> {
-        let Some(latest) = self.service.get(LATEST)? else {
+    async fn get_latest(&mut self) -> Result<Option<VersionId>> {
+        let Some(latest) = self.service.get(LATEST).await? else {
             return Ok(None);
         };
         let latest = VersionId::try_parse_ascii(&latest)
@@ -172,20 +186,26 @@ impl<SVC: Service> CloudServer<SVC> {
 
     /// Get the possible child versions of the given parent version, based only on the object
     /// names.
-    fn get_child_versions(&mut self, parent_version_id: &VersionId) -> Result<Vec<VersionId>> {
-        self.service
-            .list(&format!("v-{}-", parent_version_id.as_simple()))
-            .filter_map(|res| match res {
+    async fn get_child_versions(
+        &mut self,
+        parent_version_id: &VersionId,
+    ) -> Result<Vec<VersionId>> {
+        let mut versions = Vec::new();
+        let prefix = &format!("v-{}-", parent_version_id.as_simple());
+        let mut iterator = self.service.list(prefix).await;
+        while let Some(res) = iterator.next().await {
+            match res {
                 Ok(ObjectInfo { name, .. }) => {
                     if let Some((_, c)) = Self::parse_version_name(&name) {
-                        Some(Ok(c))
-                    } else {
-                        None
+                        versions.push(c);
                     }
                 }
-                Err(e) => Some(Err(e)),
-            })
-            .collect::<Result<Vec<_>>>()
+                Err(e) => {
+                    return Err(e);
+                }
+            }
+        }
+        Ok(versions)
     }
 
     /// Determine the snapshot urgency. This is done probabalistically:
@@ -203,32 +223,33 @@ impl<SVC: Service> CloudServer<SVC> {
     }
 
     /// Maybe call `cleanup` depending on `cleanup_probability`.
-    fn maybe_cleanup(&mut self) -> Result<()> {
+    async fn maybe_cleanup(&mut self) -> Result<()> {
         if self.randint()? < self.cleanup_probability {
             self.cleanup_probability = DEFAULT_CLEANUP_PROBABILITY;
-            self.cleanup()
+            self.cleanup().await
         } else {
             Ok(())
         }
     }
 
     /// Perform cleanup, deleting unnecessary data.
-    fn cleanup(&mut self) -> Result<()> {
+    async fn cleanup(&mut self) -> Result<()> {
         // Construct a vector containing all (child, parent, creation) tuples
-        let mut versions = self
-            .service
-            .list("v-")
-            .filter_map(|res| match res {
-                Ok(ObjectInfo { name, creation }) => {
-                    if let Some((p, c)) = Self::parse_version_name(&name) {
-                        Some(Ok((c, p, creation)))
-                    } else {
-                        None
+        let mut versions = {
+            let mut versions = Vec::new();
+            let mut iterator = self.service.list("v-").await;
+            while let Some(res) = iterator.next().await {
+                match res {
+                    Ok(ObjectInfo { name, creation }) => {
+                        if let Some((p, c)) = Self::parse_version_name(&name) {
+                            versions.push((c, p, creation));
+                        }
                     }
+                    Err(e) => return Err(e),
                 }
-                Err(e) => Some(Err(e)),
-            })
-            .collect::<Result<Vec<_>>>()?;
+            }
+            versions
+        };
         versions.sort();
 
         // Function to find the parent of a given child version in `versions`, taking
@@ -242,7 +263,7 @@ impl<SVC: Service> CloudServer<SVC> {
         // at "latest".
         let mut rev_chain = HashMap::new();
         let mut iterations = versions.len() + 1; // For cycle detection.
-        let latest = self.get_latest()?;
+        let latest = self.get_latest().await?;
         if let Some(mut c) = latest {
             while let Some(p) = parent_of(c) {
                 rev_chain.insert(c, p);
@@ -284,19 +305,26 @@ impl<SVC: Service> CloudServer<SVC> {
         // so any pair with parent equal to latest is allowed to stay.
         for (c, p, _) in versions {
             if rev_chain.get(&c) != Some(&p) && Some(p) != latest {
-                self.service.del(&Self::version_name(&p, &c))?;
+                self.service.del(&Self::version_name(&p, &c)).await?;
             }
         }
 
         // Collect a set of all snapshots.
-        let snapshots = self
-            .service
-            .list("s-")
-            .filter_map(|res| match res {
-                Ok(ObjectInfo { name, .. }) => Self::parse_snapshot_name(&name).map(Ok),
-                Err(e) => Some(Err(e)),
-            })
-            .collect::<Result<HashSet<_>>>()?;
+        let snapshots = {
+            let mut snapshots = HashSet::new();
+            let mut iterator = self.service.list("s-").await;
+            while let Some(res) = iterator.next().await {
+                match res {
+                    Ok(ObjectInfo { name, .. }) => {
+                        if let Some(parsed_name) = Self::parse_snapshot_name(&name) {
+                            snapshots.insert(parsed_name);
+                        }
+                    }
+                    Err(e) => return Err(e),
+                }
+            }
+            snapshots
+        };
 
         // Find the latest snapshot by iterating back from "latest". Note that this iteration is
         // guaranteed not to be cyclical, as that was checked above.
@@ -322,7 +350,7 @@ impl<SVC: Service> CloudServer<SVC> {
         };
         for version in snapshots {
             if version != latest_snapshot {
-                self.service.del(&Self::snapshot_name(&version))?;
+                self.service.del(&Self::snapshot_name(&version)).await?;
             }
         }
 
@@ -331,7 +359,9 @@ impl<SVC: Service> CloudServer<SVC> {
         let mut version = latest_snapshot;
         while let Some(parent) = rev_chain.get(&version) {
             if old_versions.contains(&version) {
-                self.service.del(&Self::version_name(parent, &version))?;
+                self.service
+                    .del(&Self::version_name(parent, &version))
+                    .await?;
             }
             version = *parent;
         }
@@ -340,13 +370,14 @@ impl<SVC: Service> CloudServer<SVC> {
     }
 }
 
-impl<SVC: Service> Server for CloudServer<SVC> {
-    fn add_version(
+#[async_trait]
+impl<SVC: Service + Send> Server for CloudServer<SVC> {
+    async fn add_version(
         &mut self,
         parent_version_id: VersionId,
         history_segment: HistorySegment,
     ) -> Result<(AddVersionResult, SnapshotUrgency)> {
-        let latest = self.get_latest()?;
+        let latest = self.get_latest().await?;
         if let Some(l) = latest {
             if l != parent_version_id {
                 return Ok((
@@ -363,11 +394,11 @@ impl<SVC: Service> Server for CloudServer<SVC> {
             version_id,
             payload: history_segment,
         })?;
-        self.service.put(&new_name, sealed.as_ref())?;
+        self.service.put(&new_name, sealed.as_ref()).await?;
 
         #[cfg(test)]
-        if let Some(f) = self.add_version_intercept {
-            f(&mut self.service);
+        if let Some(f) = self.add_version_intercept.take() {
+            f(&mut self.service).await;
         }
 
         // Try to compare-and-swap this value into LATEST
@@ -375,11 +406,12 @@ impl<SVC: Service> Server for CloudServer<SVC> {
         let new_value = version_to_bytes(version_id);
         if !self
             .service
-            .compare_and_swap(LATEST, old_value, new_value)?
+            .compare_and_swap(LATEST, old_value, new_value)
+            .await?
         {
             // Delete the version data, since it was not latest.
-            self.service.del(&new_name)?;
-            let latest = self.get_latest()?;
+            self.service.del(&new_name).await?;
+            let latest = self.get_latest().await?;
             let latest = latest.unwrap_or(Uuid::nil());
             return Ok((
                 AddVersionResult::ExpectedParentVersion(latest),
@@ -388,23 +420,26 @@ impl<SVC: Service> Server for CloudServer<SVC> {
         }
 
         // Attempt a cleanup, but ignore errors.
-        let _ = self.maybe_cleanup();
+        let _ = self.maybe_cleanup().await;
 
         Ok((AddVersionResult::Ok(version_id), self.snapshot_urgency()?))
     }
 
-    fn get_child_version(&mut self, parent_version_id: VersionId) -> Result<GetVersionResult> {
+    async fn get_child_version(
+        &mut self,
+        parent_version_id: VersionId,
+    ) -> Result<GetVersionResult> {
         // The `get_child_versions` function may return several possible children, only one of
         // those will lead to `latest`, and importantly the others will not have their own
         // children. So we can detect the "true" child as the one that is equal to "latest" or has
         // children. Note that even if `get_child_versions` returns a single version, that version
         // may not be valid and the appropriate result may be NoSuchVersion.
-        let version_id = match &(self.get_child_versions(&parent_version_id)?)[..] {
+        let version_id = match &(self.get_child_versions(&parent_version_id).await?)[..] {
             [] => return Ok(GetVersionResult::NoSuchVersion),
             children => {
                 // There are some extra version objects, so a cleanup is warranted.
                 self.cleanup_probability = 255;
-                let latest = self.get_latest()?;
+                let latest = self.get_latest().await?;
                 let mut true_child = None;
                 for child in children {
                     if Some(*child) == latest {
@@ -414,7 +449,7 @@ impl<SVC: Service> Server for CloudServer<SVC> {
                 }
                 if true_child.is_none() {
                     for child in children {
-                        if !self.get_child_versions(child)?.is_empty() {
+                        if !self.get_child_versions(child).await?.is_empty() {
                             true_child = Some(*child)
                         }
                     }
@@ -428,7 +463,8 @@ impl<SVC: Service> Server for CloudServer<SVC> {
 
         let Some(sealed) = self
             .service
-            .get(&Self::version_name(&parent_version_id, &version_id))?
+            .get(&Self::version_name(&parent_version_id, &version_id))
+            .await?
         else {
             // This really shouldn't happen, since the chain was derived from object names, but
             // perhaps the object was deleted.
@@ -445,26 +481,26 @@ impl<SVC: Service> Server for CloudServer<SVC> {
         })
     }
 
-    fn add_snapshot(&mut self, version_id: VersionId, snapshot: Snapshot) -> Result<()> {
+    async fn add_snapshot(&mut self, version_id: VersionId, snapshot: Snapshot) -> Result<()> {
         let name = Self::snapshot_name(&version_id);
         let sealed = self.cryptor.seal(Unsealed {
             version_id,
             payload: snapshot,
         })?;
-        self.service.put(&name, sealed.as_ref())?;
+        self.service.put(&name, sealed.as_ref()).await?;
         Ok(())
     }
 
-    fn get_snapshot(&mut self) -> Result<Option<(VersionId, Snapshot)>> {
+    async fn get_snapshot(&mut self) -> Result<Option<(VersionId, Snapshot)>> {
         // Pick the first snapshot we find.
-        let Some(name) = self.service.list("s-").next() else {
+        let Some(name) = self.service.list("s-").await.next().await else {
             return Ok(None);
         };
         let ObjectInfo { name, .. } = name?;
         let Some(version_id) = Self::parse_snapshot_name(&name) else {
             return Ok(None);
         };
-        let Some(payload) = self.service.get(&name)? else {
+        let Some(payload) = self.service.get(&name).await? else {
             return Ok(None);
         };
         let unsealed = self.cryptor.unseal(Sealed {
@@ -478,7 +514,10 @@ impl<SVC: Service> Server for CloudServer<SVC> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::server::NIL_VERSION_ID;
+    use crate::server::{
+        cloud::iter::{AsyncObjectIterator, SyncIteratorWrapper},
+        NIL_VERSION_ID,
+    };
 
     /// A simple in-memory service for testing. All insertions via Service methods occur at time
     /// `INSERTION_TIME`. All versions older that 1000 are considered "old".
@@ -496,22 +535,23 @@ mod tests {
         }
     }
 
+    #[async_trait]
     impl Service for MockService {
-        fn put(&mut self, name: &str, value: &[u8]) -> Result<()> {
+        async fn put(&mut self, name: &str, value: &[u8]) -> Result<()> {
             self.0.insert(name.into(), (INSERTION_TIME, value.into()));
             Ok(())
         }
 
-        fn get(&mut self, name: &str) -> Result<Option<Vec<u8>>> {
+        async fn get(&mut self, name: &str) -> Result<Option<Vec<u8>>> {
             Ok(self.0.get(name).map(|(_, data)| data.clone()))
         }
 
-        fn del(&mut self, name: &str) -> Result<()> {
+        async fn del(&mut self, name: &str) -> Result<()> {
             self.0.remove(name);
             Ok(())
         }
 
-        fn compare_and_swap(
+        async fn compare_and_swap(
             &mut self,
             name: &str,
             existing_value: Option<Vec<u8>>,
@@ -524,21 +564,21 @@ mod tests {
             Ok(false)
         }
 
-        fn list<'a>(
+        async fn list<'a>(
             &'a mut self,
             prefix: &'a str,
-        ) -> Box<dyn Iterator<Item = Result<ObjectInfo>> + 'a> {
-            Box::new(
-                self.0
-                    .iter()
-                    .filter(move |(k, _)| k.starts_with(prefix))
-                    .map(|(k, (t, _))| {
-                        Ok(ObjectInfo {
-                            name: k.to_string(),
-                            creation: *t,
-                        })
-                    }),
-            )
+        ) -> Box<dyn AsyncObjectIterator + Send + 'a> {
+            let inner = self
+                .0
+                .iter()
+                .filter(move |(k, _)| k.starts_with(prefix))
+                .map(|(k, (t, _))| {
+                    Ok(ObjectInfo {
+                        name: k.to_string(),
+                        creation: *t,
+                    })
+                });
+            Box::new(SyncIteratorWrapper { inner })
         }
     }
 
@@ -644,8 +684,10 @@ mod tests {
 
     const SECRET: &[u8] = b"testing";
 
-    fn make_server() -> CloudServer<MockService> {
-        let mut server = CloudServer::new(MockService::new(), SECRET.into()).unwrap();
+    async fn make_server() -> CloudServer<MockService> {
+        let mut server = CloudServer::new(MockService::new(), SECRET.into())
+            .await
+            .unwrap();
         // Prevent cleanup during tests.
         server.cleanup_probability = 0;
         server
@@ -758,91 +800,105 @@ mod tests {
         );
     }
 
-    #[test]
-    fn get_salt_existing() {
+    #[tokio::test]
+    async fn get_salt_existing() {
         let mut service = MockService::new();
         assert_eq!(
-            CloudServer::<MockService>::get_salt(&mut service).unwrap(),
+            CloudServer::<MockService>::get_salt(&mut service)
+                .await
+                .unwrap(),
             b"abcdefghabcdefgh".to_vec()
         );
     }
 
-    #[test]
-    fn get_salt_create() {
+    #[tokio::test]
+    async fn get_salt_create() {
         let mut service = MockService::new();
-        service.del("salt").unwrap();
-        let got_salt = CloudServer::<MockService>::get_salt(&mut service).unwrap();
-        let salt_obj = service.get("salt").unwrap().unwrap();
+        service.del("salt").await.unwrap();
+        let got_salt = CloudServer::<MockService>::get_salt(&mut service)
+            .await
+            .unwrap();
+        let salt_obj = service.get("salt").await.unwrap().unwrap();
         assert_eq!(got_salt, salt_obj);
     }
 
-    #[test]
-    fn get_latest_empty() {
-        let mut server = make_server();
-        assert_eq!(server.get_latest().unwrap(), None);
+    #[tokio::test]
+    async fn get_latest_empty() {
+        let mut server = make_server().await;
+        assert_eq!(server.get_latest().await.unwrap(), None);
     }
 
-    #[test]
-    fn get_latest_exists() {
-        let mut server = make_server();
+    #[tokio::test]
+    async fn get_latest_exists() {
+        let mut server = make_server().await;
         let latest = Uuid::new_v4();
         server.mock_set_latest(latest);
-        assert_eq!(server.get_latest().unwrap(), Some(latest));
+        assert_eq!(server.get_latest().await.unwrap(), Some(latest));
     }
 
-    #[test]
-    fn get_latest_invalid() {
-        let mut server = make_server();
+    #[tokio::test]
+    async fn get_latest_invalid() {
+        let mut server = make_server().await;
         server
             .service
             .0
             .insert(LATEST.into(), (999, b"not-a-uuid".to_vec()));
-        assert!(server.get_latest().is_err());
+        assert!(server.get_latest().await.is_err());
     }
 
-    #[test]
-    fn get_child_versions_empty() {
-        let mut server = make_server();
-        assert_eq!(server.get_child_versions(&Uuid::new_v4()).unwrap().len(), 0);
+    #[tokio::test]
+    async fn get_child_versions_empty() {
+        let mut server = make_server().await;
+        assert_eq!(
+            server
+                .get_child_versions(&Uuid::new_v4())
+                .await
+                .unwrap()
+                .len(),
+            0
+        );
     }
 
-    #[test]
-    fn get_child_versions_single() {
-        let mut server = make_server();
+    #[tokio::test]
+    async fn get_child_versions_single() {
+        let mut server = make_server().await;
         let (v1, v2) = (Uuid::new_v4(), Uuid::new_v4());
         server.mock_add_version(v2, v1, 1000, b"first");
-        assert_eq!(server.get_child_versions(&v1).unwrap().len(), 0);
-        assert_eq!(server.get_child_versions(&v2).unwrap(), vec![v1]);
+        assert_eq!(server.get_child_versions(&v1).await.unwrap().len(), 0);
+        assert_eq!(server.get_child_versions(&v2).await.unwrap(), vec![v1]);
     }
 
-    #[test]
-    fn get_child_versions_multiple() {
-        let mut server = make_server();
+    #[tokio::test]
+    async fn get_child_versions_multiple() {
+        let mut server = make_server().await;
         let (v1, v2, v3) = (Uuid::new_v4(), Uuid::new_v4(), Uuid::new_v4());
         server.mock_add_version(v3, v1, 1000, b"first");
         server.mock_add_version(v3, v2, 1000, b"second");
-        assert_eq!(server.get_child_versions(&v1).unwrap().len(), 0);
-        assert_eq!(server.get_child_versions(&v2).unwrap().len(), 0);
-        let versions = server.get_child_versions(&v3).unwrap();
+        assert_eq!(server.get_child_versions(&v1).await.unwrap().len(), 0);
+        assert_eq!(server.get_child_versions(&v2).await.unwrap().len(), 0);
+        let versions = server.get_child_versions(&v3).await.unwrap();
         assert!(versions == vec![v1, v2] || versions == vec![v2, v1]);
     }
 
-    #[test]
-    fn add_version_empty() {
-        let mut server = make_server();
+    #[tokio::test]
+    async fn add_version_empty() {
+        let mut server = make_server().await;
         let parent = Uuid::new_v4();
-        let (res, _) = server.add_version(parent, b"history".to_vec()).unwrap();
+        let (res, _) = server
+            .add_version(parent, b"history".to_vec())
+            .await
+            .unwrap();
         assert!(matches!(res, AddVersionResult::Ok(_)));
     }
 
-    #[test]
-    fn add_version_good() {
-        let mut server = make_server();
+    #[tokio::test]
+    async fn add_version_good() {
+        let mut server = make_server().await;
         let (v1, v2) = (Uuid::new_v4(), Uuid::new_v4());
         server.mock_add_version(v1, v2, 1000, b"first");
         server.mock_set_latest(v2);
 
-        let (res, _) = server.add_version(v2, b"history".to_vec()).unwrap();
+        let (res, _) = server.add_version(v2, b"history".to_vec()).await.unwrap();
         let AddVersionResult::Ok(new_version) = res else {
             panic!("expected OK");
         };
@@ -855,36 +911,38 @@ mod tests {
         assert_eq!(server.unencrypted(), expected.unencrypted());
     }
 
-    #[test]
-    fn add_version_not_latest() {
+    #[tokio::test]
+    async fn add_version_not_latest() {
         // The `add_version` method does nothing if the version is not latest.
-        let mut server = make_server();
+        let mut server = make_server().await;
         let (v1, v2) = (Uuid::new_v4(), Uuid::new_v4());
         server.mock_add_version(v1, v2, 1000, b"first");
         server.mock_set_latest(v2);
 
         let expected = server.clone();
 
-        let (res, _) = server.add_version(v1, b"history".to_vec()).unwrap();
+        let (res, _) = server.add_version(v1, b"history".to_vec()).await.unwrap();
         assert_eq!(res, AddVersionResult::ExpectedParentVersion(v2));
         assert_eq!(server.unencrypted(), expected.unencrypted());
     }
 
-    #[test]
-    fn add_version_not_latest_race() {
+    #[tokio::test]
+    async fn add_version_not_latest_race() {
         // The `add_version` function effectively checks twice for a conflict: once by just
         // fetching "latest", returning early if the value is not as expected; and once in the
         // compare-and-swap. This test uses `add_version_intercept` to force the first check to
         // succeed and the second test to fail.
-        let mut server = make_server();
+        let mut server: CloudServer<MockService> = make_server().await;
         let (v1, v2) = (Uuid::new_v4(), Uuid::new_v4());
         const V3: Uuid = Uuid::max();
         server.mock_add_version(v1, v2, 1000, b"first");
         server.mock_add_version(v2, V3, 1000, b"second");
         server.mock_set_latest(v2);
-        server.add_version_intercept = Some(|service| {
-            service.put(LATEST, &version_to_bytes(V3)).unwrap();
-        });
+        server.add_version_intercept = Some(Box::new(|service| {
+            Box::pin(async move {
+                service.put(LATEST, &version_to_bytes(V3)).await.unwrap();
+            })
+        }));
 
         let mut expected = server.empty_clone();
         expected.mock_add_version(v1, v2, 1000, b"first");
@@ -892,14 +950,14 @@ mod tests {
         expected.mock_set_latest(V3); // updated by the intercept
 
         assert_ne!(server.unencrypted(), expected.unencrypted());
-        let (res, _) = server.add_version(v2, b"history".to_vec()).unwrap();
+        let (res, _) = server.add_version(v2, b"history".to_vec()).await.unwrap();
         assert_eq!(res, AddVersionResult::ExpectedParentVersion(V3));
         assert_eq!(server.unencrypted(), expected.unencrypted());
     }
 
-    #[test]
-    fn add_version_unknown() {
-        let mut server = make_server();
+    #[tokio::test]
+    async fn add_version_unknown() {
+        let mut server = make_server().await;
         let (v1, v2) = (Uuid::new_v4(), Uuid::new_v4());
         server.mock_add_version(v1, v2, 1000, b"first");
         server.mock_set_latest(v2);
@@ -908,32 +966,33 @@ mod tests {
 
         let (res, _) = server
             .add_version(Uuid::new_v4(), b"history".to_vec())
+            .await
             .unwrap();
         assert_eq!(res, AddVersionResult::ExpectedParentVersion(v2));
         assert_eq!(server.unencrypted(), expected.unencrypted());
     }
 
-    #[test]
-    fn get_child_version_empty() {
-        let mut server = make_server();
+    #[tokio::test]
+    async fn get_child_version_empty() {
+        let mut server = make_server().await;
         assert_eq!(
-            server.get_child_version(Uuid::new_v4()).unwrap(),
+            server.get_child_version(Uuid::new_v4()).await.unwrap(),
             GetVersionResult::NoSuchVersion
         );
     }
 
-    #[test]
-    fn get_child_version_single() {
-        let mut server = make_server();
+    #[tokio::test]
+    async fn get_child_version_single() {
+        let mut server = make_server().await;
         let (v1, v2) = (Uuid::new_v4(), Uuid::new_v4());
         server.mock_add_version(v2, v1, 1000, b"first");
         server.mock_set_latest(v1);
         assert_eq!(
-            server.get_child_version(v1).unwrap(),
+            server.get_child_version(v1).await.unwrap(),
             GetVersionResult::NoSuchVersion
         );
         assert_eq!(
-            server.get_child_version(v2).unwrap(),
+            server.get_child_version(v2).await.unwrap(),
             GetVersionResult::Version {
                 version_id: v1,
                 parent_version_id: v2,
@@ -942,17 +1001,17 @@ mod tests {
         );
     }
 
-    #[test]
-    fn get_child_version_single_invalid() {
+    #[tokio::test]
+    async fn get_child_version_single_invalid() {
         // This is a regression test for #387.
-        let mut server = make_server();
+        let mut server = make_server().await;
         let (v1, v2, v3) = (Uuid::new_v4(), Uuid::new_v4(), Uuid::new_v4());
         // Here v2 is latest, so v3 is not a valid child of v2.
         server.mock_add_version(v1, v2, 1000, b"second");
         server.mock_add_version(v2, v3, 1000, b"third");
         server.mock_set_latest(v2);
         assert_eq!(
-            server.get_child_version(v1).unwrap(),
+            server.get_child_version(v1).await.unwrap(),
             GetVersionResult::Version {
                 version_id: v2,
                 parent_version_id: v1,
@@ -960,14 +1019,14 @@ mod tests {
             }
         );
         assert_eq!(
-            server.get_child_version(v2).unwrap(),
+            server.get_child_version(v2).await.unwrap(),
             GetVersionResult::NoSuchVersion
         );
     }
 
-    #[test]
-    fn get_child_version_multiple() {
-        let mut server = make_server();
+    #[tokio::test]
+    async fn get_child_version_multiple() {
+        let mut server = make_server().await;
         let (v1, v2, v3) = (Uuid::new_v4(), Uuid::new_v4(), Uuid::new_v4());
         let (vx, vy, vz) = (Uuid::new_v4(), Uuid::new_v4(), Uuid::new_v4());
         server.mock_add_version(v1, v2, 1000, b"second");
@@ -977,7 +1036,7 @@ mod tests {
         server.mock_add_version(v2, vz, 1000, b"false start z");
         server.mock_set_latest(v3);
         assert_eq!(
-            server.get_child_version(v1).unwrap(),
+            server.get_child_version(v1).await.unwrap(),
             GetVersionResult::Version {
                 version_id: v2,
                 parent_version_id: v1,
@@ -985,7 +1044,7 @@ mod tests {
             }
         );
         assert_eq!(
-            server.get_child_version(v2).unwrap(),
+            server.get_child_version(v2).await.unwrap(),
             GetVersionResult::Version {
                 version_id: v3,
                 parent_version_id: v2,
@@ -993,22 +1052,22 @@ mod tests {
             }
         );
         assert_eq!(
-            server.get_child_version(v3).unwrap(),
+            server.get_child_version(v3).await.unwrap(),
             GetVersionResult::NoSuchVersion
         );
     }
 
-    #[test]
-    fn cleanup_empty() {
-        let mut server = make_server();
-        server.cleanup().unwrap();
+    #[tokio::test]
+    async fn cleanup_empty() {
+        let mut server = make_server().await;
+        server.cleanup().await.unwrap();
     }
 
-    #[test]
-    fn cleanup_linear() {
+    #[tokio::test]
+    async fn cleanup_linear() {
         // Test that cleanup does nothing for a linear version history with a snapshot at the
         // oldest version.
-        let mut server = make_server();
+        let mut server = make_server().await;
         let (v1, v2, v3) = (Uuid::new_v4(), Uuid::new_v4(), Uuid::new_v4());
         server.mock_add_version(NIL_VERSION_ID, v1, 1000, b"first");
         server.mock_add_version(v1, v2, 1000, b"second");
@@ -1018,14 +1077,14 @@ mod tests {
 
         let expected = server.clone();
 
-        server.cleanup().unwrap();
+        server.cleanup().await.unwrap();
         assert_eq!(server.unencrypted(), expected.unencrypted());
     }
 
-    #[test]
-    fn cleanup_cycle() {
+    #[tokio::test]
+    async fn cleanup_cycle() {
         // When a cycle is present, cleanup succeeds and makes no changes.
-        let mut server = make_server();
+        let mut server = make_server().await;
         let (v1, v2, v3) = (Uuid::new_v4(), Uuid::new_v4(), Uuid::new_v4());
         server.mock_add_version(v3, v1, 1000, b"first");
         server.mock_add_version(v1, v2, 1000, b"second");
@@ -1034,14 +1093,14 @@ mod tests {
 
         let expected = server.clone();
 
-        assert!(server.cleanup().is_err());
+        assert!(server.cleanup().await.is_err());
         assert_eq!(server.unencrypted(), expected.unencrypted());
     }
 
-    #[test]
-    fn cleanup_extra_branches() {
+    #[tokio::test]
+    async fn cleanup_extra_branches() {
         // Cleanup deletes extra branches in the versions.
-        let mut server = make_server();
+        let mut server = make_server().await;
         let (v1, v2, v3) = (Uuid::new_v4(), Uuid::new_v4(), Uuid::new_v4());
         let (vx, vy) = (Uuid::new_v4(), Uuid::new_v4());
         server.mock_add_version(v1, v2, 1000, b"second");
@@ -1056,13 +1115,13 @@ mod tests {
         expected.mock_set_latest(v3);
 
         assert_ne!(server.unencrypted(), expected.unencrypted());
-        server.cleanup().unwrap();
+        server.cleanup().await.unwrap();
         assert_eq!(server.unencrypted(), expected.unencrypted());
     }
 
-    #[test]
-    fn cleanup_extra_snapshots() {
-        let mut server = make_server();
+    #[tokio::test]
+    async fn cleanup_extra_snapshots() {
+        let mut server = make_server().await;
         let (v1, v2, v3) = (Uuid::new_v4(), Uuid::new_v4(), Uuid::new_v4());
         let vy = Uuid::new_v4();
         server.mock_add_version(v1, v2, 1000, b"second");
@@ -1080,14 +1139,14 @@ mod tests {
         expected.mock_set_latest(v3);
 
         assert_ne!(server.unencrypted(), expected.unencrypted());
-        server.cleanup().unwrap();
+        server.cleanup().await.unwrap();
         assert_eq!(server.unencrypted(), expected.unencrypted());
     }
 
-    #[test]
-    fn cleanup_old_versions_no_snapshot() {
+    #[tokio::test]
+    async fn cleanup_old_versions_no_snapshot() {
         // If there are old versions ,but no snapshot, nothing is cleaned up.
-        let mut server = make_server();
+        let mut server = make_server().await;
         let (v1, v2, v3) = (Uuid::new_v4(), Uuid::new_v4(), Uuid::new_v4());
         server.mock_add_version(v1, v2, 200, b"second");
         server.mock_add_version(v2, v3, 300, b"third");
@@ -1095,15 +1154,15 @@ mod tests {
 
         let expected = server.clone();
 
-        server.cleanup().unwrap();
+        server.cleanup().await.unwrap();
         assert_eq!(server.unencrypted(), expected.unencrypted());
     }
 
-    #[test]
-    fn cleanup_old_versions_with_snapshot() {
+    #[tokio::test]
+    async fn cleanup_old_versions_with_snapshot() {
         // If there are old versions that are also older than a snapshot, they are
         // cleaned up.
-        let mut server = make_server();
+        let mut server = make_server().await;
         let (v1, v2, v3) = (Uuid::new_v4(), Uuid::new_v4(), Uuid::new_v4());
         let (v4, v5, v6) = (Uuid::new_v4(), Uuid::new_v4(), Uuid::new_v4());
         server.mock_add_version(v1, v2, 200, b"second");
@@ -1122,14 +1181,14 @@ mod tests {
         expected.mock_set_latest(v6);
 
         assert_ne!(server.unencrypted(), expected.unencrypted());
-        server.cleanup().unwrap();
+        server.cleanup().await.unwrap();
         assert_eq!(server.unencrypted(), expected.unencrypted());
     }
 
-    #[test]
-    fn cleanup_old_versions_newer_than_snapshot() {
+    #[tokio::test]
+    async fn cleanup_old_versions_newer_than_snapshot() {
         // Old versions that are newer than the latest snapshot are not cleaned up.
-        let mut server = make_server();
+        let mut server = make_server().await;
         let (v1, v2, v3) = (Uuid::new_v4(), Uuid::new_v4(), Uuid::new_v4());
         let (v4, v5, v6) = (Uuid::new_v4(), Uuid::new_v4(), Uuid::new_v4());
         server.mock_add_version(v1, v2, 200, b"second");
@@ -1148,14 +1207,14 @@ mod tests {
         expected.mock_set_latest(v6);
 
         assert_ne!(server.unencrypted(), expected.unencrypted());
-        server.cleanup().unwrap();
+        server.cleanup().await.unwrap();
         assert_eq!(server.unencrypted(), expected.unencrypted());
     }
 
-    #[test]
-    fn cleanup_children_of_latest() {
+    #[tokio::test]
+    async fn cleanup_children_of_latest() {
         // New versions that are children of the latest version are not cleaned up.
-        let mut server = make_server();
+        let mut server = make_server().await;
         let (v1, v2, v3) = (Uuid::new_v4(), Uuid::new_v4(), Uuid::new_v4());
         let (vnew1, vnew2) = (Uuid::new_v4(), Uuid::new_v4());
         server.mock_add_version(v1, v2, 1000, b"second");
@@ -1167,34 +1226,37 @@ mod tests {
 
         let expected = server.clone();
 
-        server.cleanup().unwrap();
+        server.cleanup().await.unwrap();
         assert_eq!(server.unencrypted(), expected.unencrypted());
     }
 
-    #[test]
-    fn add_snapshot() {
-        let mut server = make_server();
+    #[tokio::test]
+    async fn add_snapshot() {
+        let mut server = make_server().await;
         let v = Uuid::new_v4();
 
         let mut expected = server.empty_clone();
         expected.mock_add_snapshot(v, INSERTION_TIME, b"SNAP");
 
         assert_ne!(server.unencrypted(), expected.unencrypted());
-        server.add_snapshot(v, b"SNAP".to_vec()).unwrap();
+        server.add_snapshot(v, b"SNAP".to_vec()).await.unwrap();
         assert_eq!(server.unencrypted(), expected.unencrypted());
     }
 
-    #[test]
-    fn get_snapshot_missing() {
-        let mut server = make_server();
-        assert_eq!(server.get_snapshot().unwrap(), None);
+    #[tokio::test]
+    async fn get_snapshot_missing() {
+        let mut server = make_server().await;
+        assert_eq!(server.get_snapshot().await.unwrap(), None);
     }
 
-    #[test]
-    fn get_snapshot_present() {
-        let mut server = make_server();
+    #[tokio::test]
+    async fn get_snapshot_present() {
+        let mut server = make_server().await;
         let v = Uuid::new_v4();
         server.mock_add_snapshot(v, 1000, b"SNAP");
-        assert_eq!(server.get_snapshot().unwrap(), Some((v, b"SNAP".to_vec())));
+        assert_eq!(
+            server.get_snapshot().await.unwrap(),
+            Some((v, b"SNAP".to_vec()))
+        );
     }
 }

--- a/src/server/cloud/test.rs
+++ b/src/server/cloud/test.rs
@@ -23,249 +23,281 @@ macro_rules! service_tests {
             move |n: &_| format!("{}-{}", prefix.as_simple(), n)
         }
 
-        #[test]
-        fn put_and_get() -> $crate::errors::Result<()> {
+        #[tokio::test]
+        async fn put_and_get() -> $crate::errors::Result<()> {
             let Some(service) = $service else {
                 return Ok(());
             };
-            $crate::server::cloud::test::put_and_get(service, make_pfx())
+            $crate::server::cloud::test::put_and_get(service, make_pfx()).await
         }
-        #[test]
-        fn get_missing() -> $crate::errors::Result<()> {
+        #[tokio::test]
+        async fn get_missing() -> $crate::errors::Result<()> {
             let Some(service) = $service else {
                 return Ok(());
             };
-            $crate::server::cloud::test::get_missing(service, make_pfx())
+            $crate::server::cloud::test::get_missing(service, make_pfx()).await
         }
-        #[test]
-        fn del() -> $crate::errors::Result<()> {
+        #[tokio::test]
+        async fn del() -> $crate::errors::Result<()> {
             let Some(service) = $service else {
                 return Ok(());
             };
-            $crate::server::cloud::test::del(service, make_pfx())
+            $crate::server::cloud::test::del(service, make_pfx()).await
         }
-        #[test]
-        fn del_missing() -> $crate::errors::Result<()> {
+        #[tokio::test]
+        async fn del_missing() -> $crate::errors::Result<()> {
             let Some(service) = $service else {
                 return Ok(());
             };
-            $crate::server::cloud::test::del_missing(service, make_pfx())
+            $crate::server::cloud::test::del_missing(service, make_pfx()).await
         }
-        #[test]
-        fn list() -> $crate::errors::Result<()> {
+        #[tokio::test]
+        async fn list() -> $crate::errors::Result<()> {
             let Some(service) = $service else {
                 return Ok(());
             };
-            $crate::server::cloud::test::list(service, make_pfx())
+            $crate::server::cloud::test::list(service, make_pfx()).await
         }
-        #[test]
-        fn compare_and_swap_create() -> $crate::errors::Result<()> {
+        #[tokio::test]
+        async fn compare_and_swap_create() -> $crate::errors::Result<()> {
             let Some(service) = $service else {
                 return Ok(());
             };
-            $crate::server::cloud::test::compare_and_swap_create(service, make_pfx())
+            $crate::server::cloud::test::compare_and_swap_create(service, make_pfx()).await
         }
-        #[test]
-        fn compare_and_swap_matches() -> $crate::errors::Result<()> {
+        #[tokio::test]
+        async fn compare_and_swap_matches() -> $crate::errors::Result<()> {
             let Some(service) = $service else {
                 return Ok(());
             };
-            $crate::server::cloud::test::compare_and_swap_matches(service, make_pfx())
+            $crate::server::cloud::test::compare_and_swap_matches(service, make_pfx()).await
         }
-        #[test]
-        fn compare_and_swap_expected_no_file() -> $crate::errors::Result<()> {
+        #[tokio::test]
+        async fn compare_and_swap_expected_no_file() -> $crate::errors::Result<()> {
             let Some(service) = $service else {
                 return Ok(());
             };
             $crate::server::cloud::test::compare_and_swap_expected_no_file(service, make_pfx())
+                .await
         }
-        #[test]
-        fn compare_and_swap_old_value() -> $crate::errors::Result<()> {
+        #[tokio::test]
+        async fn compare_and_swap_old_value() -> $crate::errors::Result<()> {
             let Some(service) = $service else {
                 return Ok(());
             };
-            $crate::server::cloud::test::compare_and_swap_old_value(service, make_pfx())
+            $crate::server::cloud::test::compare_and_swap_old_value(service, make_pfx()).await
         }
-        #[test]
-        fn compare_and_swap_changes() -> $crate::errors::Result<()> {
+        #[tokio::test]
+        async fn compare_and_swap_changes() -> $crate::errors::Result<()> {
             let Some(service) = $service else {
                 return Ok(());
             };
-            $crate::server::cloud::test::compare_and_swap_changes(service, make_pfx())
+            $crate::server::cloud::test::compare_and_swap_changes(service, make_pfx()).await
         }
-        #[test]
-        fn compare_and_swap_disappears() -> $crate::errors::Result<()> {
+        #[tokio::test]
+        async fn compare_and_swap_disappears() -> $crate::errors::Result<()> {
             let Some(service) = $service else {
                 return Ok(());
             };
-            $crate::server::cloud::test::compare_and_swap_disappears(service, make_pfx())
+            $crate::server::cloud::test::compare_and_swap_disappears(service, make_pfx()).await
         }
-        #[test]
-        fn compare_and_swap_appears() -> $crate::errors::Result<()> {
+        #[tokio::test]
+        async fn compare_and_swap_appears() -> $crate::errors::Result<()> {
             let Some(service) = $service else {
                 return Ok(());
             };
-            $crate::server::cloud::test::compare_and_swap_appears(service, make_pfx())
+            $crate::server::cloud::test::compare_and_swap_appears(service, make_pfx()).await
         }
     };
 }
 
 pub(crate) use service_tests;
 
-pub(super) fn put_and_get(mut svc: impl Service, pfx: impl Fn(&str) -> String) -> Result<()> {
-    svc.put(&pfx("testy"), b"foo")?;
-    let got = svc.get(&pfx("testy"))?;
+pub(super) async fn put_and_get(mut svc: impl Service, pfx: impl Fn(&str) -> String) -> Result<()> {
+    svc.put(&pfx("testy"), b"foo").await?;
+    let got = svc.get(&pfx("testy")).await?;
     assert_eq!(got, Some(b"foo".to_vec()));
 
     // Clean up.
-    svc.del(&pfx("testy"))?;
+    svc.del(&pfx("testy")).await?;
     Ok(())
 }
 
-pub(super) fn get_missing(mut svc: impl Service, pfx: impl Fn(&str) -> String) -> Result<()> {
-    let got = svc.get(&pfx("testy"))?;
+pub(super) async fn get_missing(mut svc: impl Service, pfx: impl Fn(&str) -> String) -> Result<()> {
+    let got = svc.get(&pfx("testy")).await?;
     assert_eq!(got, None);
     Ok(())
 }
 
-pub(super) fn del(mut svc: impl Service, pfx: impl Fn(&str) -> String) -> Result<()> {
-    svc.put(&pfx("testy"), b"data")?;
-    svc.del(&pfx("testy"))?;
-    let got = svc.get(&pfx("testy"))?;
+pub(super) async fn del(mut svc: impl Service, pfx: impl Fn(&str) -> String) -> Result<()> {
+    svc.put(&pfx("testy"), b"data").await?;
+    svc.del(&pfx("testy")).await?;
+    let got = svc.get(&pfx("testy")).await?;
     assert_eq!(got, None);
     Ok(())
 }
 
-pub(super) fn del_missing(mut svc: impl Service, pfx: impl Fn(&str) -> String) -> Result<()> {
+pub(super) async fn del_missing(mut svc: impl Service, pfx: impl Fn(&str) -> String) -> Result<()> {
     // Deleting an object that does not exist is not an error.
-    assert!(svc.del(&pfx("testy")).is_ok());
+    assert!(svc.del(&pfx("testy")).await.is_ok());
     Ok(())
 }
 
-pub(super) fn list(mut svc: impl Service, pfx: impl Fn(&str) -> String) -> Result<()> {
+pub(super) async fn list(mut svc: impl Service, pfx: impl Fn(&str) -> String) -> Result<()> {
     let mut names: Vec<_> = (0..20).map(|i| pfx(&format!("pp-{i:02}"))).collect();
     names.sort();
     // Create 20 objects that will be listed.
     for n in &names {
-        svc.put(n, b"data")?;
+        svc.put(n, b"data").await?;
     }
     // And another object that should not be included in the list.
-    svc.put(&pfx("xxx"), b"data")?;
+    svc.put(&pfx("xxx"), b"data").await?;
 
-    let got_objects: Vec<_> = svc.list(&pfx("pp-")).collect::<Result<_>>()?;
-    let mut got_names: Vec<_> = got_objects.into_iter().map(|oi| oi.name).collect();
+    let mut got_names: Vec<_> = {
+        let mut got_names = Vec::new();
+        let prefix = &pfx("pp-");
+        let mut iterator = svc.list(prefix).await;
+        while let Some(res) = iterator.next().await {
+            match res {
+                Ok(o) => got_names.push(o.name),
+                Err(e) => return Err(e),
+            }
+        }
+        got_names
+    };
     got_names.sort();
     assert_eq!(got_names, names);
 
     // Clean up.
     for n in got_names {
-        svc.del(&n)?;
+        svc.del(&n).await?;
     }
-    svc.del(&pfx("xxx"))?;
+    svc.del(&pfx("xxx")).await?;
     Ok(())
 }
 
-pub(super) fn compare_and_swap_create(
+pub(super) async fn compare_and_swap_create(
     mut svc: impl Service,
     pfx: impl Fn(&str) -> String,
 ) -> Result<()> {
-    assert!(svc.compare_and_swap(&pfx("testy"), None, b"bar".to_vec())?);
-    let got = svc.get(&pfx("testy"))?;
+    assert!(
+        svc.compare_and_swap(&pfx("testy"), None, b"bar".to_vec())
+            .await?
+    );
+    let got = svc.get(&pfx("testy")).await?;
     assert_eq!(got, Some(b"bar".to_vec()));
 
     // Clean up.
-    svc.del(&pfx("testy"))?;
+    svc.del(&pfx("testy")).await?;
     Ok(())
 }
 
-pub(super) fn compare_and_swap_matches(
+pub(super) async fn compare_and_swap_matches(
     mut svc: impl Service,
     pfx: impl Fn(&str) -> String,
 ) -> Result<()> {
     // Create the existing file, with two different values over time.
-    svc.put(&pfx("testy"), b"foo1")?;
-    svc.put(&pfx("testy"), b"foo2")?;
+    svc.put(&pfx("testy"), b"foo1").await?;
+    svc.put(&pfx("testy"), b"foo2").await?;
     // A compare_and_swap for the latest value succeeds.
-    assert!(svc.compare_and_swap(&pfx("testy"), Some(b"foo2".to_vec()), b"bar".to_vec())?);
-    let got = svc.get(&pfx("testy"))?;
+    assert!(
+        svc.compare_and_swap(&pfx("testy"), Some(b"foo2".to_vec()), b"bar".to_vec())
+            .await?
+    );
+    let got = svc.get(&pfx("testy")).await?;
     assert_eq!(got, Some(b"bar".to_vec()));
 
     // Clean up.
-    svc.del(&pfx("testy"))?;
+    svc.del(&pfx("testy")).await?;
     Ok(())
 }
 
-pub(super) fn compare_and_swap_expected_no_file(
+pub(super) async fn compare_and_swap_expected_no_file(
     mut svc: impl Service,
     pfx: impl Fn(&str) -> String,
 ) -> Result<()> {
-    svc.put(&pfx("testy"), b"foo1")?;
-    assert!(!svc.compare_and_swap(&pfx("testy"), None, b"bar".to_vec())?);
-    let got = svc.get(&pfx("testy"))?;
+    svc.put(&pfx("testy"), b"foo1").await?;
+    assert!(
+        !svc.compare_and_swap(&pfx("testy"), None, b"bar".to_vec())
+            .await?
+    );
+    let got = svc.get(&pfx("testy")).await?;
     assert_eq!(got, Some(b"foo1".to_vec()));
 
     // Clean up.
-    svc.del(&pfx("testy"))?;
+    svc.del(&pfx("testy")).await?;
     Ok(())
 }
 
-pub(super) fn compare_and_swap_old_value(
+pub(super) async fn compare_and_swap_old_value(
     mut svc: impl Service,
     pfx: impl Fn(&str) -> String,
 ) -> Result<()> {
     // Create the existing file, with two different values over time.
-    svc.put(&pfx("testy"), b"foo1")?;
-    svc.put(&pfx("testy"), b"foo2")?;
+    svc.put(&pfx("testy"), b"foo1").await?;
+    svc.put(&pfx("testy"), b"foo2").await?;
     // A compare_and_swap for the old value fails.
-    assert!(!svc.compare_and_swap(&pfx("testy"), Some(b"foo1".to_vec()), b"bar".to_vec())?);
-    let got = svc.get(&pfx("testy"))?;
+    assert!(
+        !svc.compare_and_swap(&pfx("testy"), Some(b"foo1".to_vec()), b"bar".to_vec())
+            .await?
+    );
+    let got = svc.get(&pfx("testy")).await?;
     assert_eq!(got, Some(b"foo2".to_vec()));
 
     // Clean up.
-    svc.del(&pfx("testy"))?;
+    svc.del(&pfx("testy")).await?;
     Ok(())
 }
 
-pub(super) fn compare_and_swap_changes(
+pub(super) async fn compare_and_swap_changes(
     mut svc: impl Service,
     pfx: impl Fn(&str) -> String,
 ) -> Result<()> {
     // Create the existing object, but since it is named "racing-put" its value will change
     // just before the `put_object` call. This tests the "compare" part of `compare_and_swap`.
-    svc.put(&pfx("racing-put"), b"foo1")?;
-    assert!(!svc.compare_and_swap(&pfx("racing-put"), Some(b"foo1".to_vec()), b"bar".to_vec())?);
-    let got = svc.get(&pfx("racing-put"))?;
+    svc.put(&pfx("racing-put"), b"foo1").await?;
+    assert!(
+        !svc.compare_and_swap(&pfx("racing-put"), Some(b"foo1".to_vec()), b"bar".to_vec())
+            .await?
+    );
+    let got = svc.get(&pfx("racing-put")).await?;
     assert_eq!(got, Some(b"CHANGED".to_vec()));
     Ok(())
 }
 
-pub(super) fn compare_and_swap_disappears(
+pub(super) async fn compare_and_swap_disappears(
     mut svc: impl Service,
     pfx: impl Fn(&str) -> String,
 ) -> Result<()> {
     // Create the existing object, but since it is named "racing-delete" it will disappear just
     // before the `put_object` call. This tests the case where the exists when
     // `compare_and_swap` calls `get_object` but is deleted when it calls `put_object`.
-    svc.put(&pfx("racing-delete"), b"foo1")?;
-    assert!(!svc.compare_and_swap(
-        &pfx("racing-delete"),
-        Some(b"foo1".to_vec()),
-        b"bar".to_vec()
-    )?);
-    let got = svc.get(&pfx("racing-delete"))?;
+    svc.put(&pfx("racing-delete"), b"foo1").await?;
+    assert!(
+        !svc.compare_and_swap(
+            &pfx("racing-delete"),
+            Some(b"foo1".to_vec()),
+            b"bar".to_vec()
+        )
+        .await?
+    );
+    let got = svc.get(&pfx("racing-delete")).await?;
     assert_eq!(got, None);
     Ok(())
 }
 
-pub(super) fn compare_and_swap_appears(
+pub(super) async fn compare_and_swap_appears(
     mut svc: impl Service,
     pfx: impl Fn(&str) -> String,
 ) -> Result<()> {
     // Create the existing object, but since it is named "racing-put" the object will appear just
     // before the `put_object` call. This tests the case where the object does not exist when
     // `compare_and_swap` calls `get_object`, but does exist when it calls `put_object`.
-    assert!(!svc.compare_and_swap(&pfx("racing-put"), None, b"bar".to_vec())?);
-    let got = svc.get(&pfx("racing-put"))?;
+    assert!(
+        !svc.compare_and_swap(&pfx("racing-put"), None, b"bar".to_vec())
+            .await?
+    );
+    let got = svc.get(&pfx("racing-put")).await?;
     assert_eq!(got, Some(b"CHANGED".to_vec()));
     Ok(())
 }

--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -95,7 +95,7 @@ pub enum ServerConfig {
 
 impl ServerConfig {
     /// Get a server based on this configuration
-    pub fn into_server(self) -> Result<Box<dyn Server>> {
+    pub async fn into_server(self) -> Result<Box<dyn Server>> {
         Ok(match self {
             #[cfg(feature = "server-local")]
             ServerConfig::Local { server_dir } => Box::new(LocalServer::new(server_dir)?),
@@ -110,20 +110,26 @@ impl ServerConfig {
                 bucket,
                 credential_path,
                 encryption_secret,
-            } => Box::new(CloudServer::new(
-                GcpService::new(bucket, credential_path)?,
-                encryption_secret,
-            )?),
+            } => Box::new(
+                CloudServer::new(
+                    GcpService::new(bucket, credential_path).await?,
+                    encryption_secret,
+                )
+                .await?,
+            ),
             #[cfg(feature = "server-aws")]
             ServerConfig::Aws {
                 region,
                 bucket,
                 credentials,
                 encryption_secret,
-            } => Box::new(CloudServer::new(
-                AwsService::new(region, bucket, credentials)?,
-                encryption_secret,
-            )?),
+            } => Box::new(
+                CloudServer::new(
+                    AwsService::new(region, bucket, credentials).await?,
+                    encryption_secret,
+                )
+                .await?,
+            ),
         })
     }
 }

--- a/src/server/sync/mod.rs
+++ b/src/server/sync/mod.rs
@@ -3,6 +3,7 @@ use crate::server::{
     AddVersionResult, GetVersionResult, HistorySegment, Server, Snapshot, SnapshotUrgency,
     VersionId,
 };
+use async_trait::async_trait;
 use std::time::Duration;
 use url::Url;
 use uuid::Uuid;
@@ -107,8 +108,9 @@ fn sealed_from_resp(resp: ureq::Response, version_id: Uuid, content_type: &str) 
     }
 }
 
+#[async_trait]
 impl Server for SyncServer {
-    fn add_version(
+    async fn add_version(
         &mut self,
         parent_version_id: VersionId,
         history_segment: HistorySegment,
@@ -146,7 +148,10 @@ impl Server for SyncServer {
         }
     }
 
-    fn get_child_version(&mut self, parent_version_id: VersionId) -> Result<GetVersionResult> {
+    async fn get_child_version(
+        &mut self,
+        parent_version_id: VersionId,
+    ) -> Result<GetVersionResult> {
         let url = self.construct_endpoint_url(
             format!("v1/client/get-child-version/{}", parent_version_id).as_str(),
         )?;
@@ -174,7 +179,7 @@ impl Server for SyncServer {
         }
     }
 
-    fn add_snapshot(&mut self, version_id: VersionId, snapshot: Snapshot) -> Result<()> {
+    async fn add_snapshot(&mut self, version_id: VersionId, snapshot: Snapshot) -> Result<()> {
         let url =
             self.construct_endpoint_url(format!("v1/client/add-snapshot/{}", version_id).as_str())?;
         let unsealed = Unsealed {
@@ -191,7 +196,7 @@ impl Server for SyncServer {
             .map(|_| ())?)
     }
 
-    fn get_snapshot(&mut self) -> Result<Option<(VersionId, Snapshot)>> {
+    async fn get_snapshot(&mut self) -> Result<Option<(VersionId, Snapshot)>> {
         let url = self.construct_endpoint_url("v1/client/snapshot")?;
         match self
             .agent

--- a/src/server/test.rs
+++ b/src/server/test.rs
@@ -3,6 +3,7 @@ use crate::server::{
     AddVersionResult, GetVersionResult, HistorySegment, Server, Snapshot, SnapshotUrgency,
     VersionId, NIL_VERSION_ID,
 };
+use async_trait::async_trait;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use uuid::Uuid;
@@ -65,10 +66,11 @@ impl TestServer {
     }
 }
 
+#[async_trait]
 impl Server for TestServer {
     /// Add a new version.  If the given version number is incorrect, this responds with the
     /// appropriate version and expects the caller to try again.
-    fn add_version(
+    async fn add_version(
         &mut self,
         parent_version_id: VersionId,
         history_segment: HistorySegment,
@@ -107,7 +109,10 @@ impl Server for TestServer {
     }
 
     /// Get a vector of all versions after `since_version`
-    fn get_child_version(&mut self, parent_version_id: VersionId) -> Result<GetVersionResult> {
+    async fn get_child_version(
+        &mut self,
+        parent_version_id: VersionId,
+    ) -> Result<GetVersionResult> {
         let inner = self.0.lock().unwrap();
 
         if let Some(version) = inner.versions.get(&parent_version_id) {
@@ -121,7 +126,7 @@ impl Server for TestServer {
         }
     }
 
-    fn add_snapshot(&mut self, version_id: VersionId, snapshot: Snapshot) -> Result<()> {
+    async fn add_snapshot(&mut self, version_id: VersionId, snapshot: Snapshot) -> Result<()> {
         let mut inner = self.0.lock().unwrap();
 
         // test implementation -- does not perform any validation
@@ -129,7 +134,7 @@ impl Server for TestServer {
         Ok(())
     }
 
-    fn get_snapshot(&mut self) -> Result<Option<(VersionId, Snapshot)>> {
+    async fn get_snapshot(&mut self) -> Result<Option<(VersionId, Snapshot)>> {
         let inner = self.0.lock().unwrap();
         Ok(inner.snapshot.clone())
     }

--- a/src/server/types.rs
+++ b/src/server/types.rs
@@ -1,4 +1,5 @@
 use crate::errors::Result;
+use async_trait::async_trait;
 use uuid::Uuid;
 
 /// Versions are referred to with UUIDs.
@@ -50,6 +51,7 @@ pub enum GetVersionResult {
 }
 
 /// A value implementing this trait can act as a server against which a replica can sync.
+#[async_trait]
 pub trait Server {
     /// Add a new version.
     ///
@@ -57,17 +59,18 @@ pub trait Server {
     /// `parent_version_id`, and that all versions form a single parent-child chain. Inductively,
     /// this means that if there are any versions on the server, then `parent_version_id` must be
     /// the only version that does not already have a child.
-    fn add_version(
+    async fn add_version(
         &mut self,
         parent_version_id: VersionId,
         history_segment: HistorySegment,
     ) -> Result<(AddVersionResult, SnapshotUrgency)>;
 
     /// Get the version with the given parent VersionId
-    fn get_child_version(&mut self, parent_version_id: VersionId) -> Result<GetVersionResult>;
+    async fn get_child_version(&mut self, parent_version_id: VersionId)
+        -> Result<GetVersionResult>;
 
     /// Add a snapshot on the server
-    fn add_snapshot(&mut self, version_id: VersionId, snapshot: Snapshot) -> Result<()>;
+    async fn add_snapshot(&mut self, version_id: VersionId, snapshot: Snapshot) -> Result<()>;
 
-    fn get_snapshot(&mut self) -> Result<Option<(VersionId, Snapshot)>>;
+    async fn get_snapshot(&mut self) -> Result<Option<(VersionId, Snapshot)>>;
 }

--- a/tests/cross-sync.rs
+++ b/tests/cross-sync.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "server-local")]
+
 use chrono::Utc;
 use pretty_assertions::assert_eq;
 use taskchampion::storage::inmemory::InMemoryStorage;
@@ -5,7 +7,6 @@ use taskchampion::{Operations, Replica, ServerConfig, Status, Uuid};
 use tempfile::TempDir;
 
 #[tokio::test]
-#[cfg(feature = "server-local")]
 async fn cross_sync() -> anyhow::Result<()> {
     // set up two replicas, and demonstrate replication between them
     let mut rep1 = Replica::new(InMemoryStorage::new());
@@ -15,7 +16,7 @@ async fn cross_sync() -> anyhow::Result<()> {
     let server_config = ServerConfig::Local {
         server_dir: tmp_dir.path().to_path_buf(),
     };
-    let mut server = server_config.into_server()?;
+    let mut server = server_config.into_server().await?;
 
     let (uuid1, uuid2) = (Uuid::new_v4(), Uuid::new_v4());
     let mut ops = Operations::new();

--- a/tests/syncing-proptest.rs
+++ b/tests/syncing-proptest.rs
@@ -29,71 +29,72 @@ fn actions() -> impl Strategy<Value = Vec<(Action, u8)>> {
 
 proptest! {
 #[test]
-/// Check that various sequences of operations on mulitple db's do not get the db's into an
-/// incompatible state.  The main concern here is that there might be a sequence of operations
-/// that results in a task being in different states in different replicas. Different tasks
-/// cannot interfere with one another, so this focuses on a single task.
-fn multi_replica_sync(action_sequence in actions()) {
-    let tmp_dir = TempDir::new().expect("TempDir failed");
-    let uuid = Uuid::parse_str("83a2f9ef-f455-4195-b92e-a54c161eebfc").unwrap();
-    let server_config = ServerConfig::Local {
-        server_dir: tmp_dir.path().to_path_buf(),
-    };
-    let mut server = server_config.into_server().unwrap();
-    let mut replicas = [
-        Replica::new(InMemoryStorage::new()),
-        Replica::new(InMemoryStorage::new()),
-        Replica::new(InMemoryStorage::new()),
-    ];
+    /// Check that various sequences of operations on mulitple db's do not get the db's into an
+    /// incompatible state.  The main concern here is that there might be a sequence of operations
+    /// that results in a task being in different states in different replicas. Different tasks
+    /// cannot interfere with one another, so this focuses on a single task.
+    fn multi_replica_sync(action_sequence in actions()) {
+        let tmp_dir = TempDir::new().expect("TempDir failed");
+        let uuid = Uuid::parse_str("83a2f9ef-f455-4195-b92e-a54c161eebfc").unwrap();
+        let server_config = ServerConfig::Local {
+            server_dir: tmp_dir.path().to_path_buf(),
+        };
 
-    tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .unwrap()
-        .block_on(async {
-            for (action, rep) in action_sequence {
-                println!("{:?} on rep {}", action, rep);
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(async {
+                let mut server = server_config.into_server().await.unwrap();
+                let mut replicas = [
+                    Replica::new(InMemoryStorage::new()),
+                    Replica::new(InMemoryStorage::new()),
+                    Replica::new(InMemoryStorage::new()),
+                ];
 
-                let rep = &mut replicas[rep as usize];
-                match action {
-                    Action::Create => {
-                        if rep.get_task_data(uuid).await.unwrap().is_none() {
-                            let mut ops = Operations::new();
-                            TaskData::create(uuid, &mut ops);
-                            rep.commit_operations(ops).await.unwrap();
+                for (action, rep) in action_sequence {
+                    println!("{:?} on rep {}", action, rep);
+
+                    let rep = &mut replicas[rep as usize];
+                    match action {
+                        Action::Create => {
+                            if rep.get_task_data(uuid).await.unwrap().is_none() {
+                                let mut ops = Operations::new();
+                                TaskData::create(uuid, &mut ops);
+                                rep.commit_operations(ops).await.unwrap();
+                            }
                         }
-                    }
-                    Action::Update(p, v) => {
-                        if let Some(mut t) = rep.get_task_data(uuid).await.unwrap() {
-                            let mut ops = Operations::new();
-                            t.update(p, Some(v), &mut ops);
-                            rep.commit_operations(ops).await.unwrap();
+                        Action::Update(p, v) => {
+                            if let Some(mut t) = rep.get_task_data(uuid).await.unwrap() {
+                                let mut ops = Operations::new();
+                                t.update(p, Some(v), &mut ops);
+                                rep.commit_operations(ops).await.unwrap();
+                            }
                         }
-                    }
-                    Action::Delete => {
-                        if let Some(mut t) = rep.get_task_data(uuid).await.unwrap() {
-                            let mut ops = Operations::new();
-                            t.delete(&mut ops);
-                            rep.commit_operations(ops).await.unwrap();
+                        Action::Delete => {
+                            if let Some(mut t) = rep.get_task_data(uuid).await.unwrap() {
+                                let mut ops = Operations::new();
+                                t.delete(&mut ops);
+                                rep.commit_operations(ops).await.unwrap();
+                            }
                         }
+                        Action::Sync => rep.sync(&mut server, false).await.unwrap(),
                     }
-                    Action::Sync => rep.sync(&mut server, false).await.unwrap(),
                 }
-            }
 
-            // Sync all of the replicas, twice, to flush out any un-synced changes.
-            for rep in &mut replicas {
-                rep.sync(&mut server, false).await.unwrap()
-            }
-            for rep in &mut replicas {
-                rep.sync(&mut server, false).await.unwrap()
-            }
+                // Sync all of the replicas, twice, to flush out any un-synced changes.
+                for rep in &mut replicas {
+                    rep.sync(&mut server, false).await.unwrap()
+                }
+                for rep in &mut replicas {
+                    rep.sync(&mut server, false).await.unwrap()
+                }
 
-            let t0 = replicas[0].get_task_data(uuid).await.unwrap();
-            let t1 = replicas[1].get_task_data(uuid).await.unwrap();
-            let t2 = replicas[2].get_task_data(uuid).await.unwrap();
-            assert_eq!(t0, t1);
-            assert_eq!(t1, t2);
-        });
-}
+                let t0 = replicas[0].get_task_data(uuid).await.unwrap();
+                let t1 = replicas[1].get_task_data(uuid).await.unwrap();
+                let t2 = replicas[2].get_task_data(uuid).await.unwrap();
+                assert_eq!(t0, t1);
+                assert_eq!(t1, t2);
+            });
+    }
 }

--- a/tests/update-and-delete-sync.rs
+++ b/tests/update-and-delete-sync.rs
@@ -27,7 +27,8 @@ async fn update_and_delete_sync(delete_first: bool) -> anyhow::Result<()> {
     let mut server = ServerConfig::Local {
         server_dir: tmp_dir.path().to_path_buf(),
     }
-    .into_server()?;
+    .into_server()
+    .await?;
 
     // add a task on rep1, and sync it to rep2
     let mut ops = Operations::new();


### PR DESCRIPTION
This PR refactors the `Server` trait and its implementations to be async.

**Key Changes**
* **Async Traits:** The core `Server` trait and the underlying `cloud::Service` trait are now defined with `async_trait`. All of their methods are now `async fn`.
* **Async Iterator Pattern:** To support asynchronous pagination, the standard `Iterator` pattern for listing objects has been replaced. A new `cloud::iter::AsyncObjectIterator` trait was introduced with an `async fn next()` method. The list methods on the `Service` and `Server` traits now return a `Box<dyn AsyncObjectIterator>`.
* **Removal of Blocking Calls:** The `AwsService` and `GcpService` implementations have been refactored to remove the embedded `tokio::runtime::Runtime` and all calls to `rt.block_on`. All cloud SDK operations now use `.await` directly for non-blocking I/O.
* **Implementation Updates:** `Server` implementations have been updated to be `async`, including `CloudServer` , `LocalServer` , `SyncServer` , and the `TestServer`.
* **ServerConfig:** The primary entry point, `ServerConfig::into_server`, is now an `async` function to support the async initialization of cloud clients.
* **Tests:** The test suite has been migrated to `#[tokio::test]`, with test functions and setup helpers (`make_server`) becoming `async`.