### PR TITLE
Test tls-native-roots and fix it for clouds

### DIFF
--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -15,11 +15,13 @@ jobs:
       matrix:
         features:
           - ""
-          - "server-sync"
-          - "server-gcp"
-          - "server-aws"
-          - "tls-native-roots"
-          - "bundled"
+          - "server-sync,tls-webpki-roots"
+          - "server-gcp,tls-webpki-roots"
+          - "server-aws,tls-webpki-roots"
+          - "server-sync,tls-native-roots"
+          - "server-gcp,tls-native-roots"
+          - "server-aws,tls-native-roots"
+          - "storage,bundled"
 
     name: "taskchampion ${{ matrix.features == '' && 'with no features' || format('with features {0}', matrix.features) }}"
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,6 +78,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -397,7 +403,7 @@ dependencies = [
  "aws-smithy-types",
  "bytes",
  "fastrand",
- "h2",
+ "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
  "http-body 1.0.1",
@@ -617,6 +623,16 @@ name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -884,6 +900,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f81ec6369c545a7d40e4589b5597581fa1c441fe1cce96dd1de43159910a36a2"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1106,6 +1137,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.1.0",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1233,7 +1283,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
  "httparse",
@@ -1256,6 +1306,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
+ "h2 0.4.12",
  "http 1.1.0",
  "http-body 1.0.1",
  "httparse",
@@ -1280,6 +1331,7 @@ dependencies = [
  "rustls-native-certs 0.6.3",
  "tokio",
  "tokio-rustls 0.24.1",
+ "webpki-roots 0.25.4",
 ]
 
 [[package]]
@@ -1293,11 +1345,28 @@ dependencies = [
  "hyper 1.5.1",
  "hyper-util",
  "rustls 0.23.19",
+ "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.1",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 0.26.7",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper 1.5.1",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
 ]
 
 [[package]]
@@ -1635,6 +1704,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework 2.11.1",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1675,10 +1761,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
+name = "openssl"
+version = "0.10.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.111"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "outref"
@@ -2041,29 +2165,35 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
+ "h2 0.4.12",
  "http 1.1.0",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.5.1",
  "hyper-rustls 0.27.3",
+ "hyper-tls",
  "hyper-util",
  "ipnet",
  "js-sys",
  "log",
  "mime",
  "mime_guess",
+ "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
  "rustls 0.23.19",
+ "rustls-native-certs 0.8.1",
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
+ "system-configuration",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls 0.26.1",
  "tokio-util",
  "tower-service",
@@ -2072,7 +2202,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 0.26.7",
  "windows-registry",
 ]
 
@@ -2223,7 +2353,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pemfile 1.0.4",
  "schannel",
- "security-framework",
+ "security-framework 2.11.1",
 ]
 
 [[package]]
@@ -2236,7 +2366,19 @@ dependencies = [
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 2.11.1",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 3.0.1",
 ]
 
 [[package]]
@@ -2357,7 +2499,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
  "bitflags",
- "core-foundation",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1415a607e92bec364ea2cf9264646dcce0f91e6d65281bd6f2819cca3bf39c8"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -2600,6 +2755,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "taskchampion"
 version = "3.0.0-pre"
 dependencies = [
@@ -2608,13 +2784,18 @@ dependencies = [
  "aws-config",
  "aws-credential-types",
  "aws-sdk-s3",
+ "aws-smithy-runtime",
  "byteorder",
  "chrono",
  "flate2",
  "google-cloud-storage",
+ "hyper-rustls 0.24.2",
+ "libc",
  "log",
  "pretty_assertions",
  "proptest",
+ "reqwest",
+ "reqwest-middleware",
  "ring",
  "rstest",
  "rusqlite",
@@ -2768,6 +2949,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-rustls"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2904,7 +3095,7 @@ dependencies = [
  "rustls-native-certs 0.7.3",
  "rustls-pki-types",
  "url",
- "webpki-roots",
+ "webpki-roots 0.26.7",
 ]
 
 [[package]]
@@ -3097,6 +3288,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "webpki-roots"
+version = "0.25.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "webpki-roots"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,16 +18,16 @@ members = [ "xtask" ]
 resolver = "2"
 
 [features]
-default = ["sync", "bundled", "storage"]
+default = ["sync", "bundled", "storage", "tls-webpki-roots"]
 
 # Support for all sync solutions
 sync = ["server-sync", "server-gcp", "server-aws", "server-local"]
 # Support for sync to a server
 server-sync = ["encryption", "dep:ureq", "dep:url"]
 # Support for sync to GCP
-server-gcp = ["cloud", "encryption", "dep:google-cloud-storage"]
+server-gcp = ["cloud", "encryption", "dep:google-cloud-storage", "dep:reqwest-middleware"]
 # Support for sync to AWS
-server-aws = ["cloud", "encryption", "dep:aws-sdk-s3", "dep:aws-config", "dep:aws-credential-types"]
+server-aws = ["cloud", "encryption", "dep:aws-sdk-s3", "dep:aws-config", "dep:aws-credential-types", "dep:aws-smithy-runtime"]
 # Suppport for sync to another SQLite database on the same machine
 server-local = ["storage-sqlite"]
 # Support for all task storage backends
@@ -40,8 +40,10 @@ encryption = ["dep:ring"]
 cloud = []
 # static bundling of dependencies
 bundled = ["rusqlite/bundled"]
-# use native CA roots, instead of bundled
-tls-native-roots = ["ureq/native-certs"]
+# use CA roots built into the library for all HTTPS access
+tls-webpki-roots = ["dep:hyper-rustls", "hyper-rustls/webpki-roots", "dep:reqwest", "reqwest/rustls-tls-webpki-roots"]
+# use native CA roots (from the filesystem), instead of bundled for all HTTPS access
+tls-native-roots = ["ureq/native-certs", "dep:hyper-rustls", "hyper-rustls/rustls-native-certs", "dep:reqwest", "reqwest/rustls-tls-native-roots"]
 
 [package.metadata.docs.rs]
 all-features = true
@@ -51,18 +53,22 @@ anyhow = "1.0"
 aws-sdk-s3 = { version = "1", optional = true }
 aws-config = { version = "1", features = ["behavior-version-latest"], optional = true }
 aws-credential-types = { version = "1", features = ["hardcoded-credentials"], optional = true }
+aws-smithy-runtime = { version = "*", optional = true } # AWS SDK selects a version
 byteorder = "1.5"
 chrono = { version = "^0.4.38", features = ["serde"] }
 flate2 = "1"
 google-cloud-storage = { version = "0.24.0", default-features = false, features = ["rustls-tls", "auth"], optional = true }
+hyper-rustls = { version = "*", optional = true } # AWS SDK selects a version
 log = "^0.4.17"
+reqwest = { version = "*", optional = true } # GCP SDK selects a version
+reqwest-middleware = { version = "*", optional = true } # GCP SDK selects a version
 ring = { version = "0.17", optional = true }
 rusqlite = { version = "0.37", optional = true}
 serde_json = "^1.0"
 serde = { version = "^1.0.147", features = ["derive"] }
 strum = "0.27"
 strum_macros = "0.27"
-tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync"] }
 thiserror = "2.0"
 ureq = { version = "^2.12.1", features = ["tls"], optional = true }
 uuid = { version = "^1.16.0", features = ["serde", "v4"] }
@@ -74,3 +80,4 @@ proptest = "^1.9.0"
 tempfile = "3"
 rstest = "0.26"
 pretty_assertions = "1"
+libc = "*"

--- a/src/crate-doc.md
+++ b/src/crate-doc.md
@@ -33,7 +33,7 @@ Several server implementations are included, and users can define their own impl
 # Example
 
 ```rust
-# #[cfg(feature = "storage-sqlite")]
+# #[cfg(all(feature = "storage-sqlite", feature = "server-local"))]
 # {
 # use taskchampion::{storage::AccessMode, ServerConfig, Replica, SqliteStorage};
 # use tempfile::TempDir;
@@ -69,12 +69,19 @@ Support for some optional functionality is controlled by feature flags.
  * `server-aws` - sync to Amazon Web Services
  * `server-gcp` - sync to Google Cloud Platform
  * `server-sync` - sync to the taskchampion-sync-server
+ * `server-local` - sync to a local file
  * `sync` - enables all of the sync features above
+ * `storage-sqlite` - store task data locally in SQLite
+ * `storage` - enables all of the storage features above
  * `bundled` - activates bundling system libraries like sqlite
- * `tls-native-roots` - use native (system) TLS roots, instead of those bundled with rustls, by
-   (indirectly) enabling the `rustls` feature `rustls-tls-native-roots`.
+ * `tls-webpki-roots` - use TLS roots bundled with the library, instead of reading them from
+   system configuration.
+ * `tls-native-roots` - use native (system) TLS roots, instead of those bundled with rustls.
+   If both `tls-webpki-roots` and `tls-native-roots` are given, `tls-native-roots` takes
+   precedence. At least one of the `tls-*-roots` features must be enabled to support any
+   of the HTTPS-based `server-*` features.
 
- By default, `sync` and `bundled` are enabled.
+By default, `sync`, `storage`, `bundled`, and `tls-webpki-roots` are enabled.
 
 # See Also
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -56,6 +56,8 @@ other_error!(google_cloud_storage::client::google_cloud_auth::error::Error);
 other_error!(aws_sdk_s3::Error);
 #[cfg(feature = "server-aws")]
 other_error!(aws_sdk_s3::primitives::ByteStreamError);
+#[cfg(feature = "server-gcp")]
+other_error!(reqwest::Error);
 
 /// Convert ureq errors more carefully
 #[cfg(feature = "server-sync")]

--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -12,6 +12,7 @@ use crate::server::cloud::CloudServer;
 use crate::server::local::LocalServer;
 #[cfg(feature = "server-sync")]
 use crate::server::sync::SyncServer;
+#[cfg(feature = "server-local")]
 use std::path::PathBuf;
 #[cfg(feature = "server-sync")]
 use uuid::Uuid;

--- a/src/server/sync/mod.rs
+++ b/src/server/sync/mod.rs
@@ -10,6 +10,11 @@ use uuid::Uuid;
 
 use super::encryption::{Cryptor, Sealed, Secret, Unsealed};
 
+#[cfg(not(any(feature = "tls-native-roots", feature = "tls-webpki-roots")))]
+compile_error!(
+    "Either feature \"tls-native-roots\" or \"tls-webpki-roots\" must be enabled for TLS support."
+);
+
 pub(crate) struct SyncServer {
     base_url: Url,
     client_id: Uuid,

--- a/tests/aws-tls.rs
+++ b/tests/aws-tls.rs
@@ -1,0 +1,29 @@
+#![cfg(all(feature = "server-aws", target_os = "linux"))]
+use taskchampion::{server::AwsCredentials, ServerConfig};
+
+mod tls_utils;
+
+#[tokio::test]
+/// Check that the AWS server implementation correctly uses, or does not use,
+/// tls-native-roots.
+async fn aws_tls() -> anyhow::Result<()> {
+    tls_utils::reset_seen_ssl_file();
+
+    // This will fail getting the salt due to bad credentials, but after making a TLS connection,
+    // which is what this test requires.
+    let _ = ServerConfig::Aws {
+        region: "us-east-2".into(),
+        bucket: "gotheneburgbitfactory".into(),
+        credentials: AwsCredentials::AccessKey {
+            access_key_id: "not".into(),
+            secret_access_key: "valid".into(),
+        },
+        encryption_secret: b"abc".into(),
+    }
+    .into_server()
+    .await;
+
+    tls_utils::assert_expected_seen_ssl_file();
+
+    Ok(())
+}

--- a/tests/gcp-tls.rs
+++ b/tests/gcp-tls.rs
@@ -1,0 +1,55 @@
+#![cfg(all(feature = "server-gcp", target_os = "linux"))]
+use std::{
+    fs::{metadata, set_permissions, File},
+    io::Write,
+    os::unix::fs::PermissionsExt,
+};
+
+use taskchampion::ServerConfig;
+use tempfile::TempDir;
+
+mod tls_utils;
+
+#[tokio::test]
+/// Check that the GCP server implementation correctly uses, or does not use,
+/// tls-native-roots.
+async fn gcp_tls() -> anyhow::Result<()> {
+    // In order to attempt a connection, GCP requires a file containing what appears to be valid
+    // credentials.
+    let tmp_dir = TempDir::new()?;
+    let creds_path = tmp_dir.path().join("creds.json");
+    File::create_new(&creds_path)
+        .expect("Could not open temp creds file")
+        .write_all(
+            br#"{
+  "client_id": "765432109876-abcdefghijklmnopqrstuvwxyz.apps.googleusercontent.com",
+  "client_secret": "aBcDeFgHiJkLmNoPqRsTuVwXyZ",
+  "refresh_token": "1/abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz",
+  "type": "authorized_user"
+}"#,
+        )
+        .expect("Could not write temp creds file");
+
+    // File::create_new creates files with permissions 0o000, which the GCP client
+    // will not be able to read.
+    let metadata = metadata(&creds_path)?;
+    let mut permissions = metadata.permissions();
+    permissions.set_mode(0o777);
+    set_permissions(&creds_path, permissions)?;
+
+    tls_utils::reset_seen_ssl_file();
+
+    // This will fail getting the salt due to bad credentials, but after making a TLS connection,
+    // which is what this test requires.
+    let _ = ServerConfig::Gcp {
+        bucket: "no-bucket".into(),
+        credential_path: Some(creds_path.to_str().unwrap().into()),
+        encryption_secret: b"abc".into(),
+    }
+    .into_server()
+    .await;
+
+    tls_utils::assert_expected_seen_ssl_file();
+
+    Ok(())
+}

--- a/tests/sync-server-tls.rs
+++ b/tests/sync-server-tls.rs
@@ -1,0 +1,26 @@
+#![cfg(all(feature = "server-sync", target_os = "linux"))]
+use taskchampion::ServerConfig;
+use uuid::Uuid;
+
+mod tls_utils;
+
+#[tokio::test]
+/// Check that the sync server implementation correctly uses, or does not use,
+/// tls-native-roots.
+async fn sync_server_tls() -> anyhow::Result<()> {
+    tls_utils::reset_seen_ssl_file();
+
+    let mut server = ServerConfig::Remote {
+        url: "https://gothenburgbitfactory.org/".to_string(),
+        client_id: Uuid::new_v4(),
+        encryption_secret: b"abc".into(),
+    }
+    .into_server()
+    .await?;
+    // This will return a 404, which is not a `Result::Err`.
+    server.get_child_version(Uuid::new_v4()).await?;
+
+    tls_utils::assert_expected_seen_ssl_file();
+
+    Ok(())
+}

--- a/tests/tls_utils.rs
+++ b/tests/tls_utils.rs
@@ -1,0 +1,63 @@
+#![cfg(target_os = "linux")]
+//! Utilities for testing TLS behaviors.
+//!
+//! This package intercepts calls to libc's `open64` method, and checks for paths containing
+//! `/ssl/`. This is useful to determine whether some deeply nested library is using native TLS
+//! certificates (which are typically at pathnames containing `/ssl`) or built-in certificate lists
+//! (which are embedded in the binary and not read from disk).
+//!
+//! This is likely to only work on GNU libc on Linux, but that's sufficient to verify that TC's
+//! use of libraries is correctly communicating a desire to use, or not use, native certificates.
+use libc::{c_char, c_int, dlsym, RTLD_NEXT};
+use std::ffi::CStr;
+
+static mut INTERCEPTING: bool = false;
+static mut SEEN_SSL: bool = false;
+
+/// Intercept the libc `open64` call, and set a flag when a path containing `/ssl/` is seen.
+///
+/// # SAFETY
+///
+/// This works on Linux, enough to perform some tests.
+#[no_mangle]
+pub unsafe extern "C" fn open64(path: *const c_char, flags: c_int) -> c_int {
+    if unsafe { INTERCEPTING } {
+        let path_rust = CStr::from_ptr(path)
+            .to_str()
+            .expect("path is not valid utf-8");
+        if path_rust.contains("/ssl/") {
+            unsafe { SEEN_SSL = true };
+        }
+        println!("open64({path_rust:?}, ..)");
+    }
+    type Open64Fn = unsafe extern "C" fn(*const c_char, c_int) -> c_int;
+    let original_open64: Open64Fn = {
+        let ptr = dlsym(RTLD_NEXT, c"open64".as_ptr());
+        assert!(!ptr.is_null());
+        std::mem::transmute(ptr)
+    };
+    original_open64(path, flags)
+}
+
+/// Return true if a file containing `/ssl/` has been opened since the
+/// last call to `reset_seen_ssl_file`.
+pub fn have_seen_ssl_file() -> bool {
+    unsafe { SEEN_SSL }
+}
+
+/// Reset the flag returned by `have_seen_ssl_file` to false.
+pub fn reset_seen_ssl_file() {
+    unsafe {
+        SEEN_SSL = false;
+        INTERCEPTING = true;
+    }
+}
+
+/// Assert that an SSL file was seen if the `tls-native-roots` feature
+/// is enabled, and otherwise assert that no such file was seen.
+pub fn assert_expected_seen_ssl_file() {
+    #[cfg(feature = "tls-native-roots")]
+    assert!(have_seen_ssl_file(), "Expected something to open a filename containing /ssl/ to load native certs, since `tls-native-roots` is enabled.");
+    #[cfg(not(feature = "tls-native-roots"))]
+    assert!(!have_seen_ssl_file(), "Did not expect anything to open a filename containing /ssl/ to load native certs, since `tls-native-roots` is not enabled.");
+}


### PR DESCRIPTION
This adds tests to ensure TC is correctly implementing tls-native-roots and tls-webpki-roots for all server backends, then fixes it for AWS and GCP.

To save on binary size, it introduces a new feature, `tls-webpki-roots`, which when disabled (via `--no-default-features`) will omit the webpki dependency and thus save the binary size of bundling all those certs. This constitutes a breaking change for users building with `--no-default-features`.

Fixes #608.