### PR TITLE
Fix warnings with --no-default-features

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -82,6 +82,7 @@ pub(crate) type Result<T> = std::result::Result<T, Error>;
 
 #[cfg(test)]
 mod test {
+    #[cfg(feature = "server-sync")]
     use super::*;
 
     #[cfg(feature = "server-sync")]

--- a/src/server/config.rs
+++ b/src/server/config.rs
@@ -97,6 +97,8 @@ pub enum ServerConfig {
 impl ServerConfig {
     /// Get a server based on this configuration
     pub async fn into_server(self) -> Result<Box<dyn Server>> {
+        // This expression is unreachable if no server features are enabled.
+        #[allow(unreachable_code)]
         Ok(match self {
             #[cfg(feature = "server-local")]
             ServerConfig::Local { server_dir } => Box::new(LocalServer::new(server_dir)?),


### PR DESCRIPTION
The warning in config.rs occurs when there are no server features enabled, in which case any attempt to construct `ServerConfig` will fail.

The errors.rs warning is just an unused import since the test that uses it is conditional.

These warnings were annoying me while working on WASM support!