### PR TITLE
Wait for wrapped storage to be dropped

### DIFF
--- a/src/storage/sqlite/mod.rs
+++ b/src/storage/sqlite/mod.rs
@@ -41,7 +41,6 @@ impl ToSql for StoredUuid {
 }
 
 /// SqliteStorage stores task data in a file on disk.
-#[derive(Clone)]
 pub struct SqliteStorage(Wrapper);
 
 impl SqliteStorage {


### PR DESCRIPTION
This removes the unnecessary `Clone` implementation from SqliteStorage, since JoinHandle is not clonable. I'm not sure why that was added. `SqliteStorage` did not implement `Clone` in 2.x, so I think we can "cheat" and remove this implementation in 3.0.1.

I've confirmed that this fixes the `test/read-only.test.py` tests in Taskwarrior.