### PR TITLE
relax restrictions on tag chars after first, following TaskWarrior

### DIFF
--- a/src/task/tag.rs
+++ b/src/task/tag.rs
@@ -5,7 +5,7 @@ use std::str::FromStr;
 /// A Tag is a descriptor for a task, that is either present or absent, and can be used for
 /// filtering.  Tags composed of all uppercase letters are reserved for synthetic tags.
 ///
-/// Valid tags must not contain whitespace or any of the characters in `+-*/()<>^! %=~`.
+/// Valid tags must not contain whitespace or any of the characters in `+-*/()<>^!%=~`.
 /// The first characters additionally cannot be a digit, and subsequent characters cannot be `:`.
 /// This definition is based on [that of
 /// TaskWarrior](https://github.com/GothenburgBitFactory/taskwarrior/blob/663c6575ceca5bd0135ae884879339dac89d3142/src/Lexer.cpp#L146-L164).
@@ -20,7 +20,7 @@ pub(super) enum TagInner {
 }
 
 // see doc comment for Tag, above
-pub(crate) const INVALID_TAG_CHARACTERS: &str = "+-*/()<>^! %=~";
+pub(crate) const INVALID_TAG_CHARACTERS: &str = "+-*/()<>^!%=~";
 
 impl Tag {
     /// True if this tag is a synthetic tag

--- a/src/task/tag.rs
+++ b/src/task/tag.rs
@@ -5,7 +5,7 @@ use std::str::FromStr;
 /// A Tag is a descriptor for a task, that is either present or absent, and can be used for
 /// filtering.  Tags composed of all uppercase letters are reserved for synthetic tags.
 ///
-/// Valid tags must not contain whitespace or any of the characters in `+-*/(<>^! %=~`.
+/// Valid tags must not contain whitespace or any of the characters in `+-*/()<>^! %=~`.
 /// The first characters additionally cannot be a digit, and subsequent characters cannot be `:`.
 /// This definition is based on [that of
 /// TaskWarrior](https://github.com/GothenburgBitFactory/taskwarrior/blob/663c6575ceca5bd0135ae884879339dac89d3142/src/Lexer.cpp#L146-L164).
@@ -20,7 +20,7 @@ pub(super) enum TagInner {
 }
 
 // see doc comment for Tag, above
-pub(crate) const INVALID_TAG_CHARACTERS: &str = "+-*/(<>^! %=~";
+pub(crate) const INVALID_TAG_CHARACTERS: &str = "+-*/()<>^! %=~";
 
 impl Tag {
     /// True if this tag is a synthetic tag

--- a/src/task/task.rs
+++ b/src/task/task.rs
@@ -788,7 +788,10 @@ mod test {
                 (String::from("tag_ok"), String::from("")),
                 (String::from("tag_"), String::from("")),
                 (String::from("tag_123"), String::from("")),
+                (String::from("tag_!!a"), String::from("")),
                 (String::from("tag_a!!"), String::from("")),
+                (String::from("tag_\u{1f980}a"), String::from("")),
+                (String::from("tag_\u{1f980}"), String::from("")),
             ]
             .drain(..)
             .collect(),
@@ -801,9 +804,12 @@ mod test {
         assert_eq!(
             tags,
             HashSet::from([
-                utag("ok"),
                 stag(SyntheticTag::Pending),
-                stag(SyntheticTag::Unblocked)
+                utag("a!!"),
+                utag("\u{1f980}a"),
+                utag("\u{1f980}"),
+                stag(SyntheticTag::Unblocked),
+                utag("ok"),
             ])
         );
     }

--- a/src/task/task.rs
+++ b/src/task/task.rs
@@ -187,9 +187,11 @@ impl Task {
             .filter_map(|k| {
                 if let Some(tag) = k.strip_prefix("tag_") {
                     if let Ok(tag) = tag.try_into() {
+                        trace!("success with tag {tag}");
                         return Some(tag);
                     }
                     // note that invalid "tag_*" are ignored
+                    trace!("skipped tag {tag}");
                 }
                 None
             })
@@ -780,20 +782,19 @@ mod test {
 
     #[test]
     fn test_get_tags_invalid_tags() {
-        let task = Task::new(
-            TaskData::new(
-                Uuid::new_v4(),
-                vec![
-                    (String::from("tag_ok"), String::from("")),
-                    (String::from("tag_"), String::from("")),
-                    (String::from("tag_123"), String::from("")),
-                    (String::from("tag_a!!"), String::from("")),
-                ]
-                .drain(..)
-                .collect(),
-            ),
-            dm(),
+        let taskdata = TaskData::new(
+            Uuid::new_v4(),
+            vec![
+                (String::from("tag_ok"), String::from("")),
+                (String::from("tag_"), String::from("")),
+                (String::from("tag_123"), String::from("")),
+                (String::from("tag_a!!"), String::from("")),
+            ]
+            .drain(..)
+            .collect(),
         );
+        trace!("{:?}", taskdata);
+        let task = Task::new(taskdata, dm());
 
         // only "ok" is OK
         let tags: HashSet<_> = task.get_tags().collect();


### PR DESCRIPTION
This patch just allows the second and following chars for a tag to be anything except whitespace, which follows what TaskWarrior will be doing soon.

Restrictions remain on the first char.

A couple typos in the invalid char list are also fixed.

See https://github.com/GothenburgBitFactory/taskwarrior/pull/3961#pullrequestreview-3277625253
