### PR TITLE
Add server-sync support on WASM

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,5 @@
 [alias]
 xtask = "run --package xtask --"
+
+[target.wasm32-unknown-unknown]
+rustflags = ['--cfg', 'getrandom_backend="wasm_js"']

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -121,8 +121,8 @@ jobs:
 
       - run: |
           wasm-pack test --headless --firefox \
-            --no-default-features --features storage-indexeddb
+            --no-default-features --features storage-indexeddb,server-sync
 
       - run: |
           wasm-pack test --headless --chrome \
-            --no-default-features --features storage-indexeddb
+            --no-default-features --features storage-indexeddb,server-sync

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -883,8 +883,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.13.3+wasi-0.2.2",
+ "wasm-bindgen",
  "windows-targets",
 ]
 
@@ -2430,6 +2432,7 @@ dependencies = [
  "byteorder",
  "chrono",
  "flate2",
+ "getrandom 0.3.1",
  "google-cloud-storage",
  "httptest",
  "idb",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,19 +61,12 @@ additional-targets = ["wasm32-unknown-unknown"]
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1.89"
-aws-sdk-s3 = { version = "1.119", default-features = false, optional = true }
-aws-config = { version = "1.8", default-features = false, features = ["rt-tokio", "behavior-version-latest"], optional = true }
-aws-credential-types = { version = "1", default-features = false, features = ["hardcoded-credentials"], optional = true }
-aws-smithy-runtime-api = { version = "1.9", default-features = false, optional = true }
-aws-smithy-types = { version = "1.3", default-features = false, optional = true }
 byteorder = "1.5"
 chrono = { version = "^0.4.38", features = ["serde"] }
 flate2 = "1"
-google-cloud-storage = { version = "0.24.0", default-features = false, features = ["rustls-tls", "auth"], optional = true }
 idb = { version = "0.6.4", optional = true }
 log = "^0.4.17"
 reqwest = { version = "0.12", default-features = false, optional = true }
-reqwest-middleware = { version = "0.4", optional = true }
 ring = { version = "0.17", optional = true }
 rusqlite = { version = "0.37", optional = true}
 serde_json = "^1.0"
@@ -85,9 +78,13 @@ thiserror = "2.0"
 uuid = { version = "^1.19.0", features = ["serde", "v4"] }
 url = { version = "2", optional = true }
 
-## wasm-only dependencies
+## wasm-only dependencies.
+# Some of these have version="*" because the version is given in the general dependencies and
+# only adds a feature here.
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 uuid = { version = "*", features = ["js"] }
+ring = { version = "*", optional = true, features = ["wasm32_unknown_unknown_js"] }
+getrandom = { version = "0.3", features = ["wasm_js"] }
 wasm-bindgen = { version = "0.2" }
 wasm-bindgen-futures = { version = "0.4" }
 serde-wasm-bindgen = "0.6"
@@ -107,6 +104,16 @@ web-sys = { version = "0.3.83", optional = true, features = [
   "console",
 ]}
 
+## non-wasm dependencies
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+aws-sdk-s3 = { version = "1.119", default-features = false, optional = true }
+aws-config = { version = "1.8", default-features = false, features = ["rt-tokio", "behavior-version-latest"], optional = true }
+aws-credential-types = { version = "1", default-features = false, features = ["hardcoded-credentials"], optional = true }
+aws-smithy-runtime-api = { version = "1.9", default-features = false, optional = true }
+aws-smithy-types = { version = "1.3", default-features = false, optional = true }
+google-cloud-storage = { version = "0.24.0", default-features = false, features = ["rustls-tls", "auth"], optional = true }
+reqwest-middleware = { version = "0.4", optional = true }
+
 ## common dev-dependencies
 [dev-dependencies]
 tempfile = "3"
@@ -121,6 +128,6 @@ wasm-bindgen-test = "0.3"
 
 ## non-wasm dev-dependencies
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-# proptest requires getrandom, which is not supported on WASM
+# proptest has a number of non-WASM-compatible requirements
 proptest = "^1.9.0"
 httptest = "0.16"

--- a/src/crate-doc.md
+++ b/src/crate-doc.md
@@ -89,6 +89,7 @@ By default, `sync`, `storage`, `bundled`, and `tls-webpki-roots` are enabled.
 TaskChampion can be built for WASM with the usual WASM tools, such as
 `wasm-pack`. Only the following features are supported:
 
+ * `server-sync` - communicate with the sync server using the Fetch API
  * `storage-indexeddb` - store task data in the browser using IndexedDB (WASM only)
 
 # See Also

--- a/src/server/cloud/mod.rs
+++ b/src/server/cloud/mod.rs
@@ -7,6 +7,9 @@
 * chain of versions, even if multiple replicas attempt to sync at the same time.
 */
 
+#[cfg(target_arch = "wasm32")]
+compile_error!("Cloud servers are not available on WASM targets");
+
 mod iter;
 mod server;
 mod service;

--- a/src/server/cloud/server.rs
+++ b/src/server/cloud/server.rs
@@ -370,7 +370,7 @@ impl<SVC: Service> CloudServer<SVC> {
     }
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 impl<SVC: Service + Send> Server for CloudServer<SVC> {
     async fn add_version(
         &mut self,

--- a/src/server/encryption.rs
+++ b/src/server/encryption.rs
@@ -27,6 +27,7 @@ impl Cryptor {
     }
 
     /// Generate a suitable random salt.
+    #[cfg(any(test, feature = "cloud"))] // server-sync uses the clientId as the salt.
     pub(super) fn gen_salt() -> Result<Vec<u8>> {
         let rng = rand::SystemRandom::new();
         let mut salt = [0u8; 16];

--- a/src/server/http.rs
+++ b/src/server/http.rs
@@ -3,11 +3,12 @@
 //! This contains some utilities to make using `reqwest` easier, including getting
 //! the correct TLS certificate store.
 
-use std::time::Duration;
-
 use crate::errors::Result;
 
-#[cfg(not(any(feature = "tls-native-roots", feature = "tls-webpki-roots")))]
+#[cfg(all(
+    not(target_arch = "wasm32"),
+    not(any(feature = "tls-native-roots", feature = "tls-webpki-roots"))
+))]
 compile_error!(
     "Either feature \"tls-native-roots\" or \"tls-webpki-roots\" must be enabled for HTTP client support."
 );
@@ -15,7 +16,9 @@ compile_error!(
 static USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"),);
 
 /// Create a new [`reqwest::Client`] with configuration appropriate to this library.
+#[cfg(not(target_arch = "wasm32"))]
 pub(super) fn client() -> Result<reqwest::Client> {
+    use std::time::Duration;
     let client = reqwest::Client::builder()
         .use_rustls_tls()
         .user_agent(USER_AGENT)
@@ -28,6 +31,18 @@ pub(super) fn client() -> Result<reqwest::Client> {
     let client = client.tls_built_in_native_certs(true);
     #[cfg(all(feature = "tls-webpki-roots", not(feature = "tls-native-roots")))]
     let client = client.tls_built_in_webpki_certs(true);
+
+    Ok(client.build()?)
+}
+
+/// Create a new [`reqwest::Client`] with configuration appropriate to this library.
+///
+/// On WASM, this uses the Fetch API.
+#[cfg(target_arch = "wasm32")]
+pub(super) fn client() -> Result<reqwest::Client> {
+    let client = reqwest::Client::builder().user_agent(USER_AGENT);
+
+    // Timeouts and TLS cannot be configured via the Fetch API.
 
     Ok(client.build()?)
 }

--- a/src/server/local/mod.rs
+++ b/src/server/local/mod.rs
@@ -109,7 +109,7 @@ impl LocalServer {
     }
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 impl Server for LocalServer {
     // TODO: better transaction isolation for add_version (gets and sets should be in the same
     // transaction)

--- a/src/server/sync/mod.rs
+++ b/src/server/sync/mod.rs
@@ -10,11 +10,6 @@ use uuid::Uuid;
 
 use super::encryption::{Cryptor, Sealed, Secret, Unsealed};
 
-#[cfg(not(any(feature = "tls-native-roots", feature = "tls-webpki-roots")))]
-compile_error!(
-    "Either feature \"tls-native-roots\" or \"tls-webpki-roots\" must be enabled for TLS support."
-);
-
 pub(crate) struct SyncServer {
     base_url: Url,
     client_id: Uuid,
@@ -122,7 +117,7 @@ async fn sealed_from_resp(
     }
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 impl Server for SyncServer {
     async fn add_version(
         &mut self,
@@ -243,7 +238,9 @@ impl Server for SyncServer {
     }
 }
 
-#[cfg(test)]
+// httptest is not available on WASM32, so do not build these tests
+// on that platform (they wouldn't run anyway!).
+#[cfg(all(not(target_arch = "wasm32"), test))]
 mod test {
     use super::*;
     use crate::Server as ServerTrait;

--- a/src/server/test.rs
+++ b/src/server/test.rs
@@ -66,7 +66,7 @@ impl TestServer {
     }
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 impl Server for TestServer {
     /// Add a new version.  If the given version number is incorrect, this responds with the
     /// appropriate version and expects the caller to try again.

--- a/src/server/types.rs
+++ b/src/server/types.rs
@@ -51,7 +51,7 @@ pub enum GetVersionResult {
 }
 
 /// A value implementing this trait can act as a server against which a replica can sync.
-#[async_trait]
+#[async_trait(?Send)]
 pub trait Server {
     /// Add a new version.
     ///


### PR DESCRIPTION
This supports server-sync with few changes by virtue of reqwest's WASM support.

The `wasm-pack test` machinery does not support starting a test server reachable from the browser, so there is no practical way to test this functionality on this platform. Since the implementation differs only slightly from that for non-web platforms, this is acceptable.

I experimented with supporting the cloud sync backends as well. I was able to get AWS working, at the cost of some shenanigans around Send and non-Send futures. However, GCP appears impossible. The current `google_cloud_storage` version we are using unconditionally requires `tokio` and its I/O features, which means `mio` which does not build on WASM. The newer and completely rewritten (see note in [the docs](https://docs.rs/google-cloud-storage/latest/google_cloud_storage/)) version of `google_cloud_storage` does not allow supplying an HTTP client, and thus also requires `mio`. Even if we could build these libraries for WASM, they would likely be huge and impractical to download and run in a web browser.

I think we should ship TaskChampion 3.0.0 without WASM cloud support, and then think of alternatives to support this. The binary size of the cloud libraries is also a problem on regular POSIX and Windows systems, so perhaps some kind of external interface would be best.