### PR TITLE
Add an IndexedDB storage implementation

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -43,6 +43,13 @@ jobs:
           args: --all-features --no-deps -- -D warnings
           name: "Clippy Results"
 
+      - uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          target: wasm32-unknown-unknown
+          args: --no-default-features --features storage-indexeddb --no-deps -- -D warnings
+          name: "Clippy Results (WASM)"
+
   rustdoc:
     runs-on: ubuntu-latest
     name: "Rustdoc"

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -92,11 +92,14 @@ jobs:
 
   ## Test a build for WASM.
   wasm:
-    name: "WASM Build"
+    name: "WASM Tests"
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v6
+
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
       - name: Cache cargo registry
         uses: actions/cache@v5
@@ -116,7 +119,10 @@ jobs:
           target: wasm32-unknown-unknown
           override: true
 
-      - name: build
-        # At the moment, only sqlite storage and the local server are
-        # supported. See https://github.com/GothenburgBitFactory/taskchampion/issues/599.
-        run: cargo build --no-default-features --features storage-sqlite,server-local
+      - run: |
+          wasm-pack test --headless --firefox \
+            --no-default-features --features storage-indexeddb
+
+      - run: |
+          wasm-pack test --headless --chrome \
+            --no-default-features --features storage-indexeddb

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,6 +507,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1325,6 +1331,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "idb"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3afe8830d5802f769dc0be20a87f9f116798c896650cb6266eb5c19a3c109eed"
+dependencies = [
+ "js-sys",
+ "num-traits",
+ "thiserror 1.0.69",
+ "tokio",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "idna"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1369,9 +1389,9 @@ checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "js-sys"
-version = "0.3.74"
+version = "0.3.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a865e038f7f6ed956f788f0d7d60c541fff74c7bd74272c5d4cf15c63743e705"
+checksum = "464a3709c7f55f1f721e5389aa6ea4e3bc6aba669353300af094b29ffbdde1d8"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1397,6 +1417,12 @@ name = "libc"
 version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+
+[[package]]
+name = "libm"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libsqlite3-sys"
@@ -1479,6 +1505,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "minicov"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27fe9f1cc3c22e1687f9446c2083c4c5fc7f0bcf1c7a86bdbded14985895b4b"
+dependencies = [
+ "cc",
+ "walkdir",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1496,6 +1532,15 @@ dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1530,6 +1575,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1537,6 +1583,12 @@ name = "once_cell"
 version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "openssl-probe"
@@ -2100,6 +2152,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2150,6 +2211,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-wasm-bindgen"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2350,6 +2422,7 @@ dependencies = [
  "flate2",
  "google-cloud-storage",
  "httptest",
+ "idb",
  "libc",
  "log",
  "pretty_assertions",
@@ -2360,6 +2433,7 @@ dependencies = [
  "rstest",
  "rusqlite",
  "serde",
+ "serde-wasm-bindgen",
  "serde_json",
  "strum",
  "strum_macros",
@@ -2368,6 +2442,10 @@ dependencies = [
  "tokio",
  "url",
  "uuid",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test",
+ "web-sys",
 ]
 
 [[package]]
@@ -2688,6 +2766,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2713,35 +2801,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.97"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d15e63b4482863c109d70a7b8706c1e364eb6ea449b201a76c5b89cedcec2d5c"
+checksum = "0d759f433fa64a2d763d1340820e46e111a7a5ab75f993d1852d70b03dbb80fd"
 dependencies = [
  "cfg-if",
  "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.97"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d36ef12e3aaca16ddd3f67922bc63e48e953f126de60bd33ccc0101ef9998cd"
-dependencies = [
- "bumpalo",
- "log",
- "once_cell",
- "proc-macro2",
- "quote",
- "syn",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.47"
+version = "0.4.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dfaf8f50e5f293737ee323940c7d8b08a66a95a419223d9f41610ca08b0833d"
+checksum = "836d9622d604feee9e5de25ac10e3ea5f2d65b41eac0d9ce72eb5deae707ce7c"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2752,9 +2827,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.97"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "705440e08b42d3e4b36de7d66c944be628d579796b8090bfa3471478a2260051"
+checksum = "48cb0d2638f8baedbc542ed444afc0644a29166f1595371af4fecf8ce1e7eeb3"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2762,22 +2837,57 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.97"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98c9ae5a76e46f4deecd0f0255cc223cfa18dc9b261213b8aa0c7b36f61b3f1d"
+checksum = "cefb59d5cd5f92d9dcf80e4683949f15ca4b511f4ac0a6e14d4e1ac60c6ecd40"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
  "syn",
- "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.97"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ee99da9c5ba11bd675621338ef6fa52296b76b83305e9b6e5c77d4c286d6d49"
+checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "wasm-bindgen-test"
+version = "0.3.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25e90e66d265d3a1efc0e72a54809ab90b9c0c515915c67cdf658689d2c22c6c"
+dependencies = [
+ "async-trait",
+ "cast",
+ "js-sys",
+ "libm",
+ "minicov",
+ "nu-ansi-term",
+ "num-traits",
+ "oorandom",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7150335716dce6028bead2b848e72f47b45e7b9422f64cccdc23bedca89affc1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "wasm-streams"
@@ -2794,9 +2904,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.74"
+version = "0.3.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a98bc3c33f0fe7e59ad7cd041b89034fa82a7c2d4365ca538dda6cdaf513863c"
+checksum = "9b32828d774c412041098d182a8b38b16ea816958e07cf40eec2bc080ae137ac"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2819,6 +2929,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d642ff16b7e79272ae451b7322067cdc17cadf68c23264be9d94a32319efe7e"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,9 @@ rust-version = "1.88.0"
 members = [ "xtask" ]
 resolver = "2"
 
+[lib]
+crate-type = ["cdylib", "rlib"]
+
 [features]
 default = ["sync", "bundled", "storage", "tls-webpki-roots"]
 
@@ -30,10 +33,14 @@ server-gcp = ["cloud", "encryption", "http", "dep:google-cloud-storage", "dep:re
 server-aws = ["cloud", "encryption", "http", "dep:aws-sdk-s3", "dep:aws-config", "dep:aws-credential-types", "dep:aws-smithy-runtime-api", "dep:aws-smithy-types"]
 # Suppport for sync to another SQLite database on the same machine
 server-local = ["dep:rusqlite"]
-# Support for all task storage backends
+
+# Support for all task storage backends (except indexeddb, which only works on WASM builds)
 storage = ["storage-sqlite"]
 # Support for SQLite task storage
 storage-sqlite = ["dep:rusqlite"]
+# Support for IndexedDB task storage
+storage-indexeddb = ["dep:idb", "dep:web-sys"]
+
 # (private) Support for sync protocol encryption
 encryption = ["dep:ring"]
 # (private) Generic support for cloud sync
@@ -49,9 +56,11 @@ http = ["dep:reqwest", "dep:url"]
 
 [package.metadata.docs.rs]
 all-features = true
+additional-targets = ["wasm32-unknown-unknown"]
 
 [dependencies]
 anyhow = "1.0"
+async-trait = "0.1.89"
 aws-sdk-s3 = { version = "1.118", default-features = false, optional = true }
 aws-config = { version = "1.8", default-features = false, features = ["rt-tokio", "behavior-version-latest"], optional = true }
 aws-credential-types = { version = "1", default-features = false, features = ["hardcoded-credentials"], optional = true }
@@ -61,6 +70,7 @@ byteorder = "1.5"
 chrono = { version = "^0.4.38", features = ["serde"] }
 flate2 = "1"
 google-cloud-storage = { version = "0.24.0", default-features = false, features = ["rustls-tls", "auth"], optional = true }
+idb = { version = "0.6.4", optional = true }
 log = "^0.4.17"
 reqwest = { version = "0.12", default-features = false, optional = true }
 reqwest-middleware = { version = "0.4", optional = true }
@@ -74,16 +84,43 @@ tokio = { version = "1", features = ["macros", "sync", "rt"] }
 thiserror = "2.0"
 uuid = { version = "^1.16.0", features = ["serde", "v4"] }
 url = { version = "2", optional = true }
-async-trait = "0.1.89"
 
+## wasm-only dependencies
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 uuid = { version = "*", features = ["js"] }
+wasm-bindgen = { version = "0.2" }
+wasm-bindgen-futures = { version = "0.4" }
+serde-wasm-bindgen = "0.6"
+web-sys = { version = "0.3.83", optional = true, features = [
+  "Window",
+  "IdbFactory",
+  "IdbOpenDbRequest",
+  "IdbDatabase",
+  "IdbTransaction",
+  "IdbObjectStore",
+  "IdbRequest",
+  "DomException",
+  "IdbObjectStoreParameters",
+  "IdbTransactionMode",
+  "EventTarget",
+  "Event",
+  "console",
+]}
 
+## common dev-dependencies
 [dev-dependencies]
-proptest = "^1.9.0"
 tempfile = "3"
 rstest = "0.26"
 pretty_assertions = "1"
 libc = "*"
 tokio = { version = "*", features = ["time", "rt"] }
+
+## wasm-only dev-dependencies
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+wasm-bindgen-test = "0.3"
+
+## non-wasm dev-dependencies
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+# proptest requires getrandom, which is not supported on WASM
+proptest = "^1.9.0"
 httptest = "0.16"

--- a/src/crate-doc.md
+++ b/src/crate-doc.md
@@ -71,8 +71,9 @@ Support for some optional functionality is controlled by feature flags.
  * `server-sync` - sync to the taskchampion-sync-server
  * `server-local` - sync to a local file
  * `sync` - enables all of the sync features above
+ * `storage-indexeddb` - store task data in the browser using IndexedDB (WASM only)
  * `storage-sqlite` - store task data locally in SQLite
- * `storage` - enables all of the storage features above
+ * `storage` - enables all of the storage features above except `storage-indexeddb`
  * `bundled` - activates bundling system libraries like sqlite
  * `tls-webpki-roots` - use TLS roots bundled with the library, instead of reading them from
    system configuration.
@@ -82,6 +83,13 @@ Support for some optional functionality is controlled by feature flags.
    of the HTTPS-based `server-*` features.
 
 By default, `sync`, `storage`, `bundled`, and `tls-webpki-roots` are enabled.
+
+# WASM Support
+
+TaskChampion can be built for WASM with the usual WASM tools, such as
+`wasm-pack`. Only the following features are supported:
+
+ * `storage-indexeddb` - store task data in the browser using IndexedDB (WASM only)
 
 # See Also
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -57,6 +57,22 @@ impl<T: Sync + Send + 'static> From<tokio::sync::mpsc::error::SendError<T>> for 
     }
 }
 
+/// Convert [`idb::Error`] into [`Error::Database`]
+#[cfg(all(target_arch = "wasm32", feature = "storage-indexeddb"))]
+impl From<idb::Error> for Error {
+    fn from(err: idb::Error) -> Self {
+        Error::Database(err.to_string())
+    }
+}
+
+/// Convert [`serde_wasm_bindgen::Error`] into [`Error::Database`]
+#[cfg(all(target_arch = "wasm32", feature = "storage-indexeddb"))]
+impl From<serde_wasm_bindgen::Error> for Error {
+    fn from(err: serde_wasm_bindgen::Error) -> Self {
+        Error::Database(err.to_string())
+    }
+}
+
 /// Convert reqwest errors more carefully
 #[cfg(feature = "http")]
 impl From<reqwest::Error> for Error {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,8 @@ pub use errors::Error;
 pub use operation::{Operation, Operations};
 pub use replica::Replica;
 pub use server::{Server, ServerConfig};
+#[cfg(all(target_arch = "wasm32", feature = "storage-indexeddb"))]
+pub use storage::indexeddb::IndexedDbStorage;
 #[cfg(feature = "storage-sqlite")]
 pub use storage::sqlite::SqliteStorage;
 pub use task::{utc_timestamp, Annotation, Status, Tag, Task, TaskData};

--- a/src/server/op.rs
+++ b/src/server/op.rs
@@ -176,13 +176,11 @@ impl SyncOp {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::storage::TaskMap;
     use crate::taskdb::TaskDb;
     use crate::Operations;
     use crate::{errors::Result, storage::inmemory::InMemoryStorage};
     use chrono::{Duration, Utc};
     use pretty_assertions::assert_eq;
-    use proptest::prelude::*;
 
     #[test]
     fn test_json_create() -> Result<()> {
@@ -403,6 +401,18 @@ mod test {
         )
         .await;
     }
+}
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod proptest_test {
+    use super::*;
+    use crate::storage::inmemory::InMemoryStorage;
+    use crate::storage::TaskMap;
+    use crate::taskdb::TaskDb;
+    use crate::Operations;
+    use chrono::Utc;
+    use pretty_assertions::assert_eq;
+    use proptest::prelude::*;
 
     fn uuid_strategy() -> impl Strategy<Value = Uuid> {
         prop_oneof![

--- a/src/storage/indexeddb/mod.rs
+++ b/src/storage/indexeddb/mod.rs
@@ -1,0 +1,7 @@
+#[cfg(not(target_arch = "wasm32"))]
+compile_error!("IndexdDBStorage is only available on WASM targets");
+
+mod storage;
+pub use storage::IndexedDbStorage;
+
+mod schema;

--- a/src/storage/indexeddb/schema.rs
+++ b/src/storage/indexeddb/schema.rs
@@ -1,0 +1,71 @@
+use crate::errors::Result;
+use idb::{Database, KeyPath};
+
+/// The IndexedDB database version. This can be incremented to trigger calls to
+/// `upgrade`.
+pub(super) const DB_VERSION: u32 = 1;
+
+pub(super) const TASKS: &str = "tasks";
+pub(super) const OPERATIONS: &str = "operations";
+pub(super) const OPERATIONS_BY_UUID: &str = "operations_by_uuid";
+pub(super) const OPERATIONS_BY_UNSYNCED: &str = "operations_by_unsynced";
+pub(super) const SYNC_META: &str = "sync_meta";
+pub(super) const WORKING_SET: &str = "working_set";
+
+/* Current Schema:
+ *
+ *  - Object store `tasks` stores TaskMaps as values, in the form of a JS object. Keys are UUIDs in
+ *    the form of a string.
+ *
+ *  - Object store `operations` stores values {uuid, operation, unsynced}, with `unsynced` omitted
+ *    for synced operations. Keys are auto-incrementing integers. The `uuid` and `unsynced`
+ *    properties are indexed.
+ *
+ *  - Object store `sync_meta` stores string values with string keys. At the moment it only stores
+ *    the base revision.
+ *
+ *  - Object store `working_set` stores UUIDs as strings, keyed by the working set ID as an integer.
+ */
+
+fn upgrade_0_to_1(db: Database) -> Result<()> {
+    // Create the `tasks` table
+    let mut params = idb::ObjectStoreParams::new();
+    params.key_path(None);
+    params.auto_increment(false);
+    db.create_object_store(TASKS, params)?;
+
+    // Create the `operations` table
+    let mut params = idb::ObjectStoreParams::new();
+    params.key_path(None);
+    params.auto_increment(true);
+    let ops = db.create_object_store(OPERATIONS, params)?;
+
+    ops.create_index(OPERATIONS_BY_UUID, KeyPath::new_single("uuid"), None)?;
+    ops.create_index(
+        OPERATIONS_BY_UNSYNCED,
+        KeyPath::new_single("unsynced"),
+        None,
+    )?;
+
+    // Create the `sync_meta` table
+    let mut params = idb::ObjectStoreParams::new();
+    params.key_path(None);
+    params.auto_increment(false);
+    db.create_object_store(SYNC_META, params)?;
+
+    // Create the `working_set` table
+    let mut params = idb::ObjectStoreParams::new();
+    params.key_path(None);
+    params.auto_increment(false);
+    db.create_object_store(WORKING_SET, params)?;
+
+    Ok(())
+}
+
+pub(super) fn upgrade(db: Database, old_version: u32) -> Result<()> {
+    if old_version == 0 {
+        upgrade_0_to_1(db)
+    } else {
+        unreachable!("old_version should be less than DB_VERSION");
+    }
+}

--- a/src/storage/indexeddb/storage.rs
+++ b/src/storage/indexeddb/storage.rs
@@ -1,0 +1,467 @@
+use super::schema;
+use crate::errors::{Error, Result};
+use crate::operation::Operation;
+use crate::storage::send_wrapper::{WrappedStorage, WrappedStorageTxn, Wrapper};
+use crate::storage::{Storage, StorageTxn, TaskMap, VersionId, DEFAULT_BASE_VERSION};
+use async_trait::async_trait;
+use idb::{CursorDirection, DatabaseEvent, Query, Transaction, TransactionMode};
+use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
+use uuid::Uuid;
+use wasm_bindgen::JsValue;
+
+struct Inner {
+    db: idb::Database,
+}
+
+#[async_trait(?Send)]
+impl WrappedStorage for Inner {
+    async fn txn<'a>(&'a mut self) -> Result<Box<dyn WrappedStorageTxn + 'a>> {
+        Ok(Box::new(InnerTxn(Some(self.db.transaction(
+            &[
+                schema::TASKS,
+                schema::OPERATIONS,
+                schema::SYNC_META,
+                schema::WORKING_SET,
+            ],
+            TransactionMode::ReadWrite,
+        )?))))
+    }
+}
+
+/// Return a new error stating the data is invalid.
+fn invalid() -> Error {
+    Error::Database("invalid data in IndexedDB".into())
+}
+
+/// Wrap the given error stating the data is invalid.
+fn invalid_err(e: impl std::error::Error) -> Error {
+    Error::Database(format!("invalid data in IndexedDB: {e}"))
+}
+
+/// Return a new error indicating this transaction has been committed.
+fn already_committed() -> Error {
+    Error::Database("transaction is already committed".into())
+}
+
+/// Return a new error indicating the operation was not found.
+fn operation_not_found() -> Error {
+    Error::Database("operation not found".into())
+}
+
+/// Return a new error indicating the operation has already been synced.
+fn operation_synced() -> Error {
+    Error::Database("operation has been synced".into())
+}
+
+/// Convert a JsValue to a Uuid.
+fn js2uuid(js: JsValue) -> Result<Uuid> {
+    let json = js.as_string().ok_or_else(invalid)?;
+    let uuid = Uuid::parse_str(json.as_str()).map_err(invalid_err)?;
+    Ok(uuid)
+}
+
+/// Convert a UUID to a JsValue.
+fn uuid2js(uuid: Uuid) -> Result<JsValue> {
+    let string = uuid.to_string();
+    let js = JsValue::from_str(string.as_str());
+    Ok(js)
+}
+
+/// Convert a JsValue to a Task.
+fn js2task(js: JsValue) -> Result<TaskMap> {
+    Ok(serde_wasm_bindgen::from_value(js)?)
+}
+
+/// Convert a Task to a JsValue.
+fn task2js(task: TaskMap) -> Result<JsValue> {
+    Ok(serde_wasm_bindgen::to_value(&task)?)
+}
+
+fn unsynced_is_zero(v: &u8) -> bool {
+    *v == 0
+}
+
+/// Operations are stored with a separate UUID (for IndexedDB indexing) and
+/// a flag indicating whether they have been synced.
+#[derive(Serialize, Deserialize)]
+struct StoredOperation {
+    uuid: Option<Uuid>,
+    operation: Operation,
+
+    // IndexedDB does not support indexing by a boolean value, so
+    // we store a number here instead. Since we want to index un-synced
+    // operations, this field is only present on such entries.
+    #[serde(skip_serializing_if = "unsynced_is_zero")]
+    #[serde(default)]
+    unsynced: u8,
+}
+
+/// Convert a JsValue to an Operation.
+fn js2op(js: JsValue) -> Result<Operation> {
+    Ok(serde_wasm_bindgen::from_value::<StoredOperation>(js)?.operation)
+}
+
+/// Convert an Operation to a JsValue.
+fn op2js(operation: Operation, unsynced: bool) -> Result<JsValue> {
+    let operation = StoredOperation {
+        uuid: operation.get_uuid(),
+        operation,
+        unsynced: unsynced as u8,
+    };
+    Ok(serde_wasm_bindgen::to_value(&operation)?)
+}
+
+struct InnerTxn(Option<Transaction>);
+
+impl InnerTxn {
+    fn idb_txn(&self) -> Result<&idb::Transaction> {
+        if let Some(transaction) = &self.0 {
+            Ok(transaction)
+        } else {
+            Err(already_committed())
+        }
+    }
+
+    async fn get_next_working_set_number(&self) -> Result<usize> {
+        let working_set = self.idb_txn()?.object_store(schema::WORKING_SET)?;
+        let mut max: usize = 0;
+        let mut maybe_cursor = working_set.open_key_cursor(None, None)?.await?;
+        while let Some(cursor) = maybe_cursor {
+            let i = cursor.key()?.as_f64().ok_or_else(invalid)? as usize;
+            if i > max {
+                max = i;
+            }
+            maybe_cursor = cursor.next(None)?.await?;
+        }
+        Ok(max + 1)
+    }
+}
+
+#[async_trait(?Send)]
+impl WrappedStorageTxn for InnerTxn {
+    async fn get_task(&mut self, uuid: Uuid) -> Result<Option<TaskMap>> {
+        let tasks = self.idb_txn()?.object_store(schema::TASKS)?;
+        if let Some(task) = tasks.get(Query::Key(uuid2js(uuid)?))?.await? {
+            Ok(Some(js2task(task)?))
+        } else {
+            Ok(None)
+        }
+    }
+
+    async fn get_pending_tasks(&mut self) -> Result<Vec<(Uuid, TaskMap)>> {
+        let tasks = self.idb_txn()?.object_store(schema::TASKS)?;
+        let working_set = self.idb_txn()?.object_store(schema::WORKING_SET)?;
+        let mut maybe_cursor = working_set
+            .open_cursor(None, Some(CursorDirection::Prev))?
+            .await?;
+        let mut res = Vec::new();
+        while let Some(cursor) = maybe_cursor {
+            let jsuuid = cursor.value()?;
+            let uuid = js2uuid(jsuuid.clone())?;
+            if let Some(task) = tasks.get(Query::Key(jsuuid))?.await? {
+                res.push((uuid, js2task(task)?));
+            }
+            maybe_cursor = cursor.next(None)?.await?;
+        }
+        Ok(res)
+    }
+
+    async fn create_task(&mut self, uuid: Uuid) -> Result<bool> {
+        let tasks = self.idb_txn()?.object_store(schema::TASKS)?;
+        match tasks
+            .add(&task2js(HashMap::new())?, Some(&uuid2js(uuid)?))?
+            .await
+        {
+            Ok(_) => Ok(true),
+
+            Err(idb::Error::DomException(e)) if e.name() == "ConstraintError" => {
+                // IndexedDB returns ConstraintError when the entry already exists,
+                // which `create_task` indicates by returning false.
+                Ok(false)
+            }
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    async fn set_task(&mut self, uuid: Uuid, task: TaskMap) -> Result<()> {
+        let tasks = self.idb_txn()?.object_store(schema::TASKS)?;
+        tasks.put(&task2js(task)?, Some(&uuid2js(uuid)?))?.await?;
+        Ok(())
+    }
+
+    async fn delete_task(&mut self, uuid: Uuid) -> Result<bool> {
+        let tasks = self.idb_txn()?.object_store(schema::TASKS)?;
+        if tasks.get_key(Query::Key(uuid2js(uuid)?))?.await?.is_some() {
+            tasks.delete(Query::Key(uuid2js(uuid)?))?.await?;
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
+    async fn all_tasks(&mut self) -> Result<Vec<(Uuid, TaskMap)>> {
+        let tasks = self.idb_txn()?.object_store(schema::TASKS)?;
+        let mut res = Vec::new();
+        let mut maybe_cursor = tasks.open_cursor(None, None)?.await?;
+        while let Some(cursor) = maybe_cursor {
+            res.push((js2uuid(cursor.key()?)?, js2task(cursor.value()?)?));
+            maybe_cursor = cursor.next(None)?.await?;
+        }
+        Ok(res)
+    }
+
+    async fn all_task_uuids(&mut self) -> Result<Vec<Uuid>> {
+        let tasks = self.idb_txn()?.object_store(schema::TASKS)?;
+        let mut res = Vec::new();
+        let mut maybe_cursor = tasks.open_key_cursor(None, None)?.await?;
+        while let Some(cursor) = maybe_cursor {
+            res.push(js2uuid(cursor.key()?)?);
+            maybe_cursor = cursor.next(None)?.await?;
+        }
+        Ok(res)
+    }
+
+    async fn base_version(&mut self) -> Result<VersionId> {
+        let sync_meta = self.idb_txn()?.object_store(schema::SYNC_META)?;
+        let base_version: JsValue = "base_version".into();
+        if let Some(version) = sync_meta.get(Query::Key(base_version))?.await? {
+            Ok(js2uuid(version)?)
+        } else {
+            Ok(DEFAULT_BASE_VERSION)
+        }
+    }
+
+    async fn set_base_version(&mut self, version: VersionId) -> Result<()> {
+        let sync_meta = self.idb_txn()?.object_store(schema::SYNC_META)?;
+        let base_version: JsValue = "base_version".into();
+        sync_meta
+            .put(&uuid2js(version)?, Some(&base_version))?
+            .await?;
+        Ok(())
+    }
+
+    async fn get_task_operations(&mut self, uuid: Uuid) -> Result<Vec<Operation>> {
+        let ops_by_uuid = self
+            .idb_txn()?
+            .object_store(schema::OPERATIONS)?
+            .index(schema::OPERATIONS_BY_UUID)?;
+        let mut res = Vec::new();
+        let mut maybe_cursor = ops_by_uuid
+            .open_cursor(Some(Query::Key(uuid2js(uuid)?)), None)?
+            .await?;
+        while let Some(cursor) = maybe_cursor {
+            res.push(js2op(cursor.value()?)?);
+            maybe_cursor = cursor.next(None)?.await?;
+        }
+        Ok(res)
+    }
+
+    async fn unsynced_operations(&mut self) -> Result<Vec<Operation>> {
+        let ops_by_synced = self
+            .idb_txn()?
+            .object_store(schema::OPERATIONS)?
+            .index(schema::OPERATIONS_BY_UNSYNCED)?;
+        let mut res = Vec::new();
+        // Using no query here returns only values with the `unsynced` property set.
+        let mut maybe_cursor = ops_by_synced.open_cursor(None, None)?.await?;
+        while let Some(cursor) = maybe_cursor {
+            res.push(js2op(cursor.value()?)?);
+            maybe_cursor = cursor.next(None)?.await?;
+        }
+        Ok(res)
+    }
+
+    async fn num_unsynced_operations(&mut self) -> Result<usize> {
+        let ops_by_synced = self
+            .idb_txn()?
+            .object_store(schema::OPERATIONS)?
+            .index(schema::OPERATIONS_BY_UNSYNCED)?;
+        let mut count = 0;
+        // Using no query here returns only values with the `unsynced` property set.
+        let mut maybe_cursor = ops_by_synced.open_cursor(None, None)?.await?;
+        while let Some(cursor) = maybe_cursor {
+            count += 1;
+            maybe_cursor = cursor.next(None)?.await?;
+        }
+        Ok(count)
+    }
+
+    async fn add_operation(&mut self, op: Operation) -> Result<()> {
+        let operations = self.idb_txn()?.object_store(schema::OPERATIONS)?;
+        operations.add(&op2js(op, true)?, None)?.await?;
+        Ok(())
+    }
+
+    async fn remove_operation(&mut self, op: Operation) -> Result<()> {
+        // Iterate operations in reverse, to get the highest index.
+        let operations = self.idb_txn()?.object_store(schema::OPERATIONS)?;
+        let maybe_cursor = operations
+            .open_cursor(None, Some(CursorDirection::Prev))?
+            .await?;
+        let Some(cursor) = maybe_cursor else {
+            return Err(operation_not_found());
+        };
+
+        let found_op = serde_wasm_bindgen::from_value::<StoredOperation>(cursor.value()?)?;
+        if found_op.unsynced == 0 {
+            return Err(operation_synced());
+        }
+        if found_op.operation != op {
+            return Err(operation_not_found());
+        }
+        cursor.delete()?.await?;
+        Ok(())
+    }
+
+    async fn sync_complete(&mut self) -> Result<()> {
+        let ops = self.idb_txn()?.object_store(schema::OPERATIONS)?;
+        let ops_by_synced = ops.index(schema::OPERATIONS_BY_UNSYNCED)?;
+
+        // Update all operations to indicate they are sync'd. Using no query here returns only
+        // values with the `unsynced` property set.
+        let mut maybe_cursor = ops_by_synced.open_cursor(None, None)?.await?;
+        while let Some(cursor) = maybe_cursor {
+            let op = js2op(cursor.value()?)?;
+            cursor.update(&op2js(op, false)?)?.await?;
+            maybe_cursor = cursor.next(None)?.await?;
+        }
+
+        // Now delete all operations for which no task exists (usually deleted tasks).
+        let task_uuids: HashSet<Uuid, std::hash::RandomState> =
+            HashSet::from_iter(self.all_task_uuids().await?.drain(..));
+        let mut maybe_cursor = ops.open_cursor(None, None)?.await?;
+        while let Some(cursor) = maybe_cursor {
+            let stored_op = serde_wasm_bindgen::from_value::<StoredOperation>(cursor.value()?)?;
+            if let Some(uuid) = stored_op.uuid {
+                if !task_uuids.contains(&uuid) {
+                    cursor.delete()?.await?;
+                }
+            }
+            maybe_cursor = cursor.next(None)?.await?;
+        }
+
+        Ok(())
+    }
+
+    async fn get_working_set(&mut self) -> Result<Vec<Option<Uuid>>> {
+        let working_set = self.idb_txn()?.object_store(schema::WORKING_SET)?;
+        let mut res = vec![None];
+        let mut maybe_cursor = working_set
+            .open_cursor(None, Some(CursorDirection::Prev))?
+            .await?;
+        while let Some(cursor) = maybe_cursor {
+            let id = cursor.key()?.as_f64().ok_or_else(invalid)? as usize;
+            let uuid = js2uuid(cursor.value()?)?;
+            res.resize_with(res.len().max(id + 1), Default::default);
+            res[id] = Some(uuid);
+            maybe_cursor = cursor.next(None)?.await?;
+        }
+        Ok(res)
+    }
+
+    async fn add_to_working_set(&mut self, uuid: Uuid) -> Result<usize> {
+        let next_working_set_id = self.get_next_working_set_number().await?;
+        let working_set = self.idb_txn()?.object_store(schema::WORKING_SET)?;
+        working_set
+            .add(&uuid2js(uuid)?, Some(&next_working_set_id.into()))?
+            .await?;
+        Ok(next_working_set_id)
+    }
+
+    async fn set_working_set_item(&mut self, id: usize, uuid: Option<Uuid>) -> Result<()> {
+        let working_set = self.idb_txn()?.object_store(schema::WORKING_SET)?;
+        if let Some(uuid) = uuid {
+            working_set.put(&uuid2js(uuid)?, Some(&id.into()))?.await?;
+        } else {
+            working_set.delete(Query::Key(id.into()))?.await?;
+        }
+        Ok(())
+    }
+
+    async fn clear_working_set(&mut self) -> Result<()> {
+        let working_set = self.idb_txn()?.object_store(schema::WORKING_SET)?;
+        working_set.clear()?.await?;
+        Ok(())
+    }
+
+    async fn commit(&mut self) -> Result<()> {
+        self.0.take().ok_or_else(already_committed)?.commit()?;
+        Ok(())
+    }
+}
+
+impl Drop for InnerTxn {
+    fn drop(&mut self) {
+        if let Some(txn) = self.0.take() {
+            // Make an attempt to abort the transaction, but without any recourse
+            // if it fails.
+            let _ = txn.abort();
+        }
+    }
+}
+
+/// IndexedDbStorage uses the [IndexedDB
+/// API](https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API) to store tasks, and is
+/// suitable for use when running in a browser.
+///
+/// Although TaskChampion can initialize itself by synchronizing to a server, it is recommended to
+/// use the
+/// [`StorageManager.persist()`](https://developer.mozilla.org/en-US/docs/Web/API/StorageManager/persist)
+/// method to ensure the browser does not discard the database under storage pressure.
+///
+/// WARNING: Do not read or write the database except via this storage implementation. Later
+/// versions of this library may change the schema incompatibly. pub struct
+/// IndexedDbStorage(Wrapper);
+pub struct IndexedDbStorage(Wrapper);
+
+impl IndexedDbStorage {
+    /// Create a new IndexedDbStorage, using the given name for the database.
+    pub async fn new(db_name: impl Into<String>) -> Result<IndexedDbStorage> {
+        let db_name = db_name.into();
+        Ok(IndexedDbStorage(
+            Wrapper::new(async move || {
+                let factory = idb::Factory::new()?;
+                let mut open_request = factory.open(&db_name, Some(schema::DB_VERSION))?;
+                open_request.on_upgrade_needed(|event| {
+                    // It's unclear what to do with errors here. Abort the transaction?? The
+                    // callback is 'static so we can't capture with &mut some local variable
+                    // or anything of the sort. For now, `unwrap()`, which the browser will
+                    // handle as a JS exception.
+                    let old_version = event.old_version().unwrap();
+                    let db = event.database().unwrap();
+                    schema::upgrade(db, old_version).unwrap()
+                });
+                let db = open_request.await?;
+
+                Ok(Inner { db })
+            })
+            .await?,
+        ))
+    }
+}
+
+#[async_trait]
+impl Storage for IndexedDbStorage {
+    async fn txn<'a>(&'a mut self) -> Result<Box<dyn StorageTxn + Send + 'a>> {
+        Ok(self.0.txn().await?)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use wasm_bindgen_test::*;
+
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+
+    async fn storage() -> IndexedDbStorage {
+        // Use a random name for the DB, as tests run in parallel in the same
+        // browser profile and would otherwise interfere.
+        IndexedDbStorage::new(Uuid::new_v4().to_string().as_str())
+            .await
+            .expect("IndexedDB setup failed")
+    }
+
+    crate::storage::test::storage_tests_wasm!(storage().await);
+}

--- a/tests/syncing-proptest.rs
+++ b/tests/syncing-proptest.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "server-local")]
+#![cfg(all(feature = "server-local", not(target_arch = "wasm32")))]
 
 use pretty_assertions::assert_eq;
 use proptest::prelude::*;


### PR DESCRIPTION
This is tested in both browsers in CI using `wasm-pack test`, and passes all existing storage tests.

Because proptest is not compatible with WASM, this modifies some existing tests to ensure they only build on non-WASM platforms.

Refs #599.