### PR TITLE
Add dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,15 +6,21 @@
 
 version: 2
 updates:
- - package-ecosystem: "devcontainers"
-   directory: "/"
-   schedule:
-     interval: weekly
+  - package-ecosystem: "devcontainers"
+    directory: "/"
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        patterns: ["*"]
   # Enable version updates for GitHub actions
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      submodule:
+        patterns: ["*"]
   # Enable updates for Rust packages
   - package-ecosystem: "cargo"
     directory: "/" # Location of package manifests
@@ -24,9 +30,8 @@ updates:
       semver-minor-days: 7
     schedule:
       interval: "daily"
-    ignore:
-      # skip patch updates, as they can be quite noisy, but keep
-      # minor and major updates so that we don't fall too far
-      # behind
-      - dependency-name: "*"
-        update-types: ["version-update:semver-patch"]
+    groups:
+      cargo:
+        patterns: ["*"]
+        # leave major changes in their own PRs
+        update-types: ["minor", "patch"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,10 @@ updates:
   # Enable updates for Rust packages
   - package-ecosystem: "cargo"
     directory: "/" # Location of package manifests
+    cooldown:
+      default-days: 5
+      semver-major-days: 30
+      semver-minor-days: 7
     schedule:
       interval: "daily"
     ignore:


### PR DESCRIPTION
This prevents dependabot from proposing an update soon after it is released. This helps avoid buggy updates, and also provides adequate time for "supply chain attacks" to be discovered and yanked.