### PR TITLE
Factor out the Send storage wrapper

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -29,7 +29,7 @@ jobs:
 
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: "1.82.0" # MSRV
+          toolchain: "1.85.0" # MSRV
           override: true
           components: clippy
 

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -57,7 +57,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - "1.82.0" # MSRV
+          - "1.85.0" # MSRV
           - "stable"
         os:
           - ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["cli", "todo", "tasks", "taskwarrior", "task-tracking"]
 readme = "src/crate-doc.md"
 license = "MIT"
 edition = "2021"
-rust-version = "1.82.0"
+rust-version = "1.85.0"
 
 [workspace]
 members = [ "xtask" ]
@@ -68,7 +68,7 @@ serde_json = "^1.0"
 serde = { version = "^1.0.147", features = ["derive"] }
 strum = "0.27"
 strum_macros = "0.27"
-tokio = { version = "1", features = ["macros", "sync"] }
+tokio = { version = "1", features = ["macros", "sync", "rt"] }
 thiserror = "2.0"
 ureq = { version = "^2.12.1", features = ["tls"], optional = true }
 uuid = { version = "^1.16.0", features = ["serde", "v4"] }
@@ -84,4 +84,4 @@ tempfile = "3"
 rstest = "0.26"
 pretty_assertions = "1"
 libc = "*"
-tokio = { version = "*", features = ["rt"] }
+tokio = { version = "*", features = ["time", "rt"] }

--- a/src/crate-doc.md
+++ b/src/crate-doc.md
@@ -47,7 +47,7 @@ let storage = SqliteStorage::new(
   taskdb_dir,
   AccessMode::ReadWrite,
   true,
-)?;
+).await?;
 let mut replica = Replica::new(storage);
 
 // Set up a local, on-disk server.
@@ -90,4 +90,4 @@ for more information about the design and usage of the tool.
 
 # Minimum Supported Rust Version (MSRV)
 
-This crate supports Rust version 1.82.0 and higher.
+This crate supports Rust version 1.85.0 and higher.

--- a/src/replica.rs
+++ b/src/replica.rs
@@ -43,7 +43,7 @@ use uuid::Uuid;
 #   tmp_dir.path().to_path_buf(),
 #   AccessMode::ReadWrite,
 #   true
-# )?);
+# ).await?);
 // Create a new task, recording the required operations.
 let mut ops = Operations::new();
 let uuid = Uuid::new_v4();

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -27,6 +27,9 @@ pub use config::AccessMode;
 
 pub mod inmemory;
 
+#[cfg(feature = "storage-sqlite")]
+mod send_wrapper;
+
 #[doc(hidden)]
 /// For compatibility with 0.6 and earlier, [`Operation`] is re-exported here.
 pub use crate::Operation as ReplicaOp;

--- a/src/storage/send_wrapper/actor.rs
+++ b/src/storage/send_wrapper/actor.rs
@@ -1,0 +1,152 @@
+use super::{WrappedStorage, WrappedStorageTxn};
+use crate::errors::Result;
+use crate::operation::Operation;
+use crate::storage::{TaskMap, VersionId};
+use tokio::sync::{mpsc, oneshot};
+use uuid::Uuid;
+
+/// An enum for messages sent to the sync thread actor.
+pub(super) enum ActorMessage {
+    // Transaction control
+    BeginTxn(oneshot::Sender<Result<mpsc::UnboundedSender<TxnMessage>>>),
+}
+
+pub(super) enum TxnMessage {
+    Commit(oneshot::Sender<Result<()>>),
+    Rollback,
+
+    // Transactional operations
+    GetTask(Uuid, oneshot::Sender<Result<Option<TaskMap>>>),
+    GetPendingTasks(oneshot::Sender<Result<Vec<(Uuid, TaskMap)>>>),
+    CreateTask(Uuid, oneshot::Sender<Result<bool>>),
+    SetTask(Uuid, TaskMap, oneshot::Sender<Result<()>>),
+    DeleteTask(Uuid, oneshot::Sender<Result<bool>>),
+    AllTasks(oneshot::Sender<Result<Vec<(Uuid, TaskMap)>>>),
+    AllTaskUuids(oneshot::Sender<Result<Vec<Uuid>>>),
+    BaseVersion(oneshot::Sender<Result<VersionId>>),
+    SetBaseVersion(VersionId, oneshot::Sender<Result<()>>),
+    GetTaskOperations(Uuid, oneshot::Sender<Result<Vec<Operation>>>),
+    UnsyncedOperations(oneshot::Sender<Result<Vec<Operation>>>),
+    NumUnsyncedOperations(oneshot::Sender<Result<usize>>),
+    AddOperation(Operation, oneshot::Sender<Result<()>>),
+    RemoveOperation(Operation, oneshot::Sender<Result<()>>),
+    SyncComplete(oneshot::Sender<Result<()>>),
+    GetWorkingSet(oneshot::Sender<Result<Vec<Option<Uuid>>>>),
+    AddToWorkingSet(Uuid, oneshot::Sender<Result<usize>>),
+    SetWorkingSetItem(usize, Option<Uuid>, oneshot::Sender<Result<()>>),
+    ClearWorkingSet(oneshot::Sender<Result<()>>),
+    IsEmpty(oneshot::Sender<Result<bool>>),
+}
+
+/// State owned by the dedicated thread. It handles the various channels and
+/// delegates to the inner storage.
+pub(super) struct ActorImpl<S: WrappedStorage> {
+    storage: S,
+    receiver: mpsc::UnboundedReceiver<ActorMessage>,
+}
+
+impl<S: WrappedStorage> ActorImpl<S> {
+    pub(super) fn new(storage: S, receiver: mpsc::UnboundedReceiver<ActorMessage>) -> Self {
+        Self { storage, receiver }
+    }
+
+    pub(super) async fn run(&mut self) {
+        // The outer loop waits for a BeginTxn message. If the channel is disconnected, the thread
+        // will exit gracefully. Note that this loop blocks until the transaction is complete,
+        // effectively ensuring serialized access (and simplifying management of ownership).
+        while let Some(ActorMessage::BeginTxn(reply_sender)) = self.receiver.recv().await {
+            let (txn_sender, mut txn_receiver) = mpsc::unbounded_channel::<TxnMessage>();
+            match self.storage.txn().await {
+                Ok(mut txn) => {
+                    // Send the new transaction channel sender back
+                    if reply_sender.send(Ok(txn_sender)).is_err() {
+                        continue; // Don't handle the txn if the client is gone.
+                    }
+                    Self::handle_transaction(&mut txn_receiver, &mut txn).await;
+                }
+                Err(e) => {
+                    // Send the database error back to the caller
+                    let _ = reply_sender.send(Err(e));
+                }
+            }
+        }
+    }
+
+    /// The inner loop for handling messages within an active transaction.
+    async fn handle_transaction(
+        receiver: &mut mpsc::UnboundedReceiver<TxnMessage>,
+        txn: &mut Box<dyn WrappedStorageTxn + '_>,
+    ) {
+        while let Some(msg) = receiver.recv().await {
+            match msg {
+                TxnMessage::Commit(resp) => {
+                    let _ = resp.send(txn.commit().await);
+                    return; // Transaction over, return to the outer loop.
+                }
+                TxnMessage::Rollback => {
+                    return; // Transaction over, return to the outer loop.
+                }
+                TxnMessage::GetTask(uuid, resp) => {
+                    let _ = resp.send(txn.get_task(uuid).await);
+                }
+                TxnMessage::GetPendingTasks(resp) => {
+                    let _ = resp.send(txn.get_pending_tasks().await);
+                }
+                TxnMessage::CreateTask(uuid, resp) => {
+                    let _ = resp.send(txn.create_task(uuid).await);
+                }
+                TxnMessage::SetTask(uuid, t, resp) => {
+                    let _ = resp.send(txn.set_task(uuid, t).await);
+                }
+                TxnMessage::DeleteTask(uuid, resp) => {
+                    let _ = resp.send(txn.delete_task(uuid).await);
+                }
+                TxnMessage::AllTasks(resp) => {
+                    let _ = resp.send(txn.all_tasks().await);
+                }
+                TxnMessage::AllTaskUuids(resp) => {
+                    let _ = resp.send(txn.all_task_uuids().await);
+                }
+                TxnMessage::BaseVersion(resp) => {
+                    let _ = resp.send(txn.base_version().await);
+                }
+                TxnMessage::SetBaseVersion(v, resp) => {
+                    let _ = resp.send(txn.set_base_version(v).await);
+                }
+                TxnMessage::GetTaskOperations(u, resp) => {
+                    let _ = resp.send(txn.get_task_operations(u).await);
+                }
+                TxnMessage::UnsyncedOperations(resp) => {
+                    let _ = resp.send(txn.unsynced_operations().await);
+                }
+                TxnMessage::NumUnsyncedOperations(resp) => {
+                    let _ = resp.send(txn.num_unsynced_operations().await);
+                }
+                TxnMessage::AddOperation(o, resp) => {
+                    let _ = resp.send(txn.add_operation(o).await);
+                }
+                TxnMessage::RemoveOperation(o, resp) => {
+                    let _ = resp.send(txn.remove_operation(o).await);
+                }
+                TxnMessage::SyncComplete(resp) => {
+                    let _ = resp.send(txn.sync_complete().await);
+                }
+                TxnMessage::GetWorkingSet(resp) => {
+                    let _ = resp.send(txn.get_working_set().await);
+                }
+                TxnMessage::AddToWorkingSet(u, resp) => {
+                    let _ = resp.send(txn.add_to_working_set(u).await);
+                }
+                TxnMessage::SetWorkingSetItem(i, u, resp) => {
+                    let _ = resp.send(txn.set_working_set_item(i, u).await);
+                }
+                TxnMessage::ClearWorkingSet(resp) => {
+                    let _ = resp.send(txn.clear_working_set().await);
+                }
+                TxnMessage::IsEmpty(resp) => {
+                    let _ = resp.send(txn.is_empty().await);
+                }
+            };
+        }
+    }
+}

--- a/src/storage/send_wrapper/mod.rs
+++ b/src/storage/send_wrapper/mod.rs
@@ -1,0 +1,16 @@
+//! This module implements a wrapper around a non-Send version of the Storage and StorageTxn
+//! traits, exposing implementations of those traits.
+//!
+//! The wrapper uses an actor model: the wrapper uses channels to communicate with a single
+//! instance of the wrapped type, running in a dedicated thread.
+
+mod actor;
+
+mod traits;
+pub(super) use traits::*;
+
+mod wrapper;
+pub(super) use wrapper::Wrapper;
+
+#[cfg(test)]
+mod test;

--- a/src/storage/send_wrapper/test.rs
+++ b/src/storage/send_wrapper/test.rs
@@ -1,0 +1,145 @@
+use super::Wrapper;
+use crate::errors::{Error, Result};
+use crate::operation::Operation;
+use crate::storage::inmemory::InMemoryStorage;
+use crate::storage::send_wrapper::{WrappedStorage, WrappedStorageTxn};
+use crate::storage::{Storage, StorageTxn, TaskMap, VersionId};
+use async_trait::async_trait;
+use pretty_assertions::assert_eq;
+use uuid::Uuid;
+
+// Implement WrappedStorage(Txn) for InMemoryStorage and a boxed StorageTxn
+
+#[async_trait(?Send)]
+impl WrappedStorageTxn for Box<dyn StorageTxn + Send + '_> {
+    async fn get_task(&mut self, uuid: Uuid) -> Result<Option<TaskMap>> {
+        self.as_mut().get_task(uuid).await
+    }
+
+    async fn get_pending_tasks(&mut self) -> Result<Vec<(Uuid, TaskMap)>> {
+        self.as_mut().get_pending_tasks().await
+    }
+
+    async fn create_task(&mut self, uuid: Uuid) -> Result<bool> {
+        self.as_mut().create_task(uuid).await
+    }
+
+    async fn set_task(&mut self, uuid: Uuid, task: TaskMap) -> Result<()> {
+        self.as_mut().set_task(uuid, task).await
+    }
+
+    async fn delete_task(&mut self, uuid: Uuid) -> Result<bool> {
+        self.as_mut().delete_task(uuid).await
+    }
+
+    async fn all_tasks(&mut self) -> Result<Vec<(Uuid, TaskMap)>> {
+        self.as_mut().all_tasks().await
+    }
+
+    async fn all_task_uuids(&mut self) -> Result<Vec<Uuid>> {
+        self.as_mut().all_task_uuids().await
+    }
+
+    async fn base_version(&mut self) -> Result<VersionId> {
+        self.as_mut().base_version().await
+    }
+
+    async fn set_base_version(&mut self, version: VersionId) -> Result<()> {
+        self.as_mut().set_base_version(version).await
+    }
+
+    async fn get_task_operations(&mut self, uuid: Uuid) -> Result<Vec<Operation>> {
+        self.as_mut().get_task_operations(uuid).await
+    }
+
+    async fn unsynced_operations(&mut self) -> Result<Vec<Operation>> {
+        self.as_mut().unsynced_operations().await
+    }
+
+    async fn num_unsynced_operations(&mut self) -> Result<usize> {
+        self.as_mut().num_unsynced_operations().await
+    }
+
+    async fn add_operation(&mut self, op: Operation) -> Result<()> {
+        self.as_mut().add_operation(op).await
+    }
+
+    async fn remove_operation(&mut self, op: Operation) -> Result<()> {
+        self.as_mut().remove_operation(op).await
+    }
+
+    async fn sync_complete(&mut self) -> Result<()> {
+        self.as_mut().sync_complete().await
+    }
+
+    async fn get_working_set(&mut self) -> Result<Vec<Option<Uuid>>> {
+        self.as_mut().get_working_set().await
+    }
+
+    async fn add_to_working_set(&mut self, uuid: Uuid) -> Result<usize> {
+        self.as_mut().add_to_working_set(uuid).await
+    }
+
+    async fn set_working_set_item(&mut self, index: usize, uuid: Option<Uuid>) -> Result<()> {
+        self.as_mut().set_working_set_item(index, uuid).await
+    }
+
+    async fn clear_working_set(&mut self) -> Result<()> {
+        self.as_mut().clear_working_set().await
+    }
+
+    #[allow(clippy::wrong_self_convention)] // mut is required here for storage access
+    async fn is_empty(&mut self) -> Result<bool> {
+        self.as_mut().is_empty().await
+    }
+
+    async fn commit(&mut self) -> Result<()> {
+        self.as_mut().commit().await
+    }
+}
+
+#[async_trait(?Send)]
+impl WrappedStorage for InMemoryStorage {
+    async fn txn<'a>(&'a mut self) -> Result<Box<dyn WrappedStorageTxn + 'a>> {
+        Ok(Box::new(<InMemoryStorage as Storage>::txn(self).await?))
+    }
+}
+
+async fn storage() -> Result<Wrapper> {
+    Wrapper::new(async || Ok(InMemoryStorage::new())).await
+}
+
+crate::storage::test::storage_tests!(storage().await.unwrap());
+
+#[tokio::test]
+async fn test_implicit_rollback() -> Result<()> {
+    let mut storage = storage().await?;
+    let uuid = Uuid::new_v4();
+
+    // Begin a transaction, create a task, but do not commit.
+    // The transaction will go out of scope, triggering Drop.
+    {
+        let mut txn = storage.txn().await?;
+        assert!(txn.create_task(uuid).await?);
+        // txn is dropped here, which should trigger a rollback message.
+    }
+
+    // Begin a new transaction and verify the task does not exist.
+    let mut txn = storage.txn().await?;
+    let task = txn.get_task(uuid).await?;
+    assert_eq!(task, None, "Task should not exist after implicit rollback");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_init_failure() -> Result<()> {
+    // The constructor runs in the thread, and its failure must be transmitted back via channels to
+    // appear here.
+    assert!(
+        Wrapper::new::<InMemoryStorage, _, _>(async || Err(Error::Database("uhoh!".into())))
+            .await
+            .is_err()
+    );
+    Ok(())
+}

--- a/src/storage/send_wrapper/traits.rs
+++ b/src/storage/send_wrapper/traits.rs
@@ -1,0 +1,45 @@
+use crate::errors::Result;
+use crate::operation::Operation;
+use crate::storage::{TaskMap, VersionId};
+use async_trait::async_trait;
+use uuid::Uuid;
+
+/// This trait is identical to [`crate::storage::StorageTxn`] except that it is not Send.
+#[async_trait(?Send)]
+pub(in crate::storage) trait WrappedStorageTxn {
+    async fn get_task(&mut self, uuid: Uuid) -> Result<Option<TaskMap>>;
+    async fn get_pending_tasks(&mut self) -> Result<Vec<(Uuid, TaskMap)>>;
+    async fn create_task(&mut self, uuid: Uuid) -> Result<bool>;
+    async fn set_task(&mut self, uuid: Uuid, task: TaskMap) -> Result<()>;
+    async fn delete_task(&mut self, uuid: Uuid) -> Result<bool>;
+    async fn all_tasks(&mut self) -> Result<Vec<(Uuid, TaskMap)>>;
+    async fn all_task_uuids(&mut self) -> Result<Vec<Uuid>>;
+    async fn base_version(&mut self) -> Result<VersionId>;
+    async fn set_base_version(&mut self, version: VersionId) -> Result<()>;
+    async fn get_task_operations(&mut self, uuid: Uuid) -> Result<Vec<Operation>>;
+    async fn unsynced_operations(&mut self) -> Result<Vec<Operation>>;
+    async fn num_unsynced_operations(&mut self) -> Result<usize>;
+    async fn add_operation(&mut self, op: Operation) -> Result<()>;
+    async fn remove_operation(&mut self, op: Operation) -> Result<()>;
+    async fn sync_complete(&mut self) -> Result<()>;
+    async fn get_working_set(&mut self) -> Result<Vec<Option<Uuid>>>;
+    async fn add_to_working_set(&mut self, uuid: Uuid) -> Result<usize>;
+    async fn set_working_set_item(&mut self, index: usize, uuid: Option<Uuid>) -> Result<()>;
+    async fn clear_working_set(&mut self) -> Result<()>;
+    #[allow(clippy::wrong_self_convention)] // mut is required here for storage access
+    async fn is_empty(&mut self) -> Result<bool> {
+        let mut empty = true;
+        empty = empty && self.all_tasks().await?.is_empty();
+        empty = empty && self.get_working_set().await? == vec![None];
+        empty = empty && self.base_version().await? == Uuid::nil();
+        empty = empty && self.unsynced_operations().await?.is_empty();
+        Ok(empty)
+    }
+    async fn commit(&mut self) -> Result<()>;
+}
+
+/// This trait is similar to [`crate::storage::Storage`] except that it is not Send.
+#[async_trait(?Send)]
+pub(in crate::storage) trait WrappedStorage {
+    async fn txn<'a>(&'a mut self) -> Result<Box<dyn WrappedStorageTxn + 'a>>;
+}

--- a/src/storage/send_wrapper/wrapper.rs
+++ b/src/storage/send_wrapper/wrapper.rs
@@ -1,0 +1,229 @@
+use super::actor::{ActorImpl, ActorMessage, TxnMessage};
+use super::WrappedStorage;
+use crate::errors::Result;
+use crate::operation::Operation;
+use crate::storage::{Storage, StorageTxn, TaskMap, VersionId};
+use async_trait::async_trait;
+use std::future::Future;
+use tokio::sync::{mpsc, oneshot};
+use uuid::Uuid;
+
+/// Wrapper wraps a `!Send` storage implementation (specifically, implementing [`WrappedStorage`]
+/// to make it Send ([`Storage`]).
+///
+/// Async runtimes like Tokio can move a future between threads to support efficient execution.
+/// This requires the future to also implement `Send`. For most purposes, this is not an issue, but
+/// a few types are `!Send` and any async function handling such types are also `!Send`.
+///
+/// On WASM, the wrapped storage runs in an async task, but not in a thread.
+#[derive(Clone)]
+pub(in crate::storage) struct Wrapper {
+    sender: mpsc::UnboundedSender<ActorMessage>,
+}
+
+impl Wrapper {
+    /// Create a new wrapper.
+    ///
+    /// The constructor is called in a dedicated single-threaded runtime, and all operations on the
+    /// resulting WrappedStorage implementation will also occur in that thread. As such, neither
+    /// the constructor nor any of the [`WrappedStorage`] or [`super::traits::WrappedStorageTxn`]
+    /// methods are required to implement `Send`.
+    pub(in crate::storage) async fn new<S, FN, FUT>(constructor: FN) -> Result<Self>
+    where
+        S: WrappedStorage,
+        FUT: Future<Output = Result<S>>,
+        FN: FnOnce() -> FUT + Send + 'static,
+    {
+        let (sender, receiver) = mpsc::unbounded_channel();
+        // Use a oneshot channel to block until the thread has initialized.
+        let (init_sender, init_receiver): (oneshot::Sender<Result<_>>, _) = oneshot::channel();
+
+        let in_thread = async move |init_sender: oneshot::Sender<Result<_>>| {
+            match constructor().await {
+                Ok(storage) => {
+                    // Send Ok back to the caller of `new` and then start the actor loop.
+                    let _ = init_sender.send(Ok(()));
+                    let mut actor = ActorImpl::new(storage, receiver);
+                    actor.run().await;
+                }
+                Err(e) => {
+                    // Send the initialization error back.
+                    let _ = init_sender.send(Err(e));
+                }
+            }
+        };
+
+        // On WASM, we do not have threads, so spawn the constructor in the current thread.
+        #[cfg(target_arch = "wasm32")]
+        {
+            wasm_bindgen_futures::spawn_local(in_thread(init_sender));
+        }
+
+        // Otherwise, spawn a new thread, and within that a local Tokio RT that can handle !Send
+        // futures.
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            use std::thread;
+            use tokio::runtime;
+            thread::spawn(move || {
+                let rt = match runtime::Builder::new_current_thread().build() {
+                    Ok(rt) => rt,
+                    Err(e) => {
+                        let _ = init_sender.send(Err(e.into()));
+                        return;
+                    }
+                };
+
+                rt.block_on(in_thread(init_sender));
+            });
+        }
+
+        // Wait until the thread sends its initialization result.
+        init_receiver.await??;
+        Ok(Self { sender })
+    }
+}
+
+#[async_trait]
+impl Storage for Wrapper {
+    // Sends the BeginTxn message to the underlying ActorImpl. Now that the txn has
+    // begun, this async txn obj can be passed around and operated upon, as it
+    // communicates with the underlying sync txn.
+    async fn txn<'a>(&'a mut self) -> Result<Box<dyn StorageTxn + Send + 'a>> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.sender.send(ActorMessage::BeginTxn(reply_tx))?;
+        let txn_sender = reply_rx.await??;
+        Ok(Box::new(WrapperTxn::new(txn_sender)))
+    }
+}
+
+/// An async proxy for a transaction running on the sync actor thread.
+struct WrapperTxn {
+    sender: mpsc::UnboundedSender<TxnMessage>,
+    committed: bool,
+}
+
+impl WrapperTxn {
+    fn new(sender: mpsc::UnboundedSender<TxnMessage>) -> Self {
+        Self {
+            sender,
+            committed: false,
+        }
+    }
+
+    async fn call<R, F>(&self, f: F) -> Result<R>
+    where
+        F: FnOnce(oneshot::Sender<Result<R>>) -> TxnMessage,
+        R: Send + 'static,
+    {
+        let (tx, rx) = oneshot::channel();
+        self.sender.send(f(tx))?;
+        rx.await?
+    }
+}
+
+impl Drop for WrapperTxn {
+    fn drop(&mut self) {
+        if !self.committed {
+            // If the transaction proxy is dropped without being committed,
+            // we send a Rollback message. There's nothing we can do if this
+            // fails, so ignore the result and do not use a channel to wait
+            // for a response.
+            let _ = self.sender.send(TxnMessage::Rollback);
+        }
+    }
+}
+
+#[async_trait]
+impl StorageTxn for WrapperTxn {
+    async fn commit(&mut self) -> Result<()> {
+        let res = self.call(TxnMessage::Commit).await;
+        if res.is_ok() {
+            self.committed = true;
+        }
+        res
+    }
+
+    async fn get_task(&mut self, uuid: Uuid) -> Result<Option<TaskMap>> {
+        self.call(|tx| TxnMessage::GetTask(uuid, tx)).await
+    }
+
+    async fn create_task(&mut self, uuid: Uuid) -> Result<bool> {
+        self.call(|tx| TxnMessage::CreateTask(uuid, tx)).await
+    }
+
+    async fn set_task(&mut self, uuid: Uuid, task: TaskMap) -> Result<()> {
+        self.call(|tx| TxnMessage::SetTask(uuid, task, tx)).await
+    }
+
+    async fn delete_task(&mut self, uuid: Uuid) -> Result<bool> {
+        self.call(|tx| TxnMessage::DeleteTask(uuid, tx)).await
+    }
+
+    async fn get_pending_tasks(&mut self) -> Result<Vec<(Uuid, TaskMap)>> {
+        self.call(TxnMessage::GetPendingTasks).await
+    }
+
+    async fn all_tasks(&mut self) -> Result<Vec<(Uuid, TaskMap)>> {
+        self.call(TxnMessage::AllTasks).await
+    }
+
+    async fn all_task_uuids(&mut self) -> Result<Vec<Uuid>> {
+        self.call(TxnMessage::AllTaskUuids).await
+    }
+
+    async fn base_version(&mut self) -> Result<VersionId> {
+        self.call(TxnMessage::BaseVersion).await
+    }
+
+    async fn set_base_version(&mut self, version: VersionId) -> Result<()> {
+        self.call(|tx| TxnMessage::SetBaseVersion(version, tx))
+            .await
+    }
+
+    async fn get_task_operations(&mut self, uuid: Uuid) -> Result<Vec<Operation>> {
+        self.call(|tx| TxnMessage::GetTaskOperations(uuid, tx))
+            .await
+    }
+
+    async fn unsynced_operations(&mut self) -> Result<Vec<Operation>> {
+        self.call(TxnMessage::UnsyncedOperations).await
+    }
+
+    async fn num_unsynced_operations(&mut self) -> Result<usize> {
+        self.call(TxnMessage::NumUnsyncedOperations).await
+    }
+
+    async fn add_operation(&mut self, op: Operation) -> Result<()> {
+        self.call(|tx| TxnMessage::AddOperation(op, tx)).await
+    }
+
+    async fn remove_operation(&mut self, op: Operation) -> Result<()> {
+        self.call(|tx| TxnMessage::RemoveOperation(op, tx)).await
+    }
+
+    async fn sync_complete(&mut self) -> Result<()> {
+        self.call(TxnMessage::SyncComplete).await
+    }
+
+    async fn get_working_set(&mut self) -> Result<Vec<Option<Uuid>>> {
+        self.call(TxnMessage::GetWorkingSet).await
+    }
+
+    async fn add_to_working_set(&mut self, uuid: Uuid) -> Result<usize> {
+        self.call(|tx| TxnMessage::AddToWorkingSet(uuid, tx)).await
+    }
+
+    async fn set_working_set_item(&mut self, index: usize, uuid: Option<Uuid>) -> Result<()> {
+        self.call(|tx| TxnMessage::SetWorkingSetItem(index, uuid, tx))
+            .await
+    }
+
+    async fn clear_working_set(&mut self) -> Result<()> {
+        self.call(TxnMessage::ClearWorkingSet).await
+    }
+
+    async fn is_empty(&mut self) -> Result<bool> {
+        self.call(TxnMessage::IsEmpty).await
+    }
+}

--- a/src/storage/sqlite/mod.rs
+++ b/src/storage/sqlite/mod.rs
@@ -1,15 +1,12 @@
-use crate::errors::{Error, Result};
-use crate::operation::Operation;
+use crate::errors::Result;
 use crate::storage::config::AccessMode;
+use crate::storage::send_wrapper::Wrapper;
 use crate::storage::sqlite::inner::SqliteStorageInner;
-use crate::storage::{Storage, StorageTxn, TaskMap, VersionId};
+use crate::storage::{Storage, StorageTxn};
 use async_trait::async_trait;
 use rusqlite::types::FromSql;
 use rusqlite::ToSql;
 use std::path::Path;
-use std::sync::mpsc;
-use std::thread;
-use tokio::sync::oneshot;
 use uuid::Uuid;
 
 mod inner;
@@ -43,344 +40,52 @@ impl ToSql for StoredUuid {
     }
 }
 
-/// An enum for messages sent to the sync thread actor.
-pub(crate) enum ActorMessage {
-    // Transaction control
-    BeginTxn(oneshot::Sender<Result<mpsc::Sender<TxnMessage>>>),
-}
-
-pub(crate) enum TxnMessage {
-    Commit(oneshot::Sender<Result<()>>),
-    Rollback(oneshot::Sender<Result<()>>),
-
-    // Transactional operations
-    GetTask(Uuid, oneshot::Sender<Result<Option<TaskMap>>>),
-    GetPendingTasks(oneshot::Sender<Result<Vec<(Uuid, TaskMap)>>>),
-    CreateTask(Uuid, oneshot::Sender<Result<bool>>),
-    SetTask(Uuid, TaskMap, oneshot::Sender<Result<()>>),
-    DeleteTask(Uuid, oneshot::Sender<Result<bool>>),
-    AllTasks(oneshot::Sender<Result<Vec<(Uuid, TaskMap)>>>),
-    AllTaskUuids(oneshot::Sender<Result<Vec<Uuid>>>),
-    BaseVersion(oneshot::Sender<Result<VersionId>>),
-    SetBaseVersion(VersionId, oneshot::Sender<Result<()>>),
-    GetTaskOperations(Uuid, oneshot::Sender<Result<Vec<Operation>>>),
-    UnsyncedOperations(oneshot::Sender<Result<Vec<Operation>>>),
-    NumUnsyncedOperations(oneshot::Sender<Result<usize>>),
-    AddOperation(Operation, oneshot::Sender<Result<()>>),
-    RemoveOperation(Operation, oneshot::Sender<Result<()>>),
-    SyncComplete(oneshot::Sender<Result<()>>),
-    GetWorkingSet(oneshot::Sender<Result<Vec<Option<Uuid>>>>),
-    AddToWorkingSet(Uuid, oneshot::Sender<Result<usize>>),
-    SetWorkingSetItem(usize, Option<Uuid>, oneshot::Sender<Result<()>>),
-    ClearWorkingSet(oneshot::Sender<Result<()>>),
-}
-
-/// State owned by the dedicated synchronous thread. It handles the low-level,
-/// sync db ops.
-struct Actor {
-    storage: SqliteStorageInner,
-    receiver: mpsc::Receiver<ActorMessage>,
-}
-
-impl Actor {
-    fn run(&mut self) {
-        // The outer loop waits for a BeginTxn message. If the channel is disconnected,
-        // the thread will exit gracefully.
-        while let Ok(ActorMessage::BeginTxn(reply_sender)) = self.receiver.recv() {
-            let (txn_sender, txn_receiver) = mpsc::channel::<TxnMessage>();
-            match self.storage.txn() {
-                Ok(mut txn) => {
-                    // Send the new transaction channel sender back
-                    if reply_sender.send(Ok(txn_sender)).is_err() {
-                        log::warn!("Client disconnected before transaction could be established");
-                        continue; // Don't handle the txn if the client is gone.
-                    }
-                    Self::handle_transaction(&txn_receiver, &mut txn);
-                }
-                Err(e) => {
-                    // Send the database error back to the caller
-                    log::error!("Could not start SQLite transaction: {e}");
-                    let _ = reply_sender.send(Err(e));
-                }
-            }
-        }
-    }
-
-    /// The inner loop for handling messages within an active transaction.
-    fn handle_transaction(
-        receiver: &mpsc::Receiver<TxnMessage>,
-        txn: &mut crate::storage::sqlite::inner::Txn,
-    ) {
-        while let Ok(msg) = receiver.recv() {
-            match msg {
-                TxnMessage::Commit(resp) => {
-                    let _ = resp.send(txn.commit());
-                    return; // Transaction over, return to the outer loop.
-                }
-                TxnMessage::Rollback(resp) => {
-                    // The sync txn is implicitly rolled back when it's dropped.
-                    let _ = resp.send(Ok(()));
-                    return; // Transaction over, return to the outer loop.
-                }
-                TxnMessage::GetTask(uuid, resp) => {
-                    let _ = resp.send(txn.get_task(uuid));
-                }
-                TxnMessage::GetPendingTasks(resp) => {
-                    let _ = resp.send(txn.get_pending_tasks());
-                }
-                TxnMessage::CreateTask(uuid, resp) => {
-                    let _ = resp.send(txn.create_task(uuid));
-                }
-                TxnMessage::SetTask(uuid, t, resp) => {
-                    let _ = resp.send(txn.set_task(uuid, t));
-                }
-                TxnMessage::DeleteTask(uuid, resp) => {
-                    let _ = resp.send(txn.delete_task(uuid));
-                }
-                TxnMessage::AllTasks(resp) => {
-                    let _ = resp.send(txn.all_tasks());
-                }
-                TxnMessage::AllTaskUuids(resp) => {
-                    let _ = resp.send(txn.all_task_uuids());
-                }
-                TxnMessage::BaseVersion(resp) => {
-                    let _ = resp.send(txn.base_version());
-                }
-                TxnMessage::SetBaseVersion(v, resp) => {
-                    let _ = resp.send(txn.set_base_version(v));
-                }
-                TxnMessage::GetTaskOperations(u, resp) => {
-                    let _ = resp.send(txn.get_task_operations(u));
-                }
-                TxnMessage::UnsyncedOperations(resp) => {
-                    let _ = resp.send(txn.unsynced_operations());
-                }
-                TxnMessage::NumUnsyncedOperations(resp) => {
-                    let _ = resp.send(txn.num_unsynced_operations());
-                }
-                TxnMessage::AddOperation(o, resp) => {
-                    let _ = resp.send(txn.add_operation(o));
-                }
-                TxnMessage::RemoveOperation(o, resp) => {
-                    let _ = resp.send(txn.remove_operation(o));
-                }
-                TxnMessage::SyncComplete(resp) => {
-                    let _ = resp.send(txn.sync_complete());
-                }
-                TxnMessage::GetWorkingSet(resp) => {
-                    let _ = resp.send(txn.get_working_set());
-                }
-                TxnMessage::AddToWorkingSet(u, resp) => {
-                    let _ = resp.send(txn.add_to_working_set(u));
-                }
-                TxnMessage::SetWorkingSetItem(i, u, resp) => {
-                    let _ = resp.send(txn.set_working_set_item(i, u));
-                }
-                TxnMessage::ClearWorkingSet(resp) => {
-                    let _ = resp.send(txn.clear_working_set());
-                }
-            };
-        }
-    }
-}
-
 /// SqliteStorageActor is an async actor wrapper for the sync SqliteStorage.
 #[derive(Clone)]
-pub struct SqliteStorage {
-    sender: mpsc::Sender<ActorMessage>,
-}
+pub struct SqliteStorage(Wrapper);
 
 impl SqliteStorage {
-    pub fn new<P: AsRef<Path>>(
+    pub async fn new<P: AsRef<Path>>(
         path: P,
         access_mode: AccessMode,
         create_if_missing: bool,
     ) -> Result<Self> {
-        let (sender, receiver) = mpsc::channel();
         let path = path.as_ref().to_path_buf();
-
-        // Use a sync_channel to block until the thread has initialized.
-        let (init_sender, init_receiver) = mpsc::sync_channel(0);
-
-        thread::spawn(move || {
-            match SqliteStorageInner::new(path, access_mode, create_if_missing) {
-                Ok(storage) => {
-                    // Send Ok back to the caller of `new` and then start the actor loop.
-                    init_sender.send(Ok(())).unwrap();
-                    let mut actor = Actor { storage, receiver };
-                    actor.run();
-                }
-                Err(e) => {
-                    // Send the initialization error back.
-                    init_sender.send(Err(e)).unwrap();
-                }
-            }
-        });
-
-        // Block until the thread sends its initialization result.
-        init_receiver.recv().unwrap()?;
-        Ok(Self { sender })
+        Ok(Self(
+            Wrapper::new(async move || {
+                let inner = SqliteStorageInner::new(&path, access_mode, create_if_missing)?;
+                Ok(inner)
+            })
+            .await?,
+        ))
     }
 }
 
 #[async_trait]
 impl Storage for SqliteStorage {
-    // Sends the BeginTxn message to the underlying SqliteStorage. Now that the txn has
-    // begun, this async txn obj can be passed around and operated upon, as it
-    // communicates with the underlying sync txn.
     async fn txn<'a>(&'a mut self) -> Result<Box<dyn StorageTxn + Send + 'a>> {
-        let (reply_tx, reply_rx) = oneshot::channel();
-        self.sender
-            .send(ActorMessage::BeginTxn(reply_tx))
-            .map_err(|e| Error::Other(e.into()))?;
-        let txn_sender = reply_rx.await??;
-        Ok(Box::new(ActorTxn::new(txn_sender)))
-    }
-}
-
-/// An async proxy for a transaction running on the sync actor thread.
-pub(super) struct ActorTxn {
-    sender: mpsc::Sender<TxnMessage>,
-    committed: bool,
-}
-
-impl ActorTxn {
-    fn new(sender: mpsc::Sender<TxnMessage>) -> Self {
-        Self {
-            sender,
-            committed: false,
-        }
-    }
-
-    async fn call<R, F>(&self, f: F) -> Result<R>
-    where
-        F: FnOnce(oneshot::Sender<Result<R>>) -> TxnMessage,
-        R: Send + 'static,
-    {
-        let (tx, rx) = oneshot::channel();
-        self.sender
-            .send(f(tx))
-            .map_err(|e| Error::Other(e.into()))?;
-        rx.await?
-    }
-}
-
-impl Drop for ActorTxn {
-    fn drop(&mut self) {
-        if !self.committed {
-            // If the transaction proxy is dropped without being committed,
-            // we send a Rollback message. We don't need to wait for the response.
-            let (tx, _rx) = oneshot::channel();
-            let _ = self.sender.send(TxnMessage::Rollback(tx));
-        }
-    }
-}
-
-#[async_trait]
-impl StorageTxn for ActorTxn {
-    async fn commit(&mut self) -> Result<()> {
-        let res = self.call(TxnMessage::Commit).await;
-        if res.is_ok() {
-            self.committed = true;
-        }
-        res
-    }
-
-    async fn get_task(&mut self, uuid: Uuid) -> Result<Option<TaskMap>> {
-        self.call(|tx| TxnMessage::GetTask(uuid, tx)).await
-    }
-
-    async fn create_task(&mut self, uuid: Uuid) -> Result<bool> {
-        self.call(|tx| TxnMessage::CreateTask(uuid, tx)).await
-    }
-
-    async fn set_task(&mut self, uuid: Uuid, task: TaskMap) -> Result<()> {
-        self.call(|tx| TxnMessage::SetTask(uuid, task, tx)).await
-    }
-
-    async fn delete_task(&mut self, uuid: Uuid) -> Result<bool> {
-        self.call(|tx| TxnMessage::DeleteTask(uuid, tx)).await
-    }
-
-    async fn get_pending_tasks(&mut self) -> Result<Vec<(Uuid, TaskMap)>> {
-        self.call(TxnMessage::GetPendingTasks).await
-    }
-
-    async fn all_tasks(&mut self) -> Result<Vec<(Uuid, TaskMap)>> {
-        self.call(TxnMessage::AllTasks).await
-    }
-
-    async fn all_task_uuids(&mut self) -> Result<Vec<Uuid>> {
-        self.call(TxnMessage::AllTaskUuids).await
-    }
-
-    async fn base_version(&mut self) -> Result<VersionId> {
-        self.call(TxnMessage::BaseVersion).await
-    }
-
-    async fn set_base_version(&mut self, version: VersionId) -> Result<()> {
-        self.call(|tx| TxnMessage::SetBaseVersion(version, tx))
-            .await
-    }
-
-    async fn get_task_operations(&mut self, uuid: Uuid) -> Result<Vec<Operation>> {
-        self.call(|tx| TxnMessage::GetTaskOperations(uuid, tx))
-            .await
-    }
-
-    async fn unsynced_operations(&mut self) -> Result<Vec<Operation>> {
-        self.call(TxnMessage::UnsyncedOperations).await
-    }
-
-    async fn num_unsynced_operations(&mut self) -> Result<usize> {
-        self.call(TxnMessage::NumUnsyncedOperations).await
-    }
-
-    async fn add_operation(&mut self, op: Operation) -> Result<()> {
-        self.call(|tx| TxnMessage::AddOperation(op, tx)).await
-    }
-
-    async fn remove_operation(&mut self, op: Operation) -> Result<()> {
-        self.call(|tx| TxnMessage::RemoveOperation(op, tx)).await
-    }
-
-    async fn sync_complete(&mut self) -> Result<()> {
-        self.call(TxnMessage::SyncComplete).await
-    }
-
-    async fn get_working_set(&mut self) -> Result<Vec<Option<Uuid>>> {
-        self.call(TxnMessage::GetWorkingSet).await
-    }
-
-    async fn add_to_working_set(&mut self, uuid: Uuid) -> Result<usize> {
-        self.call(|tx| TxnMessage::AddToWorkingSet(uuid, tx)).await
-    }
-
-    async fn set_working_set_item(&mut self, index: usize, uuid: Option<Uuid>) -> Result<()> {
-        self.call(|tx| TxnMessage::SetWorkingSetItem(index, uuid, tx))
-            .await
-    }
-
-    async fn clear_working_set(&mut self) -> Result<()> {
-        self.call(TxnMessage::ClearWorkingSet).await
+        Ok(self.0.txn().await?)
     }
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::errors::Error;
     use crate::storage::config::AccessMode;
     use pretty_assertions::assert_eq;
     use tempfile::TempDir;
 
-    fn storage() -> Result<SqliteStorage> {
+    async fn storage() -> Result<SqliteStorage> {
         let tmp_dir = TempDir::new()?;
-        SqliteStorage::new(tmp_dir.path(), AccessMode::ReadWrite, true)
+        SqliteStorage::new(tmp_dir.path(), AccessMode::ReadWrite, true).await
     }
+
+    crate::storage::test::storage_tests!(storage().await?);
 
     #[tokio::test]
     async fn test_implicit_rollback() -> Result<()> {
-        let mut storage = storage()?;
+        let mut storage = storage().await?;
         let uuid = Uuid::new_v4();
 
         // Begin a transaction, create a task, but do not commit.
@@ -407,7 +112,7 @@ mod test {
 
         // Try to create the storage inside a path that is a file, not a directory.
         // This should cause SqliteStorage::new to fail inside the actor thread.
-        let result = SqliteStorage::new(&file_path, AccessMode::ReadWrite, true);
+        let result = SqliteStorage::new(&file_path, AccessMode::ReadWrite, true).await;
         assert!(
             result.is_err(),
             "Initialization should fail for an invalid path"


### PR DESCRIPTION
In #620, @geofflittle created a fancy wrapper for the `!Send` SQLite libraries to allow them to be used in more common `Send` runtimes (where e.g., `spawn(fut)` expects a `Send` future). The SQLite C library uses thread-local storage, and thus must always run in the same thread, which in Rust means it's `!Send`. Similarly, a planned IndexedDB backend for use in WASM builds contains raw pointers and thus is also `!Send`.

This PR factors the storage wrapper out so that it can be used to support other storage backends (in particular, a planned IndexedDB backend for use in WASM builds). It goes on to support async methods on the wrapped backend, and an async constructor for that backend. It also makes some small tweaks: removing the response channel from the Rollback message, and wrapping the `is_empty` method.

There is one breaking change: `SqliteStorage::new` is now async, as it must wait for the initialization to take place in the thread.