### PR TITLE
Iterative tasks proof of concept

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -572,6 +572,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf",
+]
+
+[[package]]
 name = "cmov"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -551,6 +551,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1690,6 +1700,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2043,6 +2071,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rrule"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "720acfb4980b9d8a6a430f6d7a11933e701ebbeba5eee39cc9d8c5f932aaff74"
+dependencies = [
+ "chrono",
+ "chrono-tz",
+ "log",
+ "regex",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "rstest"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2351,6 +2392,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "siphasher"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2487,6 +2534,7 @@ dependencies = [
  "reqwest",
  "reqwest-middleware",
  "ring",
+ "rrule",
  "rstest",
  "rusqlite",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -608,6 +608,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf",
+]
+
+[[package]]
 name = "cmov"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1840,6 +1850,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2203,6 +2231,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rrule"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "720acfb4980b9d8a6a430f6d7a11933e701ebbeba5eee39cc9d8c5f932aaff74"
+dependencies = [
+ "chrono",
+ "chrono-tz",
+ "log",
+ "regex",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "rstest"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2532,6 +2573,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2576,6 +2623,12 @@ dependencies = [
  "thiserror 2.0.18",
  "time",
 ]
+
+[[package]]
+name = "siphasher"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "slab"
@@ -2696,8 +2749,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sys-locale"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eab9a99a024a169fe8a903cf9d4a3b3601109bcc13bd9e3c6fff259138626c4"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "taskchampion"
-version = "3.1.1-pre"
+version = "4.0.0-pre"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2721,6 +2783,7 @@ dependencies = [
  "reqwest",
  "reqwest-middleware",
  "ring",
+ "rrule",
  "rstest",
  "rusqlite",
  "serde",
@@ -2730,6 +2793,7 @@ dependencies = [
  "strum",
  "strum_macros",
  "tempfile",
+ "text2rrule",
  "thiserror 2.0.18",
  "tokio",
  "url",
@@ -2751,6 +2815,17 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "text2rrule"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91525d6ce517e51341955c5f99fb2a21aef3f1efafc60e619c343633374e8eee"
+dependencies = [
+ "chrono",
+ "sys-locale",
+ "tracing",
 ]
 
 [[package]]
@@ -3074,6 +3149,7 @@ dependencies = [
  "getrandom 0.4.3",
  "js-sys",
  "serde_core",
+ "sha1_smol",
  "wasm-bindgen",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,7 @@ tokio = { version = "1", features = ["macros", "sync", "rt"] }
 thiserror = "2.0"
 uuid = { version = "^1.23.0", features = ["serde", "v4"] }
 url = { version = "2", optional = true }
+rrule = "0.14.0"
 
 ## wasm-only dependencies.
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ resolver = "2"
 crate-type = ["cdylib", "rlib"]
 
 [features]
-default = ["sync", "bundled", "storage", "tls-webpki-roots"]
+default = ["sync", "bundled", "storage", "tls-webpki-roots", "iterative-tasks"]
 
 # Support for all sync solutions
 sync = ["server-sync", "server-gcp", "server-aws", "server-local", "server-git"]
@@ -50,6 +50,8 @@ server-aws = [
 server-local = ["dep:rusqlite"]
 # Support for sync via Git
 server-git = ["dep:serde_with", "dep:glob", "encryption"]
+# Support for iterative (recurring) tasks
+iterative-tasks = ["dep:rrule"]
 
 # Support for all task storage backends (except indexeddb, which only works on WASM builds)
 storage = ["storage-sqlite"]
@@ -96,7 +98,7 @@ tokio = { version = "1", features = ["macros", "sync", "rt"] }
 thiserror = "2.0"
 uuid = { version = "^1.23.1", features = ["serde", "v4"] }
 url = { version = "2", optional = true }
-rrule = "0.14.0"
+rrule = { version = "0.14.0", optional = true }
 glob = { version = "0.3.3", optional = true }
 
 ## wasm-only dependencies.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taskchampion"
-version = "3.1.1-pre"
+version = "4.0.0-pre"
 authors = ["Dustin J. Mitchell <dustin@mozilla.com>"]
 description = "Personal task-tracking"
 homepage = "https://gothenburgbitfactory.github.io/taskchampion/"
@@ -21,7 +21,7 @@ resolver = "2"
 crate-type = ["cdylib", "rlib"]
 
 [features]
-default = ["sync", "bundled", "storage", "tls-webpki-roots"]
+default = ["sync", "bundled", "storage", "tls-webpki-roots", "iterative-tasks"]
 
 # Support for all sync solutions
 sync = ["server-sync", "server-gcp", "server-aws", "server-local", "server-git"]
@@ -50,6 +50,8 @@ server-aws = [
 server-local = ["dep:rusqlite"]
 # Support for sync via Git
 server-git = ["dep:serde_with", "dep:glob", "encryption"]
+# Support for iterative (recurring) tasks
+iterative-tasks = ["dep:rrule", "dep:text2rrule"]
 
 # Support for all task storage backends (except indexeddb, which only works on WASM builds)
 storage = ["storage-sqlite"]
@@ -94,8 +96,10 @@ strum = "0.28"
 strum_macros = "0.28"
 tokio = { version = "1", features = ["macros", "sync", "rt"] }
 thiserror = "2.0"
-uuid = { version = "^1.23.2", features = ["serde", "v4"] }
+uuid = { version = "^1.23.2", features = ["serde", "v4", "v5"] }
 url = { version = "2", optional = true }
+rrule = { version = "0.14.0", optional = true }
+text2rrule = { version = "0.1.2", optional = true }
 glob = { version = "0.3.3", optional = true }
 
 ## wasm-only dependencies.
@@ -127,8 +131,13 @@ web-sys = { version = "0.3.83", optional = true, features = [
 ## non-wasm dependencies
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 aws-sdk-s3 = { version = "1.134", default-features = false, optional = true }
-aws-config = { version = "1.8", default-features = false, features = ["rt-tokio", "behavior-version-latest"], optional = true }
-aws-credential-types = { version = "1", default-features = false, features = ["hardcoded-credentials"], optional = true }
+aws-config = { version = "1.8", default-features = false, features = [
+  "rt-tokio",
+  "behavior-version-latest",
+], optional = true }
+aws-credential-types = { version = "1", default-features = false, features = [
+  "hardcoded-credentials",
+], optional = true }
 aws-smithy-runtime-api = { version = "1.12", default-features = false, optional = true }
 aws-smithy-types = { version = "1.4", default-features = false, optional = true }
 google-cloud-storage = { version = "0.24.0", default-features = false, features = [

--- a/docs/src/iterative-tasks.md
+++ b/docs/src/iterative-tasks.md
@@ -1,0 +1,126 @@
+# TaskChampion Iterative Tasks
+
+There are several issues with how the TaskWarrior/TaskChampion ecosystem handles recurring tasks. See the TaskWarrior [issue list](https://github.com/GothenburgBitFactory/taskwarrior/issues?q=is%3Aissue%20state%3Aopen%20label%3Atopic%3Arecurrence) for examples.
+
+This proposal is for a significant redesign of the recurrence system, with a different set of trade offs. Therefore, it is currently being proposed in a way that it could either replace or live alongside the current recurring task system.
+
+### Nomenclature
+
+In order to help keep things clear and for a few technical reasons, the proposed system will be referred to as iterative tasks, while the current system will be referred to as recurring tasks.
+
+## Iterative Tasks Main Ideas
+
+The major components of the iterative task system are:
+
+- 1. Iteration handling in TaskChampion
+- 2. New task status
+- 3. Iteration Types
+- 4. RRULE based iteration scheduling
+- 5. Iterative task flow
+
+### Iteration Handling in TaskChampion
+
+Currently, task recurrence is handled by the various frontends: primarily TaskWarrior, but also the mobile apps, web apps, and other platforms. This means that each frontend has to implement their own recurrence handler, each with its own quirks and syncing issues.
+
+Task iteration will be handled in TaskChampion, as discussed in [issue 595](https://github.com/GothenburgBitFactory/taskchampion/issues/595). This will primarily be done in the Task struct with additions to the constructor and set_status functions. This does mean that frontends that primarily rely on the underlying TaskData struct will miss out on task iteration.
+
+The frontends will see iterative tasks as normal tasks, with due, start, wait, end, and other properties as expected. The primary difference will be the new Iterative status and a few UDAs.
+
+### New Task Status
+
+A new task status will be created, Iterative, for iterative tasks. This will prevent current recurrence code from interfering with the iteration system and vice versa.
+
+Note: This could be changed, see [Upgrading](#Upgrading) for more discussion.
+
+### Iteration Types
+
+There are several styles of iteration used in todo applications generally, but two stand out as most common:
+
+#### Fixed Interval
+
+When a fixed interval task is completed, the next due date is set to the next interval from when it was originally due. As an example, if rent is due on the 20th of the month, the next due date will be on the 20th of the next month, regardless of if I paid it on the 15th, the 20th or the 25th.
+
+This does invite the question of how to handle tasks that are overdue by more than their iteration period. If I missed January and February's payments, should completing the task once move the next due date to February 20th or March 20th? Lets call just moving to the next interval "fixed" and the next interval in the future "fixed+"
+
+#### Chained
+
+When a chained interval task is completed, the next due date is set to the next interval from when it was completed. As an example, if I normally get a haircut every six weeks and I got one today, my next one should be six weeks from today, even if I got this one three weeks late, or two days early.
+
+In order to handle these iteration styles, an "iter_type" UDA will be added, which can be one of "fixed", "fixed+", and "chained".
+
+### RRULE Based Iteration Definition
+
+There are a lot of ways to define iteration periods, which can be extremely complex. "Every four years on the second Tuesday in November", "The first weekday that isn't a Monday, on or after the 15th of April", and "Weekly on Monday, Tuesday, Thursday and Friday, except for the third Friday of the month" are all things that I have to deal with.
+
+Implementing those kinds of rules is difficult, but luckily RFC 5545 Section 3.8.5.3 exists for just this kind of thing. RRules are capable of representing many, though of course not all, iteration periods and there is a well tested RRule library for Rust.
+
+Combining RRules with the iteration types will take a bit of though. Fixed and fixed+ is easy enough, but in order to do chained it will be necessary to modify the DTSTART rule upon task completion.
+
+#### RRule Generation
+
+For all advantages of RRules, they are a unique syntax that no one wants to write regularly. There are plain English (or other languages?) to RRule parsers for several programming languages, though not Rust. Looking at the current supported recurrence frequencies, they all map to RRules in a simple mechanical way. We could start with a simple parser that covers the current set, then expand it in the future.
+
+This would happen in the following phases:
+
+1. Map current recur values to Rrules. This is a straightforward mechanical mapping.
+2. Simple descriptions: every Monday, Every six weeks, alternate Thursdays, etc
+3. Compound descriptions: Every Monday, Wednesday, and Sunday. The last Friday of every month, etc
+4. (maybe) Fuzzy descriptions and calculated holidays
+
+### Iterative Task Flow
+
+An iterative task consists of a single task object, like any other task. In general, an Iterative task will be handled the same as any other task, except at two points during its lifetime. To put too fine a point on it, Iterative tasks do not need any special handling like recurring tasks do, outside of two places that TaskChampion deals with.
+
+#### Creation / Status Change
+
+When an Iterative take is created, it must have Iterative as its status and an ‘iter’ entry, similar to a recurring task. When Task::new is invoked, the 'iter', 'start', 'end', and 'until' will be parsed into an RRule and set as a 'rrule' UDA. The first due date will be calculated, if not already set, along with any other properties needed. At this point, an iterative task acts the same as any other task
+
+If a task is changed from some other status to iterative using the Task::change_status function, the same logic as creation is followed.
+
+#### Done
+
+The second time that an Iterative task has special handling is when it has its status set to “Completed” using Task::set_status or Task::done.
+
+First, a copy of the task will be created, with a new UUID and a “Completed” status. It will also have a link back to the original iterative task via the 'parent' UUID attribute. This is similar to the TaskWarrior ’log’ command.
+
+Second, the next due date and wait are calculated from the RRule. For fixed or fixed+ styles, this is a single RRule library call. For chained, it requires updating the RRULEs DTSTART before calling.
+
+Yes, this is basically an inversion of the current recurring system, where a hidden “parent” task spawns new pending tasks. The advantage is that since the spawned tasks are completed, it’s not possible to end up with multiple pending tasks that are all copies of each other. In case of a sync issue, there may be multiple copies of completed tasks, but that is far less important. Iterative tasks also require less special handling, as there is no need to hide a parent task most of the time and then still have a way to find it when the user wants to edit or delete it.
+
+### Integration With TaskWarrior
+
+Integration with TaskChampion primarily involves adding the new Iterative status, handling hooks in task creation and status change, and the RRule generator.
+
+Integration with TaskWarrior will require adding the new Iterative status so that Iterative tasks are visible, and ‘iter’ as a built in UDA.
+
+## Potential Issues and Limitations
+
+There are a few potential issues with this approach
+
+### Legacy Applications
+
+First, pre-3.0 based applications are completely left out as all iterative functionality is implemented in TaskChampion.
+
+Second, all applications that haven’t been updated to recognize the Iterative status may hide or mishandle Iterative tasks. The biggest issue is likely to be marking an Iterative task done and then losing it as an iterative task. If that happens, it will disappear from that client's perspective and the iteration never advances. There are a few possible mitigations, such as a secondary UDA flag that legacy clients wouldn't set, but this might just need to be documented as a possible issue during a transition phase. This is the largest risk in the proposal.
+
+### RRule Modification
+
+Modifying the RRule on task completion for chained tasks does make the RRule history inconsistent. Searching for things like “give me the last five dates this was done” will need to be done by searching the spawned completed tasks rather than just back calculating the RRule. This is almost certainly a minor issue for almost all use cases.
+
+### Multiple Upcoming Tasks
+
+The recurring task system supports having multiple open upcoming tasks based on the recurring template task. Iterative tasks don’t support that, but calculating the next arbitrary number of due dates is trivial, which should cover most use cases.
+
+## Alternatives
+
+### Upgrading
+
+One possible alternative to maintaining two separate systems for periodic tasks would be to upgrade existing recurring tasks to the new system.
+
+The first approach would be to have TaskChampion just start treating recurring tasks as iterative tasks. This would need to be a major breaking version, as using task recurrence with legacy tools would cause many problems.
+
+The second would be to have TaskChampion migrate existing recurring tasks to iterative tasks. This could be done, but should only be an option if specificity requested.
+
+### Just Moving Recurrence Handling
+
+It would be possible to move the current recurrence system to TaskChampion, either as is of with the changes suggested in the [abandoned RFC](https://github.com/GothenburgBitFactory/taskwarrior/blob/develop/doc/devel/rfcs/recurrence.md). This would be simpler in several ways, but would still have most of the same backwards compatibility issues and not fix many of the known problems with recurring tasks.

--- a/docs/src/iterative-tasks.md
+++ b/docs/src/iterative-tasks.md
@@ -1,0 +1,152 @@
+# TaskChampion Iterative Tasks
+
+Iterative tasks are a feature for handling repeating tasks inside of TaskChampion that can replace or live alongside TaskWarrior's recurring system.
+
+The primary goals are:
+
+- 1. Provide a more intuitive repeating task model
+- 2. Handle synchronizing repeating tasks across replicas cleanly
+- 3. Support any TaskChampion front end
+- 4. Fix many of TaskWarrior's recurring tasks [issues](https://github.com/GothenburgBitFactory/taskwarrior/issues?q=is%3Aissue%20state%3Aopen%20label%3Atopic%3Arecurrence)
+
+### Nomenclature
+
+In order to help keep things clear and for a few technical reasons, the new system is referred to as `Iterative` tasks, while the current system is referred to as `Recurring` tasks.
+
+## Iterative Tasks Main Ideas
+
+The major components of the iterative task system are:
+
+- 1. Iteration handling in TaskChampion
+- 2. New task status
+- 3. Iteration Types
+- 4. RRULE based iteration scheduling
+- 5. Iterative task flow
+
+### Iteration Handling in TaskChampion
+
+All task iteration is handled in TaskChampion. Front ends like TaskWarrior only need to be updated to accept the new `Iterative` task status and call the provided `Task::set_status()/done()` functions instead of directly manipulating raw `TaskData`.
+
+### New Task Status
+
+A new task status, Iterative, is used for iterative tasks. This prevents current recurrence code from interfering with the iteration system and vice versa.
+
+### Iteration Interval Types
+
+There are three types of iteration supported by iterative tasks.
+
+#### Fixed
+
+When a `fixed` interval task is completed, the next due date is set to the next interval from when it was originally due. As an example, if rent is due on the 20th of the month, the next due date will be on the 20th of the next month, regardless of if I paid it on the 15th, the 20th or the 25th. These are called "fixed" tasks.
+
+#### Fixed+
+
+When a `fixed+` interval task is completed, the next due date is set to the next interval from when it was originally due _on or after right now_. For example, if I have to take out the garbage bins every week but miss two because I'm on vacation, I shouldn't take them out multiple days in a row to make up for it.
+
+#### Chained
+
+When a chained interval task is completed, the next due date is set to the next interval from when it was completed. As an example, if I normally get a haircut every six weeks and I got one today, my next one should be six weeks from today, even if I got this one three weeks late, or two days early.
+
+In order to handle these iteration styles, an "iter_type" UDA is added, which can be one of "fixed", "fixed+", and "chained".
+
+### Dates and Counts
+
+TaskWarrior defines four optional date fields that interact with iterative tasks.
+
+- `due` - The hard date that a task must be completed by. e.g. rent is due on the 15th.
+- `scheduled` - The date after which a task can be done. e.g. Christmas decorations can't be put up until after Thanksgiving
+- `wait` - Hides a task until after the `wait` so as to not clutter up the task list.
+- `until` - Unfortunately the meaning for this field is overloaded for recurrence and normal tasks. For a recurring task, this is the end of the recurrence period. For a normal task this is when a task will be closed because the deadline was missed by too much. Iterative tasks take the normal-task interpretation. Responsibility for closing a task that is past its `until` belongs to the front ends, not TaskChampion. A series end date is instead handled by the rrule's `UNTIL` option.
+
+TaskWarrior assumes but does not strictly enforce that `due` >= `scheduled` >= `wait`, i.e. a task should be `due` after it is `scheduled`, and shouldn't be either of those while `wait`ing.
+
+When an iterative task is closed, the `due`, `scheduled`, and `wait` are all advanced by the same amount of time if they exist. The advancement period is calculated for the highest priority date, and then the others are moved forward by the same time delta. This preserves the spacing between the three dates.
+
+Finally, RRules support a `COUNT` that limits the number of times a task iterates. Each iterative task records its position in the series in an `iter_count` UDA. When that count reaches the rule's `COUNT` no successor is created, ending the series after the intended number of iterations.
+
+### RRULE Based Iteration Definition
+
+There are a lot of ways to define iteration periods, which can be extremely complex. "Every four years on the second Tuesday in November", "The first weekday that isn't a Monday, on or after the 15th of April", and "Weekly on Monday, Tuesday, Thursday and Friday, except for the third Friday of the month" are all things that I have to deal with.
+
+Implementing those kinds of rules is difficult, but luckily RFC 5545 Section 3.8.5.3 exists for just this kind of thing. RRules are capable of representing many, though of course not all, iteration periods and there is a well tested RRule library for Rust.
+
+Combining RRules with the iteration types takes a bit of thought. The rule is stored in an unbaked, anchor-independent form (no `DTSTART`). The anchor is the task's highest-priority date (`due` > `scheduled` > `wait`). On completion the rule is re-anchored to compute the next occurrence for that date: fixed anchors off the current anchor date, fixed+ also anchors off the anchor date but advances to the next occurrence on or after now, and chained anchors off the completion time ("now"). The remaining dates then shift by the same delta, as described above.
+
+#### RRule Generation
+
+For all advantages of RRules, they are a unique syntax that (almost) no one wants to write regularly. The `iter` value is therefore accepted in three flavors:
+
+1. TaskWarrior-style shorthand: The same style as the recurring tasks: `daily`, `3wk`, `weekdays`, `fortnight`, `2year`, etc. These are mapped mechanically to RRules by a built-in parser.
+2. Free-form natural language: handled by the [`text2rrule`](https://crates.io/crates/text2rrule) crate. Phrases such as `every Monday`, `every other Tuesday`, or `every two weeks on friday` are parsed into an RRULE string and then into an `RRule` value. `text2rrule` supports multiple locales.
+3. Raw RRules, for people who wish to use them directly.
+
+Parsing tries a raw RRULE first, then the shorthand parser, then `text2rrule`, so existing `recur` values keep working unchanged.
+
+### Iterative Task Flow
+
+At any moment a series has one live Iterative task object, handled like any other task. Each time it is completed it is replaced by a successor with a new UUID, so the live UUID advances over the life of the series. The completed instances remain as records. A `series` attribute (see below) ties all instances together. Iterative tasks need special handling in only two places.
+
+#### Creation / Status Change
+
+When an Iterative task is created, it must have Iterative as its status and a non-empty `iter` entry, similar to a recurring task. When the status is set to Iterative (via `Task::new` or `Task::set_status`), the `iter` value is parsed into an RRule and stored, in unbaked form, as an `rrule` UDA. A `series` attribute is also stamped, set to the task's own UUID if not already present. Every later instance in the series carries this same value. An `iter_count` attribute is stamped to 1, marking this as the first instance, each successor increments it. Because the rule is re-baked from `iter` every time the status is set to Iterative, editing `iter` and re-asserting the status updates the schedule.
+
+The first date is chosen as follows:
+
+- If the caller has already set `due`, `scheduled`, or `wait` on the task before the transition, the highest priority value is used as the first anchor date and is preserved exactly.
+- If none of those are set, the first `due` date is the first RRule occurrence on or after now. For example, with `iter = weekdays` on a Saturday, the first due date will be the following Monday. With `iter = weekly` on any day, the first due date will be that same day.
+
+If `iter_type` is not set, it defaults to `chained`. At this point, an iterative task acts the same as any other task.
+
+#### Done
+
+The second time that an Iterative task has special handling is when it has its status set to “Completed” using Task::set_status or Task::done.
+
+The iterative task closes itself spawns its successor, a new Iterative task for the next occurrence. The successor's UUID is derived deterministically as a UUIDv5 from the completed task's UUID (`v5(ITERATIVE_NAMESPACE, completed_uuid)`), so two replicas completing the same task before syncing derive the same successor UUID and converge rather than producing duplicates. The successor's `prior` points at the task it succeeded, forming a chain, and it carries the same `series` value as every other instance.
+
+The attribute changes, where `self` is the task being completed and `successor` is the new instance:
+
+| Attribute              | `self`         | `successor`        |
+| ---------------------- | -------------- | ------------------ |
+| status                 | Completed      | Iterative          |
+| end                    | now            | none               |
+| start                  | unchanged      | none               |
+| entry                  | unchanged      | now                |
+| prior                  | unchanged      | `self`'s UUID      |
+| series                 | unchanged      | copied from `self` |
+| iter_count             | unchanged      | `self`'s + 1       |
+| iter, rrule, iter_type | none (cleared) | copied from `self` |
+| dep\_<UUID>            | unchanged      | none               |
+| modified               | now            | now                |
+| all others             | unchanged      | copied from `self` |
+
+Because the task the dependents point at is the one that becomes Completed, dependent tasks are unblocked automatically with no dep rewriting. This means completion only ever changes the task itself and the successor it creates.
+
+The successor's `due`, `scheduled` and `wait` dates are computed from the stored rule, re-anchored per iteration type. The anchor is the highest-priority date. Once its next value is computed, the remainder shift by the same delta so their spacing is preserved:
+
+- fixed anchors off the current anchor date
+- fixed+ anchors off the anchor date but advancing to the next occurrence on or after now
+- chained anchors off the completion time.
+
+If the rule carries a `COUNT`, the successor's `iter_count` is one greater than the completed instance's, and the series ends once an instance's `iter_count` reaches the `COUNT`. The rule is copied unchanged.
+
+Note: because completing a task makes its own status `Completed`, the handle used to complete it now refers to the completed occurrence.
+
+This is basically an inversion of the recurring system, where a hidden “parent” task spawns new pending tasks. The advantage is that there is only ever one live task in a series, so it is not possible to end up with multiple pending tasks that are all copies of each other. With the deterministic successor UUID, two replicas completing the same task before syncing converge to a single completed task and a single successor rather than diverging. Iterative tasks also require less special handling in the codebase, as there is no hidden parent template to maintain.
+
+## Issues and Limitations
+
+### Legacy Applications
+
+Pre-3.0 based applications are completely left out as all iterative functionality is implemented in TaskChampion.
+
+All applications that haven’t been updated to recognize the Iterative status may hide or mishandle Iterative tasks. The biggest issue is likely to be marking an Iterative task done and then losing it as an iterative task. If that happens, it will disappear from that client's perspective and the iteration never advances.
+
+### Scheduling Timezone and Cross-Replica Convergence
+
+Schedules are computed in the completing replica's local timezone, the same as TaskWarrior's recurrence.
+
+If two replicas in different timezones complete the same occurrence before syncing, each computes the next occurrence in its own timezone. Because the successor UUID is deterministic, both replicas still produce the same successor task rather than duplicates.
+
+The successor's `due`, `scheduled`, and `wait` are separate operations, so they are not resolved as a group: each field is resolved independently, last-writer-wins by that operation's own timestamp. In principle this means a successor could take `due` from one replica and `scheduled` from another. In practice, this could only happen if the task was simultaneously completed in different timezones in a way that interleaved the completion times.
+
+Either way the result converges to a single valid successor that self-corrects on the next completion, not duplicate tasks or corruption.

--- a/docs/src/tasks.md
+++ b/docs/src/tasks.md
@@ -1,21 +1,14 @@
 # Task Model
 
-Tasks are stored internally as a key/value map with string keys and values.
-Display layers should apply appropriate defaults where necessary.
+Tasks are stored internally as a key/value map with string keys and values. Display layers should apply appropriate defaults where necessary.
 
 ## Validity
 
-_Any_ key/value map is a valid task, including an empty task.
-Consumers of task data must make a best effort to interpret any map, even if it contains apparently contradictory information.
-For example, a task with status "completed" but no "end" key present should be interpreted as completed at an unknown time.
+_Any_ key/value map is a valid task, including an empty task. Consumers of task data must make a best effort to interpret any map, even if it contains apparently contradictory information. For example, a task with status "completed" but no "end" key present should be interpreted as completed at an unknown time.
 
 ## Atomicity
 
-Replicas only synchronize with one another occasionally, so it is impossible to know the "current" state of a task with certainty.
-This makes some kinds of modifications challenging.
-For example, suppose task tags were updated by reading a list of tags from a property of the key/value map, adding a tag, and writing the result back.
-Suppose two such modifications are made in different replicas, one setting `tags` to "oldtag,newtag1" and one setting `tags` to "oldtag,newtag2".
-Reconciling these two changes on a sync operation would result in one change winning, losing one of the new tags.
+Replicas only synchronize with one another occasionally, so it is impossible to know the "current" state of a task with certainty. This makes some kinds of modifications challenging. For example, suppose task tags were updated by reading a list of tags from a property of the key/value map, adding a tag, and writing the result back. Suppose two such modifications are made in different replicas, one setting `tags` to "oldtag,newtag1" and one setting `tags` to "oldtag,newtag2". Reconciling these two changes on a sync operation would result in one change winning, losing one of the new tags.
 
 The key names given below avoid this issue, allowing user updates such as adding a tag or deleting a dependency to be represented in a single modification.
 
@@ -29,22 +22,22 @@ Timestamps are stored as UNIX epoch timestamps, in the form of an integer.
 
 The following keys, and key formats, are defined:
 
-* `status` - one of `pending` for a pending task (the default), `completed`, `deleted`, or `recurring`
-* `description` - the one-line summary of the task
-* `modified` - the time of the last modification of this task
-* `start` - the most recent time at which this task was started (a task with no `start` key is not active)
-* `end` - if present, the time at which this task was completed or deleted (note that this key may not agree with `status`: it may be present for a pending task, or absent for a deleted or completed task)
-* `tag_<tag>` - indicates this task has tag `<tag>` (value is ignored)
-* `wait` - indicates the time before which this task should be hidden, as it is not actionable
-* `entry` - the time at which the task was created
-* `annotation_<timestamp>` - value is an annotation created at the given time; for example, `annotation_1693329505`.
-* `dep_<uuid>` - indicates this task depends on another task identified by `<uuid>`; the value is ignored; for example, `dep_8c4fed9c-c0d2-40c2-936d-36fc44e084a0`
+- `status` - one of `pending` for a pending task (the default), `completed`, `deleted`, or `recurring`
+- `description` - the one-line summary of the task
+- `modified` - the time of the last modification of this task
+- `start` - the most recent time at which this task was started (a task with no `start` key is not active)
+- `end` - if present, the time at which this task was completed or deleted (note that this key may not agree with `status`: it may be present for a pending task, or absent for a deleted or completed task)
+- `tag_<tag>` - indicates this task has tag `<tag>` (value is ignored)
+- `wait` - indicates the time before which this task should be hidden, as it is not actionable
+- `scheduled` - indicates the time at which this task is scheduled to become actionable
+- `entry` - the time at which the task was created
+- `annotation_<timestamp>` - value is an annotation created at the given time; for example, `annotation_1693329505`.
+- `dep_<uuid>` - indicates this task depends on another task identified by `<uuid>`; the value is ignored; for example, `dep_8c4fed9c-c0d2-40c2-936d-36fc44e084a0`
 
 Note that while TaskChampion recognizes "R" as a status, it does not implement recurrence directly.
 
 ### UDAs
 
-Any unrecognized keys are treated as "user-defined attributes" (UDAs).
-These attributes can be used to store additional data associated with a task.
-For example, applications that synchronize tasks with other systems such as calendars or team planning services might store unique identifiers for those systems as UDAs.
-The application defining a UDA defines the format of the value.
+Any unrecognized keys are treated as "user-defined attributes" (UDAs). These attributes can be used to store additional data associated with a task. For example, applications that synchronize tasks with other systems such as calendars or team planning services might store unique identifiers for those systems as UDAs. The application defining a UDA defines the format of the value.
+
+Note: as of 4.0.0, `scheduled` is a recognized key rather than a UDA. Any data previously stored under a `scheduled` UDA is no longer returned by the UDA accessors (`get_user_defined_attribute`, `get_udas`, and related iterators) and can no longer be written through `set_user_defined_attribute`. The stored value is untouched, only its classification changed.

--- a/docs/src/tasks.md
+++ b/docs/src/tasks.md
@@ -1,14 +1,21 @@
 # Task Model
 
-Tasks are stored internally as a key/value map with string keys and values. Display layers should apply appropriate defaults where necessary.
+Tasks are stored internally as a key/value map with string keys and values.
+Display layers should apply appropriate defaults where necessary.
 
 ## Validity
 
-_Any_ key/value map is a valid task, including an empty task. Consumers of task data must make a best effort to interpret any map, even if it contains apparently contradictory information. For example, a task with status "completed" but no "end" key present should be interpreted as completed at an unknown time.
+_Any_ key/value map is a valid task, including an empty task.
+Consumers of task data must make a best effort to interpret any map, even if it contains apparently contradictory information.
+For example, a task with status "completed" but no "end" key present should be interpreted as completed at an unknown time.
 
 ## Atomicity
 
-Replicas only synchronize with one another occasionally, so it is impossible to know the "current" state of a task with certainty. This makes some kinds of modifications challenging. For example, suppose task tags were updated by reading a list of tags from a property of the key/value map, adding a tag, and writing the result back. Suppose two such modifications are made in different replicas, one setting `tags` to "oldtag,newtag1" and one setting `tags` to "oldtag,newtag2". Reconciling these two changes on a sync operation would result in one change winning, losing one of the new tags.
+Replicas only synchronize with one another occasionally, so it is impossible to know the "current" state of a task with certainty.
+This makes some kinds of modifications challenging.
+For example, suppose task tags were updated by reading a list of tags from a property of the key/value map, adding a tag, and writing the result back.
+Suppose two such modifications are made in different replicas, one setting `tags` to "oldtag,newtag1" and one setting `tags` to "oldtag,newtag2".
+Reconciling these two changes on a sync operation would result in one change winning, losing one of the new tags.
 
 The key names given below avoid this issue, allowing user updates such as adding a tag or deleting a dependency to be represented in a single modification.
 
@@ -38,6 +45,11 @@ Note that while TaskChampion recognizes "R" as a status, it does not implement r
 
 ### UDAs
 
-Any unrecognized keys are treated as "user-defined attributes" (UDAs). These attributes can be used to store additional data associated with a task. For example, applications that synchronize tasks with other systems such as calendars or team planning services might store unique identifiers for those systems as UDAs. The application defining a UDA defines the format of the value.
+Any unrecognized keys are treated as "user-defined attributes" (UDAs).
+These attributes can be used to store additional data associated with a task.
+For example, applications that synchronize tasks with other systems such as calendars or team planning services might store unique identifiers for those systems as UDAs.
+The application defining a UDA defines the format of the value.
 
-Note: as of 4.0.0, `scheduled` is a recognized key rather than a UDA. Any data previously stored under a `scheduled` UDA is no longer returned by the UDA accessors (`get_user_defined_attribute`, `get_udas`, and related iterators) and can no longer be written through `set_user_defined_attribute`. The stored value is untouched, only its classification changed.
+Note: as of 4.0.0, `scheduled` is a recognized key rather than a UDA.
+Any data previously stored under a `scheduled` UDA is no longer returned by the UDA accessors (`get_user_defined_attribute`, `get_udas`, and related iterators) and can no longer be written through `set_user_defined_attribute`.
+The stored value is untouched, only its classification changed.

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -19,6 +19,9 @@ pub enum Error {
     /// A usage error
     #[error("Usage Error: {0}")]
     Usage(String),
+    /// An iterative task related error
+    #[error("Iteration Error: {0}")]
+    Iterative(String),
     /// A general error.
     #[error(transparent)]
     Other(#[from] anyhow::Error),

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -19,6 +19,10 @@ pub enum Error {
     /// A usage error
     #[error("Usage Error: {0}")]
     Usage(String),
+    /// An iterative task related error
+    #[cfg(feature = "iterative-tasks")]
+    #[error("Iteration Error: {0}")]
+    Iterative(String),
     /// A general error.
     #[error(transparent)]
     Other(#[from] anyhow::Error),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,9 @@ pub use server::{Server, ServerConfig};
 pub use storage::indexeddb::IndexedDbStorage;
 #[cfg(feature = "storage-sqlite")]
 pub use storage::sqlite::SqliteStorage;
-pub use task::{utc_timestamp, Annotation, IterType, Status, Tag, Task, TaskData};
+pub use task::{utc_timestamp, Annotation, Status, Tag, Task, TaskData};
+#[cfg(feature = "iterative-tasks")]
+pub use task::IterType;
 pub use workingset::WorkingSet;
 
 /// Re-exported type from the `uuid` crate, for ease of compatibility for consumers of this crate.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,8 @@ pub use server::{Server, ServerConfig};
 pub use storage::indexeddb::IndexedDbStorage;
 #[cfg(feature = "storage-sqlite")]
 pub use storage::sqlite::SqliteStorage;
+#[cfg(feature = "iterative-tasks")]
+pub use task::IterType;
 pub use task::{utc_timestamp, Annotation, Status, Tag, Task, TaskData};
 pub use workingset::WorkingSet;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ pub use server::{Server, ServerConfig};
 pub use storage::indexeddb::IndexedDbStorage;
 #[cfg(feature = "storage-sqlite")]
 pub use storage::sqlite::SqliteStorage;
-pub use task::{utc_timestamp, Annotation, Status, Tag, Task, TaskData};
+pub use task::{str2rrule, utc_timestamp, Annotation, IterType, Status, Tag, Task, TaskData};
 pub use workingset::WorkingSet;
 
 /// Re-exported type from the `uuid` crate, for ease of compatibility for consumers of this crate.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ pub use server::{Server, ServerConfig};
 pub use storage::indexeddb::IndexedDbStorage;
 #[cfg(feature = "storage-sqlite")]
 pub use storage::sqlite::SqliteStorage;
-pub use task::{str2rrule, utc_timestamp, Annotation, IterType, Status, Tag, Task, TaskData};
+pub use task::{utc_timestamp, Annotation, IterType, Status, Tag, Task, TaskData};
 pub use workingset::WorkingSet;
 
 /// Re-exported type from the `uuid` crate, for ease of compatibility for consumers of this crate.

--- a/src/replica.rs
+++ b/src/replica.rs
@@ -175,7 +175,7 @@ impl<S: Storage> Replica<S> {
     /// Get the dependency map for all pending tasks.
     ///
     /// A task dependency is recognized when a task in the working set depends on a task with
-    /// status equal to Pending.
+    /// status equal to Pending or Iterative.
     ///
     /// The data in this map is cached when it is first requested and may not contain modifications
     /// made locally in this Replica instance.  The result is reference-counted and may
@@ -216,12 +216,12 @@ impl<S: Storage> Replica<S> {
                                             // or if we get the task
                                             self.taskdb.get_task(dep).await?
                                         {
-                                            // and its status is "pending"
+                                            // and its status is "pending" or "iterative"
                                             let dep_pending = matches!(
                                                 dep_taskmap
                                                     .get("status")
                                                     .map(|tm| Status::from_taskmap(tm)),
-                                                Some(Status::Pending)
+                                                Some(Status::Pending) | Some(Status::Iterative)
                                             );
                                             is_pending_cache.insert(dep, dep_pending);
                                             dep_pending
@@ -358,12 +358,13 @@ impl<S: Storage> Replica<S> {
         }
 
         // Add tasks to the working set when the status property is updated from anything other
-        // than pending or recurring to one of those two statuses.
+        // than pending, recurring, or iterative to one of those three statuses.
         let pending = Status::Pending.to_taskmap();
         let recurring = Status::Recurring.to_taskmap();
+        let iterative = Status::Iterative.to_taskmap();
         let is_p_or_r = |val: &Option<String>| {
             if let Some(val) = val {
-                val == pending || val == recurring
+                val == pending || val == recurring || val == iterative
             } else {
                 false
             }
@@ -448,11 +449,12 @@ impl<S: Storage> Replica<S> {
     pub async fn rebuild_working_set(&mut self, renumber: bool) -> Result<()> {
         let pending = String::from(Status::Pending.to_taskmap());
         let recurring = String::from(Status::Recurring.to_taskmap());
+        let iterative = String::from(Status::Iterative.to_taskmap());
         self.taskdb
             .rebuild_working_set(
                 |t| {
                     if let Some(st) = t.get("status") {
-                        st == &pending || st == &recurring
+                        st == &pending || st == &recurring || st == &iterative
                     } else {
                         false
                     }
@@ -1005,6 +1007,30 @@ mod tests {
         let mut t = rep.get_task(uuid).await.unwrap().unwrap();
         let mut ops = Operations::new();
         t.set_status(Status::Recurring, &mut ops).unwrap();
+        rep.commit_operations(ops).await.unwrap();
+
+        rep.rebuild_working_set(true).await.unwrap();
+
+        let ws = rep.working_set().await.unwrap();
+        assert!(ws.by_uuid(uuid).is_some());
+    }
+
+    #[tokio::test]
+    #[cfg(feature = "iterative-tasks")]
+    async fn rebuild_working_set_includes_iterative() {
+        let mut rep = Replica::new(InMemoryStorage::new());
+
+        let uuid = Uuid::new_v4();
+        let mut ops = Operations::new();
+        let mut t = rep.create_task(uuid, &mut ops).await.unwrap();
+        t.set_value("iter", Some("weekly".into()), &mut ops)
+            .unwrap();
+        t.set_status(Status::Completed, &mut ops).unwrap();
+        rep.commit_operations(ops).await.unwrap();
+
+        let mut t = rep.get_task(uuid).await.unwrap().unwrap();
+        let mut ops = Operations::new();
+        t.set_status(Status::Iterative, &mut ops).unwrap();
         rep.commit_operations(ops).await.unwrap();
 
         rep.rebuild_working_set(true).await.unwrap();

--- a/src/replica.rs
+++ b/src/replica.rs
@@ -1025,11 +1025,6 @@ mod tests {
         let mut t = rep.create_task(uuid, &mut ops).await.unwrap();
         t.set_value("iter", Some("weekly".into()), &mut ops)
             .unwrap();
-        t.set_status(Status::Completed, &mut ops).unwrap();
-        rep.commit_operations(ops).await.unwrap();
-
-        let mut t = rep.get_task(uuid).await.unwrap().unwrap();
-        let mut ops = Operations::new();
         t.set_status(Status::Iterative, &mut ops).unwrap();
         rep.commit_operations(ops).await.unwrap();
 

--- a/src/task/iter.rs
+++ b/src/task/iter.rs
@@ -105,8 +105,7 @@ mod test {
     fn validate_rrule(input: &str) -> RRule<Validated> {
         let dt_start = chrono::Utc::now().with_timezone(&Tz::Local(chrono::Local));
         let rule = str2rrule(input).unwrap();
-        let validated = rule.validate(dt_start).unwrap();
-        validated
+        rule.validate(dt_start).unwrap()
     }
 
     #[test]

--- a/src/task/iter.rs
+++ b/src/task/iter.rs
@@ -1,0 +1,99 @@
+use crate::errors::{Error, Result};
+use rrule::{Frequency, NWeekday, RRule, Unvalidated, Weekday};
+use strum_macros::{Display, EnumString};
+/// The iteration type of a task.
+#[derive(Debug, PartialEq, Eq, Clone, Display, EnumString)]
+#[repr(C)]
+pub enum IterType {
+    #[strum(serialize = "fixed", serialize = "fx")]
+    Fixed,
+    #[strum(serialize = "fixed+", serialize = "f+", serialize = "fp")]
+    FixedPlus,
+    #[strum(serialize = "chained", serialize = "ch")]
+    Chained,
+    /// Unknown signifies an iter type in the task DB that was not
+    /// recognized.  This supports forward-compatibility if a
+    /// new type is added.  Tasks with unknown iter types should
+    /// be ignored (but not deleted).
+    Unknown(String),
+}
+
+enum SpecialDays {
+    Weekday,
+    Weekend,
+}
+/// Converts an iteration description string to a RRule.
+///
+/// For now, only handles the standard TaskWarrior style descriptions.
+pub fn str2rrule(value: &str) -> Result<RRule<Unvalidated>> {
+    // Most TW iteration strings are of the form:
+    // nPP where n is the interval number and PP is the period.
+    // e.g. 3wks -> every three weeks.
+    // If n is missing, it is assumed to be 1.
+    // Steps:
+    // 1) Normalize string (2WeEKs -> 2weeks)
+    // 2) Expand special terms (annual -> 1year, fortnight -> 2week)
+    // 2) Look for interval number (2week -> (2, week), mo -> (1, mo))
+    // 3) Parse intervals into tokens (wk -> Week)
+    // 4) Generate RRule ( (2, week) -> FREQ=WEEKLY;INTERVAL=2)
+
+    // Normalize.
+    let value = value.trim().to_ascii_lowercase();
+
+    // Special terms.
+    let value = match value.as_str() {
+        "fortnight" | "fortnightly" | "biweekly" => "2week",
+        "semiannual" => "6month",
+        "annual" => "1year",
+        "biannual" | "biannually" | "biyearly" | "biyear" => "2year",
+        _ => value.as_str(),
+    };
+
+    // Split into interval and period.
+    let num_str: String = value.chars().take_while(|c| c.is_ascii_digit()).collect();
+    let mut interval = num_str.parse::<u16>().unwrap_or(1);
+    let period = &value[num_str.len()..];
+
+    // Parse period into enum.
+    let mut special_days: Option<SpecialDays> = None;
+    let freq = match period {
+        "se" | "sec" | "second" | "seconds" | "secondly" => Frequency::Secondly,
+        "mi" | "min" | "minute" | "minutes" | "minutley" => Frequency::Minutely,
+        "hr" | "hour" | "hours" | "hourly" => Frequency::Hourly,
+        "day" | "days" | "daily" => Frequency::Daily,
+        "wk" | "week" | "weekly" | "wkly" => Frequency::Weekly,
+        "wkd" | "weekday" | "weekdays" | "weekdaily" => {
+            special_days = Some(SpecialDays::Weekday);
+            Frequency::Daily
+        }
+        "wknd" | "weekend" | "weekends" | "weekendly" => {
+            special_days = Some(SpecialDays::Weekend);
+            Frequency::Daily
+        }
+        "mo" | "month" | "months" | "monthly" => Frequency::Monthly,
+        "qtr" | "qtrs" | "quarter" | "quarterly" => {
+            interval *= 3;
+            Frequency::Monthly
+        }
+        "yr" | "year" | "yearly" | "annual" => Frequency::Yearly,
+        _ => return Err(Error::Usage(format!("Could not parse period {}.", period))),
+    };
+
+    // Generate the RRule.
+    let rule = RRule::new(freq).interval(interval);
+    let rule = match special_days {
+        None => rule,
+        Some(SpecialDays::Weekday) => rule.by_weekday(vec![
+            NWeekday::Every(Weekday::Mon),
+            NWeekday::Every(Weekday::Tue),
+            NWeekday::Every(Weekday::Wed),
+            NWeekday::Every(Weekday::Thu),
+            NWeekday::Every(Weekday::Fri),
+        ]),
+        Some(SpecialDays::Weekend) => rule.by_weekday(vec![
+            NWeekday::Every(Weekday::Thu),
+            NWeekday::Every(Weekday::Fri),
+        ]),
+    };
+    Ok(rule)
+}

--- a/src/task/iter.rs
+++ b/src/task/iter.rs
@@ -1,6 +1,7 @@
 use crate::errors::{Error, Result};
 use rrule::{Frequency, NWeekday, RRule, Unvalidated, Weekday};
 use strum_macros::{Display, EnumString};
+
 /// The iteration type of a task.
 #[derive(Debug, PartialEq, Eq, Clone, Display, EnumString)]
 #[repr(C)]
@@ -91,9 +92,164 @@ pub fn str2rrule(value: &str) -> Result<RRule<Unvalidated>> {
             NWeekday::Every(Weekday::Fri),
         ]),
         Some(SpecialDays::Weekend) => rule.by_weekday(vec![
-            NWeekday::Every(Weekday::Thu),
-            NWeekday::Every(Weekday::Fri),
+            NWeekday::Every(Weekday::Sat),
+            NWeekday::Every(Weekday::Sun),
         ]),
     };
     Ok(rule)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use rrule::{Tz, Validated};
+    use std::str::FromStr;
+
+    /// Validate an rrule string input and return its validated form.
+    fn validate_rrule(input: &str) -> RRule<Validated> {
+        let dt_start = chrono::Utc::now().with_timezone(&Tz::Local(chrono::Local));
+        let rule = str2rrule(input).unwrap();
+        let validated = rule.validate(dt_start).unwrap();
+        validated
+    }
+
+    #[test]
+    fn basic_daily() {
+        let rule = validate_rrule("daily");
+        assert_eq!(rule.get_freq(), Frequency::Daily);
+        assert_eq!(rule.get_interval(), 1);
+    }
+
+    #[test]
+    fn basic_weekly() {
+        let rule = validate_rrule("weekly");
+        assert_eq!(rule.get_freq(), Frequency::Weekly);
+        assert_eq!(rule.get_interval(), 1);
+    }
+
+    #[test]
+    fn basic_monthly() {
+        let rule = validate_rrule("month");
+        assert_eq!(rule.get_freq(), Frequency::Monthly);
+        assert_eq!(rule.get_interval(), 1);
+    }
+
+    #[test]
+    fn basic_yearly() {
+        let rule = validate_rrule("year");
+        assert_eq!(rule.get_freq(), Frequency::Yearly);
+        assert_eq!(rule.get_interval(), 1);
+    }
+
+    #[test]
+    fn interval_prefix() {
+        let rule = validate_rrule("3wk");
+        assert_eq!(rule.get_freq(), Frequency::Weekly);
+        assert_eq!(rule.get_interval(), 3);
+    }
+
+    #[test]
+    fn special_fortnight() {
+        let rule = validate_rrule("fortnight");
+        assert_eq!(rule.get_freq(), Frequency::Weekly);
+        assert_eq!(rule.get_interval(), 2);
+    }
+
+    #[test]
+    fn special_biweekly() {
+        let rule = validate_rrule("biweekly");
+        assert_eq!(rule.get_freq(), Frequency::Weekly);
+        assert_eq!(rule.get_interval(), 2);
+    }
+
+    #[test]
+    fn special_semiannual() {
+        let rule = validate_rrule("semiannual");
+        assert_eq!(rule.get_freq(), Frequency::Monthly);
+        assert_eq!(rule.get_interval(), 6);
+    }
+
+    #[test]
+    fn special_biannual() {
+        let rule = validate_rrule("biannual");
+        assert_eq!(rule.get_freq(), Frequency::Yearly);
+        assert_eq!(rule.get_interval(), 2);
+    }
+
+    #[test]
+    fn quarter_single() {
+        let rule = validate_rrule("qtr");
+        assert_eq!(rule.get_freq(), Frequency::Monthly);
+        assert_eq!(rule.get_interval(), 3);
+    }
+
+    #[test]
+    fn quarter_interval() {
+        let rule = validate_rrule("2qtrs");
+        assert_eq!(rule.get_freq(), Frequency::Monthly);
+        assert_eq!(rule.get_interval(), 6);
+    }
+
+    #[test]
+    fn weekday() {
+        let rule = validate_rrule("weekdays");
+        assert_eq!(rule.get_freq(), Frequency::Daily);
+        assert_eq!(rule.get_interval(), 1);
+        let days = rule.get_by_weekday();
+        assert!(days.contains(&NWeekday::Every(Weekday::Mon)));
+        assert!(days.contains(&NWeekday::Every(Weekday::Tue)));
+        assert!(days.contains(&NWeekday::Every(Weekday::Wed)));
+        assert!(days.contains(&NWeekday::Every(Weekday::Thu)));
+        assert!(days.contains(&NWeekday::Every(Weekday::Fri)));
+    }
+
+    #[test]
+    fn weekend() {
+        let rule = validate_rrule("weekdays");
+        assert_eq!(rule.get_freq(), Frequency::Daily);
+        assert_eq!(rule.get_interval(), 1);
+        let days = rule.get_by_weekday();
+        assert!(days.contains(&NWeekday::Every(Weekday::Sun)));
+        assert!(days.contains(&NWeekday::Every(Weekday::Mon)));
+    }
+
+    #[test]
+    fn case_insensitive() {
+        let rule = validate_rrule("DAily");
+        assert_eq!(rule.get_freq(), Frequency::Daily);
+        assert_eq!(rule.get_interval(), 1);
+        let rule = validate_rrule("3wK");
+        assert_eq!(rule.get_freq(), Frequency::Weekly);
+        assert_eq!(rule.get_interval(), 3);
+    }
+
+    #[test]
+    fn trim_whitespace() {
+        let rule = validate_rrule("  daily  ");
+        assert_eq!(rule.get_freq(), Frequency::Daily);
+        assert_eq!(rule.get_interval(), 1);
+    }
+
+    #[test]
+    fn invalid_period() {
+        let result = str2rrule("3blarg");
+        assert!(matches!(result, Err(Error::Usage(_))));
+    }
+
+    #[test]
+    fn empty_period() {
+        let result = str2rrule("");
+        assert!(matches!(result, Err(Error::Usage(_))));
+    }
+
+    #[test]
+    fn iter_type_from_str() {
+        assert_eq!(IterType::from_str("fixed").unwrap(), IterType::Fixed);
+        assert_eq!(IterType::from_str("fx").unwrap(), IterType::Fixed);
+        assert_eq!(IterType::from_str("fixed+").unwrap(), IterType::FixedPlus);
+        assert_eq!(IterType::from_str("f+").unwrap(), IterType::FixedPlus);
+        assert_eq!(IterType::from_str("fp").unwrap(), IterType::FixedPlus);
+        assert_eq!(IterType::from_str("chained").unwrap(), IterType::Chained);
+        assert_eq!(IterType::from_str("ch").unwrap(), IterType::Chained);
+    }
 }

--- a/src/task/iter.rs
+++ b/src/task/iter.rs
@@ -1,5 +1,6 @@
 use crate::errors::{Error, Result};
-use rrule::{Frequency, NWeekday, RRule, Unvalidated, Weekday};
+pub(crate) use rrule::RRule;
+use rrule::{Frequency, NWeekday, Unvalidated, Weekday};
 use strum_macros::{Display, EnumString};
 
 /// The iteration type of a task.
@@ -22,7 +23,7 @@ enum SpecialDays {
 /// Converts an iteration description string to a RRule.
 ///
 /// For now, only handles the standard TaskWarrior style descriptions.
-pub fn str2rrule(value: &str) -> Result<RRule<Unvalidated>> {
+pub(crate) fn str2rrule(value: &str) -> Result<RRule<Unvalidated>> {
     // Most TW iteration strings are of the form:
     // nPP where n is the interval number and PP is the period.
     // e.g. 3wks -> every three weeks.
@@ -69,7 +70,7 @@ pub fn str2rrule(value: &str) -> Result<RRule<Unvalidated>> {
         }
         "mo" | "month" | "months" | "monthly" => Frequency::Monthly,
         "qtr" | "qtrs" | "quarter" | "quarters" | "quarterly" => {
-            interval *= 3;
+            interval = interval.saturating_mul(3);
             Frequency::Monthly
         }
         "yr" | "year" | "yearly" | "annual" => Frequency::Yearly,

--- a/src/task/iter.rs
+++ b/src/task/iter.rs
@@ -3,20 +3,16 @@ use rrule::{Frequency, NWeekday, RRule, Unvalidated, Weekday};
 use strum_macros::{Display, EnumString};
 
 /// The iteration type of a task.
-#[derive(Debug, PartialEq, Eq, Clone, Display, EnumString)]
+#[derive(Default, Debug, PartialEq, Eq, Clone, Display, EnumString)]
 #[repr(C)]
 pub enum IterType {
     #[strum(serialize = "fixed", serialize = "fx")]
     Fixed,
     #[strum(serialize = "fixed+", serialize = "f+", serialize = "fp")]
     FixedPlus,
+    #[default]
     #[strum(serialize = "chained", serialize = "ch")]
     Chained,
-    /// Unknown signifies an iter type in the task DB that was not
-    /// recognized.  This supports forward-compatibility if a
-    /// new type is added.  Tasks with unknown iter types should
-    /// be ignored (but not deleted).
-    Unknown(String),
 }
 
 enum SpecialDays {
@@ -59,7 +55,7 @@ pub fn str2rrule(value: &str) -> Result<RRule<Unvalidated>> {
     let mut special_days: Option<SpecialDays> = None;
     let freq = match period {
         "se" | "sec" | "second" | "seconds" | "secondly" => Frequency::Secondly,
-        "mi" | "min" | "minute" | "minutes" | "minutley" => Frequency::Minutely,
+        "mi" | "min" | "minute" | "minutes" | "minutely" => Frequency::Minutely,
         "hr" | "hour" | "hours" | "hourly" => Frequency::Hourly,
         "day" | "days" | "daily" => Frequency::Daily,
         "wk" | "week" | "weekly" | "wkly" => Frequency::Weekly,
@@ -72,7 +68,7 @@ pub fn str2rrule(value: &str) -> Result<RRule<Unvalidated>> {
             Frequency::Daily
         }
         "mo" | "month" | "months" | "monthly" => Frequency::Monthly,
-        "qtr" | "qtrs" | "quarter" | "quarterly" => {
+        "qtr" | "qtrs" | "quarter" | "quarters" | "quarterly" => {
             interval *= 3;
             Frequency::Monthly
         }
@@ -185,9 +181,9 @@ mod test {
 
     #[test]
     fn quarter_interval() {
-        let rule = validate_rrule("2qtrs");
+        let rule = validate_rrule("3qtrs");
         assert_eq!(rule.get_freq(), Frequency::Monthly);
-        assert_eq!(rule.get_interval(), 6);
+        assert_eq!(rule.get_interval(), 9);
     }
 
     #[test]
@@ -201,16 +197,23 @@ mod test {
         assert!(days.contains(&NWeekday::Every(Weekday::Wed)));
         assert!(days.contains(&NWeekday::Every(Weekday::Thu)));
         assert!(days.contains(&NWeekday::Every(Weekday::Fri)));
+        assert!(!days.contains(&NWeekday::Every(Weekday::Sat)));
+        assert!(!days.contains(&NWeekday::Every(Weekday::Sun)));
     }
 
     #[test]
     fn weekend() {
-        let rule = validate_rrule("weekdays");
+        let rule = validate_rrule("weekend");
         assert_eq!(rule.get_freq(), Frequency::Daily);
         assert_eq!(rule.get_interval(), 1);
         let days = rule.get_by_weekday();
+        assert!(!days.contains(&NWeekday::Every(Weekday::Mon)));
+        assert!(!days.contains(&NWeekday::Every(Weekday::Tue)));
+        assert!(!days.contains(&NWeekday::Every(Weekday::Wed)));
+        assert!(!days.contains(&NWeekday::Every(Weekday::Thu)));
+        assert!(!days.contains(&NWeekday::Every(Weekday::Fri)));
+        assert!(days.contains(&NWeekday::Every(Weekday::Sat)));
         assert!(days.contains(&NWeekday::Every(Weekday::Sun)));
-        assert!(days.contains(&NWeekday::Every(Weekday::Mon)));
     }
 
     #[test]

--- a/src/task/iter.rs
+++ b/src/task/iter.rs
@@ -1,0 +1,350 @@
+use crate::errors::{Error, Result};
+pub(crate) use rrule::RRule;
+use rrule::{Frequency, NWeekday, Unvalidated, Weekday};
+use std::str::FromStr;
+use strum_macros::{Display, EnumString};
+
+/// The iteration type of a task.
+#[derive(Default, Debug, PartialEq, Eq, Clone, Display, EnumString)]
+#[repr(C)]
+pub enum IterType {
+    #[strum(serialize = "fixed", serialize = "fx")]
+    Fixed,
+    #[strum(serialize = "fixed+", serialize = "f+", serialize = "fp")]
+    FixedPlus,
+    #[default]
+    #[strum(serialize = "chained", serialize = "ch")]
+    Chained,
+}
+
+/// The primary anchor date for an iterative task.
+#[derive(Debug)]
+#[cfg(feature = "iterative-tasks")]
+pub(super) enum AnchorKind {
+    Due,
+    Scheduled,
+    Wait,
+}
+
+enum SpecialDays {
+    Weekday,
+    Weekend,
+}
+/// Converts an iteration description string to a RRule.
+///
+/// String format check order:
+/// 1. Direct RRULE
+/// 2. TaskWarrior-style shorthand
+/// 3. Natural language via `text2rrule`.
+pub(crate) fn str2rrule(value: &str) -> Result<RRule<Unvalidated>> {
+    if let Ok(rule) = RRule::<Unvalidated>::from_str(value) {
+        return Ok(rule);
+    }
+    if let Ok(rule) = tw_shorthand_to_rrule(value) {
+        return Ok(rule);
+    }
+    if let Ok(rule) = text2rrule::text2rrule(value) {
+        if let Ok(rule) = RRule::<Unvalidated>::from_str(&rule) {
+            return Ok(rule);
+        }
+    }
+    Err(Error::Usage(format!(
+        "Could not parse iteration value {value:?}"
+    )))
+}
+
+/// Parse a TaskWarrior-style shorthand iteration string into a RRule.
+fn tw_shorthand_to_rrule(value: &str) -> Result<RRule<Unvalidated>> {
+    // Most TW iteration strings are of the form:
+    // nPP where n is the interval number and PP is the period.
+    // e.g. 3wks -> every three weeks.
+    // If n is missing, it is assumed to be 1.
+    // Steps:
+    // 1) Normalize string (2WeEKs -> 2weeks)
+    // 2) Expand special terms (annual -> 1year, fortnight -> 2week)
+    // 2) Look for interval number (2week -> (2, week), mo -> (1, mo))
+    // 3) Parse intervals into tokens (wk -> Week)
+    // 4) Generate RRule ( (2, week) -> FREQ=WEEKLY;INTERVAL=2)
+
+    // Normalize.
+    let value = value.trim().to_ascii_lowercase();
+
+    // Special terms.
+    let value = match value.as_str() {
+        "fortnight" | "fortnightly" | "biweekly" => "2week",
+        "semiannual" => "6month",
+        "annual" => "1year",
+        "biannual" | "biannually" | "biyearly" | "biyear" => "2year",
+        _ => value.as_str(),
+    };
+
+    // Split into interval and period.
+    let num_str: String = value.chars().take_while(|c| c.is_ascii_digit()).collect();
+    // An empty number means "1" (e.g. "week" -> every 1 week). A non-empty number
+    // that doesn't fit in a u16 is an error.
+    let mut interval = if num_str.is_empty() {
+        1
+    } else {
+        num_str
+            .parse::<u16>()
+            .map_err(|e| Error::Usage(format!("Could not parse interval {num_str:?}: {e}")))?
+    };
+    let period = &value[num_str.len()..];
+
+    // Parse period into enum.
+    let mut special_days: Option<SpecialDays> = None;
+    let freq = match period {
+        "se" | "sec" | "second" | "seconds" | "secondly" => Frequency::Secondly,
+        "mi" | "min" | "minute" | "minutes" | "minutely" => Frequency::Minutely,
+        "hr" | "hour" | "hours" | "hourly" => Frequency::Hourly,
+        "day" | "days" | "daily" => Frequency::Daily,
+        "wk" | "week" | "weekly" | "wkly" => Frequency::Weekly,
+        "wkd" | "weekday" | "weekdays" | "weekdaily" => {
+            special_days = Some(SpecialDays::Weekday);
+            Frequency::Daily
+        }
+        "wknd" | "weekend" | "weekends" | "weekendly" => {
+            special_days = Some(SpecialDays::Weekend);
+            Frequency::Daily
+        }
+        "mo" | "month" | "months" | "monthly" => Frequency::Monthly,
+        "qtr" | "qtrs" | "quarter" | "quarters" | "quarterly" => {
+            interval = interval
+                .checked_mul(3)
+                .ok_or_else(|| Error::Usage(format!("Quarter interval {interval} is too large")))?;
+            Frequency::Monthly
+        }
+        "yr" | "year" | "yearly" | "annual" => Frequency::Yearly,
+        _ => return Err(Error::Usage(format!("Could not parse period {}.", period))),
+    };
+
+    // Generate the RRule.
+    let rule = RRule::new(freq).interval(interval);
+    let rule = match special_days {
+        None => rule,
+        Some(SpecialDays::Weekday) => rule.by_weekday(vec![
+            NWeekday::Every(Weekday::Mon),
+            NWeekday::Every(Weekday::Tue),
+            NWeekday::Every(Weekday::Wed),
+            NWeekday::Every(Weekday::Thu),
+            NWeekday::Every(Weekday::Fri),
+        ]),
+        Some(SpecialDays::Weekend) => rule.by_weekday(vec![
+            NWeekday::Every(Weekday::Sat),
+            NWeekday::Every(Weekday::Sun),
+        ]),
+    };
+    Ok(rule)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use rrule::{Tz, Validated};
+    use std::str::FromStr;
+
+    /// Validate an rrule string input and return its validated form.
+    fn validate_rrule(input: &str) -> RRule<Validated> {
+        let dt_start = chrono::Utc::now().with_timezone(&Tz::Local(chrono::Local));
+        let rule = str2rrule(input).unwrap();
+        rule.validate(dt_start).unwrap()
+    }
+
+    #[test]
+    fn basic_daily() {
+        let rule = validate_rrule("daily");
+        assert_eq!(rule.get_freq(), Frequency::Daily);
+        assert_eq!(rule.get_interval(), 1);
+    }
+
+    #[test]
+    fn basic_weekly() {
+        let rule = validate_rrule("weekly");
+        assert_eq!(rule.get_freq(), Frequency::Weekly);
+        assert_eq!(rule.get_interval(), 1);
+    }
+
+    #[test]
+    fn basic_monthly() {
+        let rule = validate_rrule("month");
+        assert_eq!(rule.get_freq(), Frequency::Monthly);
+        assert_eq!(rule.get_interval(), 1);
+    }
+
+    #[test]
+    fn basic_yearly() {
+        let rule = validate_rrule("year");
+        assert_eq!(rule.get_freq(), Frequency::Yearly);
+        assert_eq!(rule.get_interval(), 1);
+    }
+
+    #[test]
+    fn interval_prefix() {
+        let rule = validate_rrule("3wk");
+        assert_eq!(rule.get_freq(), Frequency::Weekly);
+        assert_eq!(rule.get_interval(), 3);
+    }
+
+    #[test]
+    fn special_fortnight() {
+        let rule = validate_rrule("fortnight");
+        assert_eq!(rule.get_freq(), Frequency::Weekly);
+        assert_eq!(rule.get_interval(), 2);
+    }
+
+    #[test]
+    fn special_biweekly() {
+        let rule = validate_rrule("biweekly");
+        assert_eq!(rule.get_freq(), Frequency::Weekly);
+        assert_eq!(rule.get_interval(), 2);
+    }
+
+    #[test]
+    fn special_semiannual() {
+        let rule = validate_rrule("semiannual");
+        assert_eq!(rule.get_freq(), Frequency::Monthly);
+        assert_eq!(rule.get_interval(), 6);
+    }
+
+    #[test]
+    fn special_biannual() {
+        let rule = validate_rrule("biannual");
+        assert_eq!(rule.get_freq(), Frequency::Yearly);
+        assert_eq!(rule.get_interval(), 2);
+    }
+
+    #[test]
+    fn quarter_single() {
+        let rule = validate_rrule("qtr");
+        assert_eq!(rule.get_freq(), Frequency::Monthly);
+        assert_eq!(rule.get_interval(), 3);
+    }
+
+    #[test]
+    fn quarter_interval() {
+        let rule = validate_rrule("3qtrs");
+        assert_eq!(rule.get_freq(), Frequency::Monthly);
+        assert_eq!(rule.get_interval(), 9);
+    }
+
+    #[test]
+    fn weekday() {
+        let rule = validate_rrule("weekdays");
+        assert_eq!(rule.get_freq(), Frequency::Daily);
+        assert_eq!(rule.get_interval(), 1);
+        let days = rule.get_by_weekday();
+        assert!(days.contains(&NWeekday::Every(Weekday::Mon)));
+        assert!(days.contains(&NWeekday::Every(Weekday::Tue)));
+        assert!(days.contains(&NWeekday::Every(Weekday::Wed)));
+        assert!(days.contains(&NWeekday::Every(Weekday::Thu)));
+        assert!(days.contains(&NWeekday::Every(Weekday::Fri)));
+        assert!(!days.contains(&NWeekday::Every(Weekday::Sat)));
+        assert!(!days.contains(&NWeekday::Every(Weekday::Sun)));
+    }
+
+    #[test]
+    fn weekend() {
+        let rule = validate_rrule("weekend");
+        assert_eq!(rule.get_freq(), Frequency::Daily);
+        assert_eq!(rule.get_interval(), 1);
+        let days = rule.get_by_weekday();
+        assert!(!days.contains(&NWeekday::Every(Weekday::Mon)));
+        assert!(!days.contains(&NWeekday::Every(Weekday::Tue)));
+        assert!(!days.contains(&NWeekday::Every(Weekday::Wed)));
+        assert!(!days.contains(&NWeekday::Every(Weekday::Thu)));
+        assert!(!days.contains(&NWeekday::Every(Weekday::Fri)));
+        assert!(days.contains(&NWeekday::Every(Weekday::Sat)));
+        assert!(days.contains(&NWeekday::Every(Weekday::Sun)));
+    }
+
+    #[test]
+    fn case_insensitive() {
+        let rule = validate_rrule("DAily");
+        assert_eq!(rule.get_freq(), Frequency::Daily);
+        assert_eq!(rule.get_interval(), 1);
+        let rule = validate_rrule("3wK");
+        assert_eq!(rule.get_freq(), Frequency::Weekly);
+        assert_eq!(rule.get_interval(), 3);
+    }
+
+    #[test]
+    fn trim_whitespace() {
+        let rule = validate_rrule("  daily  ");
+        assert_eq!(rule.get_freq(), Frequency::Daily);
+        assert_eq!(rule.get_interval(), 1);
+    }
+
+    #[test]
+    fn invalid_period() {
+        let result = str2rrule("3blarg");
+        assert!(matches!(result, Err(Error::Usage(_))));
+    }
+
+    #[test]
+    fn empty_period() {
+        let result = str2rrule("");
+        assert!(matches!(result, Err(Error::Usage(_))));
+    }
+
+    #[test]
+    fn interval_overflow() {
+        // An interval that doesn't fit in a u16 must be an error, not a silent
+        // fall back to interval 1.
+        let result = str2rrule("100000week");
+        assert!(matches!(result, Err(Error::Usage(_))));
+    }
+
+    #[test]
+    fn quarter_interval_overflow() {
+        let result = str2rrule("60000qtr");
+        assert!(matches!(result, Err(Error::Usage(_))));
+    }
+
+    #[test]
+    fn raw_rrule() {
+        let rule = str2rrule("FREQ=WEEKLY;INTERVAL=2;BYDAY=FR").unwrap();
+        assert_eq!(rule.get_freq(), Frequency::Weekly);
+        assert_eq!(rule.get_interval(), 2);
+        assert!(rule
+            .get_by_weekday()
+            .contains(&NWeekday::Every(Weekday::Fri)));
+    }
+
+    #[test]
+    fn text2rrule_every_other_friday() {
+        // "every two weeks on friday" is handled by the text2rrule fallback,
+        // not the TW shorthand parser.
+        let rule = validate_rrule("every two weeks on friday");
+        assert_eq!(rule.get_freq(), Frequency::Weekly);
+        assert_eq!(rule.get_interval(), 2);
+        assert!(rule
+            .get_by_weekday()
+            .contains(&NWeekday::Every(Weekday::Fri)));
+    }
+
+    #[test]
+    fn text2rrule_every_mon_wed_thur() {
+        let rule = validate_rrule("every mon, wed, and thur");
+        assert_eq!(rule.get_freq(), Frequency::Weekly);
+        assert!(rule
+            .get_by_weekday()
+            .contains(&NWeekday::Every(Weekday::Mon)));
+        assert!(rule
+            .get_by_weekday()
+            .contains(&NWeekday::Every(Weekday::Wed)));
+        assert!(rule
+            .get_by_weekday()
+            .contains(&NWeekday::Every(Weekday::Thu)));
+    }
+
+    #[test]
+    fn iter_type_from_str() {
+        assert_eq!(IterType::from_str("fixed").unwrap(), IterType::Fixed);
+        assert_eq!(IterType::from_str("fx").unwrap(), IterType::Fixed);
+        assert_eq!(IterType::from_str("fixed+").unwrap(), IterType::FixedPlus);
+        assert_eq!(IterType::from_str("f+").unwrap(), IterType::FixedPlus);
+        assert_eq!(IterType::from_str("fp").unwrap(), IterType::FixedPlus);
+        assert_eq!(IterType::from_str("chained").unwrap(), IterType::Chained);
+        assert_eq!(IterType::from_str("ch").unwrap(), IterType::Chained);
+    }
+}

--- a/src/task/iter.rs
+++ b/src/task/iter.rs
@@ -19,14 +19,13 @@ pub enum IterType {
 
 /// The primary anchor date for an iterative task.
 #[derive(Debug)]
-#[cfg(feature = "iterative-tasks")]
 pub(super) enum AnchorKind {
     Due,
     Scheduled,
     Wait,
 }
 
-enum SpecialDays {
+enum DayKind {
     Weekday,
     Weekend,
 }
@@ -35,12 +34,16 @@ enum SpecialDays {
 /// String format check order:
 /// 1. Direct RRULE
 /// 2. TaskWarrior-style shorthand
-/// 3. Natural language via `text2rrule`.
+/// 3. ISO-8601 duration
+/// 4. Natural language via `text2rrule`.
 pub(crate) fn str2rrule(value: &str) -> Result<RRule<Unvalidated>> {
     if let Ok(rule) = RRule::<Unvalidated>::from_str(value) {
         return Ok(rule);
     }
     if let Ok(rule) = tw_shorthand_to_rrule(value) {
+        return Ok(rule);
+    }
+    if let Ok(rule) = iso8601_to_rrule(value) {
         return Ok(rule);
     }
     if let Ok(rule) = text2rrule::text2rrule(value) {
@@ -60,29 +63,24 @@ fn tw_shorthand_to_rrule(value: &str) -> Result<RRule<Unvalidated>> {
     // e.g. 3wks -> every three weeks.
     // If n is missing, it is assumed to be 1.
     // Steps:
-    // 1) Normalize string (2WeEKs -> 2weeks)
-    // 2) Expand special terms (annual -> 1year, fortnight -> 2week)
+    // 1) Normalize string (2 WeEKs -> 2weeks)
     // 2) Look for interval number (2week -> (2, week), mo -> (1, mo))
-    // 3) Parse intervals into tokens (wk -> Week)
+    // 3) Parse the period into a frequency and an interval multiplier
+    //    (wk -> (Weekly, 1), qtr -> (Monthly, 3))
     // 4) Generate RRule ( (2, week) -> FREQ=WEEKLY;INTERVAL=2)
 
-    // Normalize.
-    let value = value.trim().to_ascii_lowercase();
-
-    // Special terms.
-    let value = match value.as_str() {
-        "fortnight" | "fortnightly" | "biweekly" => "2week",
-        "semiannual" => "6month",
-        "annual" => "1year",
-        "biannual" | "biannually" | "biyearly" | "biyear" => "2year",
-        _ => value.as_str(),
-    };
+    // Normalize. Internal whitespace is dropped so "3 wks" and "3wks" are equivalent.
+    let value: String = value
+        .chars()
+        .filter(|c| !c.is_whitespace())
+        .map(|c| c.to_ascii_lowercase())
+        .collect();
 
     // Split into interval and period.
     let num_str: String = value.chars().take_while(|c| c.is_ascii_digit()).collect();
     // An empty number means "1" (e.g. "week" -> every 1 week). A non-empty number
     // that doesn't fit in a u16 is an error.
-    let mut interval = if num_str.is_empty() {
+    let interval = if num_str.is_empty() {
         1
     } else {
         num_str
@@ -91,50 +89,129 @@ fn tw_shorthand_to_rrule(value: &str) -> Result<RRule<Unvalidated>> {
     };
     let period = &value[num_str.len()..];
 
-    // Parse period into enum.
-    let mut special_days: Option<SpecialDays> = None;
-    let freq = match period {
-        "se" | "sec" | "second" | "seconds" | "secondly" => Frequency::Secondly,
-        "mi" | "min" | "minute" | "minutes" | "minutely" => Frequency::Minutely,
-        "hr" | "hour" | "hours" | "hourly" => Frequency::Hourly,
-        "day" | "days" | "daily" => Frequency::Daily,
-        "wk" | "week" | "weekly" | "wkly" => Frequency::Weekly,
+    // Parse the period into a frequency plus a multiplier on the interval, since
+    // some periods are a multiple of their frequency - a fortnight is two weeks,
+    // a quarter is three months, and so on.
+    let mut special_days: Option<DayKind> = None;
+    let (freq, multiplier) = match period {
+        "s" | "se" | "sec" | "secs" | "second" | "seconds" | "secondly" => (Frequency::Secondly, 1),
+        "mi" | "min" | "mins" | "minute" | "minutes" | "minutely" => (Frequency::Minutely, 1),
+        "h" | "hr" | "hrs" | "hour" | "hours" | "hourly" => (Frequency::Hourly, 1),
+        "d" | "day" | "days" | "daily" => (Frequency::Daily, 1),
+        "w" | "wk" | "wks" | "week" | "weeks" | "weekly" | "wkly" => (Frequency::Weekly, 1),
         "wkd" | "weekday" | "weekdays" | "weekdaily" => {
-            special_days = Some(SpecialDays::Weekday);
-            Frequency::Daily
+            special_days = Some(DayKind::Weekday);
+            (Frequency::Daily, 1)
         }
         "wknd" | "weekend" | "weekends" | "weekendly" => {
-            special_days = Some(SpecialDays::Weekend);
-            Frequency::Daily
+            special_days = Some(DayKind::Weekend);
+            (Frequency::Daily, 1)
         }
-        "mo" | "month" | "months" | "monthly" => Frequency::Monthly,
-        "qtr" | "qtrs" | "quarter" | "quarters" | "quarterly" => {
-            interval = interval
-                .checked_mul(3)
-                .ok_or_else(|| Error::Usage(format!("Quarter interval {interval} is too large")))?;
-            Frequency::Monthly
+        "fortnight" | "fortnightly" | "sennight" | "biweekly" => (Frequency::Weekly, 2),
+        "m" | "mo" | "mth" | "mths" | "mnths" | "month" | "months" | "monthly" => {
+            (Frequency::Monthly, 1)
         }
-        "yr" | "year" | "yearly" | "annual" => Frequency::Yearly,
+        "bimonthly" => (Frequency::Monthly, 2),
+        "q" | "qtr" | "qtrs" | "qrtr" | "qrtrs" | "quarter" | "quarters" | "quarterly" => {
+            (Frequency::Monthly, 3)
+        }
+        "semiannual" => (Frequency::Monthly, 6),
+        "y" | "yr" | "yrs" | "year" | "years" | "yearly" | "annual" => (Frequency::Yearly, 1),
+        "biannual" | "biannually" | "biyearly" | "biyear" => (Frequency::Yearly, 2),
         _ => return Err(Error::Usage(format!("Could not parse period {}.", period))),
     };
+
+    let interval = interval
+        .checked_mul(multiplier)
+        .ok_or_else(|| Error::Usage(format!("Interval {interval} {period} is too large")))?;
 
     // Generate the RRule.
     let rule = RRule::new(freq).interval(interval);
     let rule = match special_days {
         None => rule,
-        Some(SpecialDays::Weekday) => rule.by_weekday(vec![
+        Some(DayKind::Weekday) => rule.by_weekday(vec![
             NWeekday::Every(Weekday::Mon),
             NWeekday::Every(Weekday::Tue),
             NWeekday::Every(Weekday::Wed),
             NWeekday::Every(Weekday::Thu),
             NWeekday::Every(Weekday::Fri),
         ]),
-        Some(SpecialDays::Weekend) => rule.by_weekday(vec![
+        Some(DayKind::Weekend) => rule.by_weekday(vec![
             NWeekday::Every(Weekday::Sat),
             NWeekday::Every(Weekday::Sun),
         ]),
     };
     Ok(rule)
+}
+
+fn iso8601_components(part: &str, designators: [char; 3]) -> Result<[u32; 3]> {
+    let mut values = [0; 3];
+    let mut next = 0;
+    let mut digits = String::new();
+    for c in part.chars() {
+        if c.is_ascii_digit() {
+            digits.push(c);
+            continue;
+        }
+        let offset = designators[next..]
+            .iter()
+            .position(|d| *d == c)
+            .ok_or_else(|| Error::Usage(format!("Unexpected {c:?} in ISO-8601 duration.")))?;
+        values[next + offset] = digits
+            .parse::<u32>()
+            .map_err(|e| Error::Usage(format!("Could not parse value before {c:?}: {e}")))?;
+        next += offset + 1;
+        digits.clear();
+    }
+    if !digits.is_empty() {
+        return Err(Error::Usage(format!(
+            "Value {digits:?} in ISO-8601 duration has no unit."
+        )));
+    }
+    Ok(values)
+}
+
+/// Parse an ISO-8601 duration (`P[nY][nM][nD][T[nH][nM][nS]]`) into a RRule.
+fn iso8601_to_rrule(value: &str) -> Result<RRule<Unvalidated>> {
+    let value = value.trim().to_ascii_uppercase();
+    let body = value
+        .strip_prefix('P')
+        .ok_or_else(|| Error::Usage(format!("{value:?} is not an ISO-8601 duration.")))?;
+
+    // The 'T' separates the date components from the time components, and is what
+    // distinguishes months from minutes.
+    let (date, time) = body.split_once('T').unwrap_or((body, ""));
+    let [years, months, days] = iso8601_components(date, ['Y', 'M', 'D'])?;
+    let [hours, minutes, seconds] = iso8601_components(time, ['H', 'M', 'S'])?;
+
+    // Reduce each kind to its smallest unit.
+    let calendar = u64::from(years) * 12 + u64::from(months);
+    let exact = u64::from(days) * 86400
+        + u64::from(hours) * 3600
+        + u64::from(minutes) * 60
+        + u64::from(seconds);
+
+    // Use the largest unit that divides the duration evenly, so that PT12H is
+    // hourly rather than every 43200 seconds.
+    let (freq, interval) = match (calendar, exact) {
+        (0, 0) => return Err(Error::Usage(format!("Duration {value:?} is zero."))),
+        (_, 0) if calendar % 12 == 0 => (Frequency::Yearly, calendar / 12),
+        (_, 0) => (Frequency::Monthly, calendar),
+        (0, _) if exact % 86400 == 0 => (Frequency::Daily, exact / 86400),
+        (0, _) if exact % 3600 == 0 => (Frequency::Hourly, exact / 3600),
+        (0, _) if exact % 60 == 0 => (Frequency::Minutely, exact / 60),
+        (0, _) => (Frequency::Secondly, exact),
+        _ => {
+            return Err(Error::Usage(format!(
+                "Duration {value:?} mixes months or years with smaller units, \
+                 which has no repetition equivalent."
+            )))
+        }
+    };
+
+    let interval = u16::try_from(interval)
+        .map_err(|_| Error::Usage(format!("Duration {value:?} is too large.")))?;
+    Ok(RRule::new(freq).interval(interval))
 }
 
 #[cfg(test)]
@@ -346,5 +423,353 @@ mod test {
         assert_eq!(IterType::from_str("fp").unwrap(), IterType::FixedPlus);
         assert_eq!(IterType::from_str("chained").unwrap(), IterType::Chained);
         assert_eq!(IterType::from_str("ch").unwrap(), IterType::Chained);
+    }
+
+    /// Assert that every string in `cases` parses correctly.
+    fn assert_all(cases: &[&str], freq: Frequency, interval: u16) {
+        for case in cases {
+            let rule = validate_rrule(case);
+            assert_eq!(rule.get_freq(), freq, "wrong frequency for {case:?}");
+            assert_eq!(rule.get_interval(), interval, "wrong interval for {case:?}");
+        }
+    }
+
+    /// Assert that every string in `cases` is rejected.
+    fn assert_all_rejected(cases: &[&str]) {
+        for case in cases {
+            assert!(
+                matches!(str2rrule(case), Err(Error::Usage(_))),
+                "expected {case:?} to be rejected"
+            );
+        }
+    }
+
+    /// Every example from https://taskwarrior.org/docs/durations/
+    mod duration_examples {
+        use super::*;
+
+        mod seconds {
+            use super::*;
+
+            #[test]
+            fn five_seconds() {
+                assert_all(
+                    &[
+                        "5 seconds",
+                        "5 second",
+                        "5 secs",
+                        "5 sec",
+                        "5 s",
+                        "5seconds",
+                        "5second",
+                        "5secs",
+                        "5sec",
+                        "5s",
+                    ],
+                    Frequency::Secondly,
+                    5,
+                );
+            }
+
+            #[test]
+            fn one_second() {
+                assert_all(&["second", "sec"], Frequency::Secondly, 1);
+            }
+        }
+
+        mod minutes {
+            use super::*;
+
+            #[test]
+            fn five_minutes() {
+                assert_all(
+                    &[
+                        "5 minutes",
+                        "5 minute",
+                        "5 mins",
+                        "5 min",
+                        "5minutes",
+                        "5minute",
+                        "5mins",
+                        "5min",
+                    ],
+                    Frequency::Minutely,
+                    5,
+                );
+            }
+
+            #[test]
+            fn one_minute() {
+                assert_all(&["minute", "min"], Frequency::Minutely, 1);
+            }
+        }
+
+        mod hours {
+            use super::*;
+
+            #[test]
+            fn three_hours() {
+                assert_all(
+                    &[
+                        "3 hours", "3 hour", "3 hrs", "3 hr", "3 h", "3hours", "3hour", "3hrs",
+                        "3hr", "3h",
+                    ],
+                    Frequency::Hourly,
+                    3,
+                );
+            }
+
+            #[test]
+            fn one_hour() {
+                assert_all(&["hour", "hr"], Frequency::Hourly, 1);
+            }
+        }
+
+        mod days {
+            use super::*;
+
+            #[test]
+            fn two_days() {
+                assert_all(
+                    &["2 days", "2 day", "2 d", "2days", "2day", "2d"],
+                    Frequency::Daily,
+                    2,
+                );
+            }
+
+            #[test]
+            fn one_day() {
+                assert_all(&["daily", "day"], Frequency::Daily, 1);
+            }
+        }
+
+        mod weeks {
+            use super::*;
+
+            #[test]
+            fn three_weeks() {
+                assert_all(
+                    &[
+                        "3 weeks", "3 week", "3 wks", "3 wk", "3 w", "3weeks", "3week", "3wks",
+                        "3wk", "3w",
+                    ],
+                    Frequency::Weekly,
+                    3,
+                );
+            }
+
+            #[test]
+            fn one_week() {
+                assert_all(&["weekly", "week", "wk"], Frequency::Weekly, 1);
+            }
+
+            #[test]
+            fn weekdays() {
+                let rule = validate_rrule("weekdays");
+                assert_eq!(rule.get_freq(), Frequency::Daily);
+                assert_eq!(rule.get_interval(), 1);
+                assert_eq!(
+                    rule.get_by_weekday(),
+                    &[
+                        NWeekday::Every(Weekday::Mon),
+                        NWeekday::Every(Weekday::Tue),
+                        NWeekday::Every(Weekday::Wed),
+                        NWeekday::Every(Weekday::Thu),
+                        NWeekday::Every(Weekday::Fri),
+                    ]
+                );
+            }
+        }
+
+        mod fortnights {
+            use super::*;
+
+            /// Twenty eight days
+            #[test]
+            fn two_fortnights() {
+                assert_all(
+                    &["2 fortnight", "2 sennight", "2fortnight", "2sennight"],
+                    Frequency::Weekly,
+                    4,
+                );
+            }
+
+            /// Fourteen days.
+            #[test]
+            fn one_fortnight() {
+                assert_all(&["biweekly", "fortnight", "sennight"], Frequency::Weekly, 2);
+            }
+        }
+
+        mod months {
+            use super::*;
+
+            #[test]
+            fn five_months() {
+                assert_all(
+                    &[
+                        "5 months", "5 month", "5 mnths", "5 mths", "5 mth", "5 mo", "5 m",
+                        "5months", "5month", "5mnths", "5mths", "5mth", "5mo", "5m",
+                    ],
+                    Frequency::Monthly,
+                    5,
+                );
+            }
+
+            #[test]
+            fn one_month() {
+                assert_all(&["monthly", "month", "mth", "mo"], Frequency::Monthly, 1);
+            }
+
+            #[test]
+            fn bimonthly() {
+                assert_all(&["bimonthly"], Frequency::Monthly, 2);
+            }
+        }
+
+        mod quarters {
+            use super::*;
+
+            #[test]
+            fn one_quarter_with_ordinal() {
+                assert_all(
+                    &[
+                        "1 quarterly",
+                        "1 quarters",
+                        "1 quarter",
+                        "1 qrtrs",
+                        "1 qrtr",
+                        "1 qtr",
+                        "1 q",
+                        "1quarterly",
+                        "1quarters",
+                        "1quarter",
+                        "1qrtrs",
+                        "1qrtr",
+                        "1qtr",
+                        "1q",
+                    ],
+                    Frequency::Monthly,
+                    3,
+                );
+            }
+
+            #[test]
+            fn one_quarter() {
+                assert_all(
+                    &["quarterly", "quarter", "qrtr", "qtr"],
+                    Frequency::Monthly,
+                    3,
+                );
+            }
+        }
+
+        mod semiannual {
+            use super::*;
+
+            #[test]
+            fn semiannual() {
+                assert_all(&["semiannual"], Frequency::Monthly, 6);
+            }
+        }
+
+        mod years {
+            use super::*;
+
+            #[test]
+            fn one_year_with_ordinal() {
+                assert_all(
+                    &[
+                        "1 years", "1 year", "1 yrs", "1 yr", "1 y", "1years", "1year", "1yrs",
+                        "1yr", "1y",
+                    ],
+                    Frequency::Yearly,
+                    1,
+                );
+            }
+
+            #[test]
+            fn one_year() {
+                assert_all(&["annual", "yearly", "year", "yr"], Frequency::Yearly, 1);
+            }
+
+            #[test]
+            fn two_years() {
+                assert_all(&["biannual", "biyearly"], Frequency::Yearly, 2);
+            }
+        }
+
+        mod iso8601 {
+            use super::*;
+
+            #[test]
+            fn date_durations() {
+                assert_all(&["P3D"], Frequency::Daily, 3);
+                assert_all(&["P1000D"], Frequency::Daily, 1000);
+                assert_all(&["P2M"], Frequency::Monthly, 2);
+                assert_all(&["P1Y"], Frequency::Yearly, 1);
+                assert_all(&["P1Y2M"], Frequency::Monthly, 14);
+            }
+
+            #[test]
+            fn time_durations() {
+                assert_all(&["PT50S"], Frequency::Secondly, 50);
+                assert_all(&["PT40M"], Frequency::Minutely, 40);
+                assert_all(&["PT40M50S"], Frequency::Secondly, 2450);
+                assert_all(&["PT12H"], Frequency::Hourly, 12);
+                assert_all(&["PT12H50S"], Frequency::Secondly, 43250);
+                assert_all(&["PT12H40M"], Frequency::Minutely, 760);
+                assert_all(&["PT12H40M50S"], Frequency::Secondly, 45650);
+            }
+
+            /// Days, hours, minutes and seconds are all exact, so they combine.
+            #[test]
+            fn combined_exact_units() {
+                assert_all(&["P3DT12H"], Frequency::Hourly, 84);
+            }
+
+            /// The length of a month varies, so a duration mixing months or years
+            /// with smaller units cannot be reduced to one frequency and interval.
+            #[test]
+            fn mixed_units_rejected() {
+                assert_all_rejected(&["P2M3D", "P1Y3D", "P1Y2M3D", "P1Y2M3DT12H40M50S"]);
+            }
+
+            #[test]
+            fn malformed_rejected() {
+                assert_all_rejected(&[
+                    "P",       // no components
+                    "PT",      // no components
+                    "P0D",     // zero duration
+                    "T50S",    // no leading P
+                    "P3",      // value with no unit
+                    "PD",      // unit with no value
+                    "PT3D",    // date unit in the time half
+                    "P3H",     // time unit in the date half
+                    "P3D2Y",   // units out of order
+                    "P3D2D",   // repeated unit
+                    "P70000D", // interval too large for a rule
+                    "P3Dgarbage",
+                ]);
+            }
+        }
+
+        /// Time doesn't run backwards, so negative durations are rejected.
+        mod negative {
+            use super::*;
+
+            #[test]
+            fn negative_durations() {
+                assert_all_rejected(&[
+                    "-PT30S",
+                    "-PT40M",
+                    "-PT12H",
+                    "-P3D",
+                    "-P2M",
+                    "-P1Y",
+                    "-P1Y2M3DT12H40M50S",
+                ]);
+            }
+        }
     }
 }

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::module_inception)]
 mod annotation;
 mod data;
+mod iter;
 mod status;
 mod tag;
 mod task;
@@ -8,6 +9,7 @@ mod time;
 
 pub use annotation::Annotation;
 pub use data::TaskData;
+pub use iter::{str2rrule, IterType};
 pub use status::Status;
 pub use tag::Tag;
 pub use task::Task;

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -1,6 +1,8 @@
 #![allow(clippy::module_inception)]
 mod annotation;
 mod data;
+#[cfg(feature = "iterative-tasks")]
+mod iter;
 mod status;
 mod tag;
 mod task;
@@ -8,8 +10,12 @@ mod time;
 
 pub use annotation::Annotation;
 pub use data::TaskData;
+#[cfg(feature = "iterative-tasks")]
+pub use iter::IterType;
 pub use status::Status;
 pub use tag::Tag;
 pub use task::Task;
+#[cfg(feature = "iterative-tasks")]
+pub(crate) use time::local_tz;
 pub use time::utc_timestamp;
-pub(crate) use time::Timestamp;
+pub(crate) use time::{utc_now, Timestamp};

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::module_inception)]
 mod annotation;
 mod data;
+#[cfg(feature = "iterative-tasks")]
 mod iter;
 mod status;
 mod tag;
@@ -9,9 +10,12 @@ mod time;
 
 pub use annotation::Annotation;
 pub use data::TaskData;
+#[cfg(feature = "iterative-tasks")]
 pub use iter::IterType;
 pub use status::Status;
 pub use tag::Tag;
 pub use task::Task;
 pub use time::utc_timestamp;
 pub(crate) use time::{utc_now, Timestamp};
+#[cfg(feature = "iterative-tasks")]
+pub(crate) use time::local_tz;

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -9,9 +9,9 @@ mod time;
 
 pub use annotation::Annotation;
 pub use data::TaskData;
-pub use iter::{str2rrule, IterType};
+pub use iter::IterType;
 pub use status::Status;
 pub use tag::Tag;
 pub use task::Task;
 pub use time::utc_timestamp;
-pub(crate) use time::Timestamp;
+pub(crate) use time::{utc_now, Timestamp};

--- a/src/task/status.rs
+++ b/src/task/status.rs
@@ -6,6 +6,7 @@ pub enum Status {
     Completed,
     Deleted,
     Recurring,
+    Iterative,
     /// Unknown signifies a status in the task DB that was not
     /// recognized.  This supports forward-compatibility if a
     /// new status is added.  Tasks with unknown status should
@@ -21,6 +22,7 @@ impl Status {
             "completed" => Status::Completed,
             "deleted" => Status::Deleted,
             "recurring" => Status::Recurring,
+            "iterative" => Status::Iterative,
             v => Status::Unknown(v.to_string()),
         }
     }
@@ -32,6 +34,7 @@ impl Status {
             Status::Completed => "completed",
             Status::Deleted => "deleted",
             Status::Recurring => "recurring",
+            Status::Iterative => "iterative",
             Status::Unknown(v) => v.as_ref(),
         }
     }
@@ -48,6 +51,7 @@ mod test {
         assert_eq!(Status::Completed.to_taskmap(), "completed");
         assert_eq!(Status::Deleted.to_taskmap(), "deleted");
         assert_eq!(Status::Recurring.to_taskmap(), "recurring");
+        assert_eq!(Status::Iterative.to_taskmap(), "iterative");
         assert_eq!(Status::Unknown("wishful".into()).to_taskmap(), "wishful");
     }
 
@@ -57,6 +61,7 @@ mod test {
         assert_eq!(Status::from_taskmap("completed"), Status::Completed);
         assert_eq!(Status::from_taskmap("deleted"), Status::Deleted);
         assert_eq!(Status::from_taskmap("recurring"), Status::Recurring);
+        assert_eq!(Status::from_taskmap("iterative"), Status::Iterative);
         assert_eq!(
             Status::from_taskmap("something-else"),
             Status::Unknown("something-else".into())
@@ -69,6 +74,7 @@ mod test {
         assert_eq!(format!("{}", Status::Completed), "Completed");
         assert_eq!(format!("{}", Status::Deleted), "Deleted");
         assert_eq!(format!("{}", Status::Recurring), "Recurring");
+        assert_eq!(format!("{}", Status::Iterative), "Iterative");
         assert_eq!(format!("{}", Status::Unknown("wishful".into())), "Unknown");
     }
 }

--- a/src/task/status.rs
+++ b/src/task/status.rs
@@ -6,6 +6,7 @@ pub enum Status {
     Completed,
     Deleted,
     Recurring,
+    Iterative,
     /// Unknown signifies a status in the task DB that was not
     /// recognized.  This supports forward-compatibility if a
     /// new status is added.  Tasks with unknown status should
@@ -21,6 +22,7 @@ impl Status {
             "completed" => Status::Completed,
             "deleted" => Status::Deleted,
             "recurring" => Status::Recurring,
+            "iterative" => Status::Iterative,
             v => Status::Unknown(v.to_string()),
         }
     }
@@ -32,6 +34,7 @@ impl Status {
             Status::Completed => "completed",
             Status::Deleted => "deleted",
             Status::Recurring => "recurring",
+            Status::Iterative => "iterative",
             Status::Unknown(v) => v.as_ref(),
         }
     }

--- a/src/task/task.rs
+++ b/src/task/task.rs
@@ -3,10 +3,11 @@ use super::{utc_timestamp, Annotation, Status, Tag, Timestamp};
 use crate::depmap::DependencyMap;
 use crate::errors::{Error, Result};
 use crate::storage::TaskMap;
+use crate::task::{iter, IterType};
 use crate::{Operations, TaskData};
 use chrono::prelude::*;
 use log::trace;
-use rrule::Tz;
+use rrule::{RRuleSet, Tz};
 use std::convert::AsRef;
 use std::convert::TryInto;
 use std::str::FromStr;
@@ -312,7 +313,17 @@ impl Task {
                     self.set_timestamp(Prop::End.as_ref(), None, ops)?;
                 }
             }
-            Status::Completed | Status::Deleted => {
+            Status::Completed => {
+                if self.get_status() == Status::Iterative {
+                    // Create clone with Completed status.
+                    // Generate new due date.
+                }
+                // set "end" when a task is deleted or completed
+                if !self.data.has(Prop::End.as_ref()) {
+                    self.set_timestamp(Prop::End.as_ref(), Some(Utc::now()), ops)?;
+                }
+            }
+            Status::Deleted => {
                 // set "end" when a task is deleted or completed
                 if !self.data.has(Prop::End.as_ref()) {
                     self.set_timestamp(Prop::End.as_ref(), Some(Utc::now()), ops)?;
@@ -325,19 +336,21 @@ impl Task {
                     // For the proof of concept, we'll assume that the rrule dt_start
                     // time is now. In the future this could be parsed from 'iter'.
                     let dt_start = chrono::Utc::now().with_timezone(&Tz::Local(chrono::Local));
-                    // Create the rrule. For the proof of concept, we'll assume
-                    // that 'iter' is an rrule. In the future, we'd parse 'iter'
-                    // into one.
-                    let rule: rrule::RRule<rrule::Unvalidated> = iter.parse().map_err(|e| {
-                        Error::Usage(format!("Couldn't parse iter into rrule: {e}"))
-                    })?;
+                    // Create the rrule.
+                    let rule = iter::str2rrule(iter)?;
                     let rule = rule
                         .validate(dt_start)
-                        .map_err(|e| Error::Usage(format!("Couldn't validate rrule: {e}")))?
-                        .to_string();
+                        .map_err(|e| Error::Usage(format!("Couldn't validate rrule: {e}")))?;
+                    let rrule_set = RRuleSet::new(dt_start).rrule(rule);
                     // Set the rrule value.
-                    self.set_value("rrule", Some(rule), ops)?;
+                    self.set_value("rrule", Some(rrule_set.to_string()), ops)?;
+                    // Check that iter_type exists, otherwise assume chained.
+                    if self.data.get("iter_type").is_none() {
+                        self.set_value("iter_type", Some(IterType::Chained.to_string()), ops)?;
+                    }
                     // Set the next due date.
+                    let due = rrule_set.after(dt_start).all(1).dates[0].to_utc();
+                    self.set_due(Some(due), ops)?;
                 } else {
                     return Err(Error::Usage(
                         "Iterative tasks require an 'iter' value.".into(),

--- a/src/task/task.rs
+++ b/src/task/task.rs
@@ -14,6 +14,34 @@ use std::str::FromStr;
 use std::sync::Arc;
 use uuid::Uuid;
 
+#[cfg(not(test))]
+fn now() -> DateTime<Utc> {
+    Utc::now()
+}
+
+#[cfg(test)]
+mod mock_time {
+    use chrono::{DateTime, Utc};
+    use std::cell::Cell;
+    thread_local! {
+        static T: Cell<Option<i64>> = Cell::new(None);
+    }
+    pub(super) fn now() -> DateTime<Utc> {
+        T.with(|t| match t.get() {
+            Some(secs) => DateTime::from_timestamp(secs, 0).unwrap(),
+            None => Utc::now(),
+        })
+    }
+    pub(super) fn set(t: DateTime<Utc>) {
+        T.with(|c| c.set(Some(t.timestamp())));
+    }
+    pub(super) fn reset() {
+        T.with(|c| c.set(None));
+    }
+}
+#[cfg(test)]
+use mock_time::now;
+
 /// A task, with a high-level interface.
 ///
 /// Building on [`crate::TaskData`], this type implements the task model, with ergonomic APIs to
@@ -316,26 +344,88 @@ impl Task {
             Status::Completed => {
                 if self.get_status() == Status::Iterative {
                     // Create clone with Completed status.
+                    let uuid = Uuid::new_v4();
+                    let mut dup = Task::new(TaskData::create(uuid, ops), self.depmap.clone());
+                    for (prop, value) in self.data.iter() {
+                        dup.data.update(prop, Some(value.to_owned()), ops);
+                    }
+                    dup.set_value(
+                        Prop::Status.as_ref(),
+                        Some(String::from(Status::Completed.to_taskmap())),
+                        ops,
+                    )?;
+                    dup.set_timestamp(Prop::End.as_ref(), Some(now()), ops)?;
                     // Generate new due date.
+                    let iter_type = match self.data.get("iter_type") {
+                        Some(t) => IterType::from_str(t).unwrap_or_default(),
+                        None => IterType::Chained,
+                    };
+                    let rule_str = self.data.get("rrule").ok_or_else(|| {
+                        Error::Iterative("Couldn't get rrule from iter task.".into())
+                    })?;
+                    let orig_due = self
+                        .get_due()
+                        .unwrap_or_else(now)
+                        .with_timezone(&Tz::Local(chrono::Local));
+
+                    let due = match iter_type {
+                        IterType::Fixed => {
+                            // create rule set from rule and orig date
+                            let rrule_set = RRuleSet::from_str(rule_str).map_err(|e| {
+                                Error::Iterative(format!("Couldn't get rule set from rule: {}", e))
+                            })?;
+                            // get first date strictly after orig due date
+                            let after = orig_due + chrono::Duration::seconds(1);
+                            rrule_set.after(after).all(1).dates[0].to_utc()
+                        }
+                        IterType::FixedPlus => {
+                            // create rule set from rule and orig date
+                            let rrule_set = RRuleSet::from_str(rule_str).map_err(|e| {
+                                Error::Iterative(format!("Couldn't get rule set from rule: {}", e))
+                            })?;
+                            // get first date strictly after now
+                            let now = now().with_timezone(&Tz::Local(chrono::Local));
+                            let after = now + chrono::Duration::seconds(1);
+                            rrule_set.after(after).all(1).dates[0].to_utc()
+                        }
+                        IterType::Chained => {
+                            // get now
+                            let now = now().with_timezone(&Tz::Local(chrono::Local));
+                            // rebuild the rule anchored to now using the stored iter string
+                            let iter_str = self.data.get("iter").ok_or_else(|| {
+                                Error::Iterative("Couldn't get iter from iter task.".into())
+                            })?;
+                            let rule = iter::str2rrule(iter_str)?.validate(now).map_err(|e| {
+                                Error::Usage(format!("Couldn't validate rrule: {e}"))
+                            })?;
+                            // get first date after now
+                            let rrule_set = RRuleSet::new(now).rrule(rule);
+                            rrule_set
+                                .after(now + chrono::Duration::seconds(1))
+                                .all(1)
+                                .dates[0]
+                                .to_utc()
+                        }
+                    };
+                    self.set_due(Some(due), ops)?;
                 }
                 // set "end" when a task is deleted or completed
                 if !self.data.has(Prop::End.as_ref()) {
-                    self.set_timestamp(Prop::End.as_ref(), Some(Utc::now()), ops)?;
+                    self.set_timestamp(Prop::End.as_ref(), Some(now()), ops)?;
                 }
             }
             Status::Deleted => {
                 // set "end" when a task is deleted or completed
                 if !self.data.has(Prop::End.as_ref()) {
-                    self.set_timestamp(Prop::End.as_ref(), Some(Utc::now()), ops)?;
+                    self.set_timestamp(Prop::End.as_ref(), Some(now()), ops)?;
                 }
             }
             Status::Iterative => {
                 // Check that there is a an 'iter' value.
                 if let Some(iter) = self.data.get("iter") {
-                    // calculate dates, etc
                     // For the proof of concept, we'll assume that the rrule dt_start
-                    // time is now. In the future this could be parsed from 'iter'.
-                    let dt_start = chrono::Utc::now().with_timezone(&Tz::Local(chrono::Local));
+                    // time is now. In the future this could be parsed from 'iter', .
+                    let dt_start = now().with_timezone(&Tz::Local(chrono::Local));
                     // Create the rrule.
                     let rule = iter::str2rrule(iter)?;
                     let rule = rule
@@ -1180,6 +1270,138 @@ mod test {
         task.data.update("iter", Some("3blarg".into()), &mut ops);
         let result = task.set_status(Status::Iterative, &mut ops);
         assert!(matches!(result, Err(Error::Usage(_))));
+    }
+
+    async fn setup_iterative_task(
+        iter: &str,
+        iter_type: Option<&str>,
+    ) -> (Replica<InMemoryStorage>, Task, Operations, Uuid) {
+        let mut replica = Replica::new(InMemoryStorage::new());
+        let mut ops = Operations::new();
+        let uuid = Uuid::new_v4();
+        let mut task = replica.create_task(uuid, &mut ops).await.unwrap();
+        task.data.update("iter", Some(iter.into()), &mut ops);
+        if let Some(t) = iter_type {
+            task.data.update("iter_type", Some(t.into()), &mut ops);
+        }
+        task.set_status(Status::Iterative, &mut ops).unwrap();
+        (replica, task, ops, uuid)
+    }
+
+    #[tokio::test]
+    async fn test_complete_iterative_chained() {
+        let (_, mut task, mut ops, _) = setup_iterative_task("daily", None).await;
+        task.set_status(Status::Completed, &mut ops).unwrap();
+        let due_after = task.get_due().unwrap();
+        // Chained anchors to now, so the next occurrence is now + 1 day (in the future).
+        assert!(
+            due_after > Utc::now(),
+            "due should be in the future: {due_after}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_complete_iterative_fixed() {
+        let (_, mut task, mut ops, _) = setup_iterative_task("daily", Some("fixed")).await;
+        let due_before = task.get_due().unwrap();
+        task.set_status(Status::Completed, &mut ops).unwrap();
+        let due_after = task.get_due().unwrap();
+        // Fixed advances from the original schedule, so the new due is strictly after the old.
+        assert!(
+            due_after > due_before,
+            "due should advance: before={due_before}, after={due_after}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_complete_iterative_fixed_plus() {
+        let (_, mut task, mut ops, _) = setup_iterative_task("daily", Some("fixed+")).await;
+        task.set_status(Status::Completed, &mut ops).unwrap();
+        let due_after = task.get_due().unwrap();
+        // FixedPlus anchors to now, so the next occurrence is now + 1 day (in the future).
+        assert!(
+            due_after > Utc::now(),
+            "due should be in the future: {due_after}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_complete_iterative_creates_clone() {
+        let (mut replica, mut task, mut ops, uuid) = setup_iterative_task("daily", None).await;
+        task.set_status(Status::Completed, &mut ops).unwrap();
+        replica.commit_operations(ops).await.unwrap();
+
+        let all = replica.all_tasks().await.unwrap();
+        assert_eq!(all.len(), 2, "should have original + completed clone");
+
+        let clone = all.values().find(|t| t.get_uuid() != uuid).unwrap();
+        assert_eq!(clone.get_status(), Status::Completed);
+        assert!(clone.data.has("end"));
+    }
+
+    #[tokio::test]
+    async fn test_complete_iterative_no_rrule_error() {
+        let mut replica = Replica::new(InMemoryStorage::new());
+        let mut ops = Operations::new();
+        let uuid = Uuid::new_v4();
+        let mut task = replica.create_task(uuid, &mut ops).await.unwrap();
+        // Manually set status=iterative without going through set_status(Iterative),
+        // so no "rrule" property is stored.
+        task.data
+            .update("status", Some("iterative".into()), &mut ops);
+        let result = task.set_status(Status::Completed, &mut ops);
+        assert!(matches!(result, Err(Error::Iterative(_))));
+    }
+
+    // time_start = 2026-01-01 00:00:00 UTC.  Weekly occurrences: Jan 8, Jan 15, Jan 22, Jan 29 …
+    // time_twenty_four_days_later = 2026-01-25 00:00:00 UTC (task is ~2.5 weeks overdue when completed).
+    fn time_start() -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap()
+    }
+    fn time_twenty_four_days_later() -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 1, 25, 0, 0, 0).unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_fixed_advances_from_schedule() {
+        super::mock_time::set(time_start());
+        let (_, mut task, mut ops, _) = setup_iterative_task("weekly", Some("fixed")).await;
+        super::mock_time::set(time_twenty_four_days_later());
+        task.set_status(Status::Completed, &mut ops).unwrap();
+        super::mock_time::reset();
+        // Fixed: first weekly occurrence strictly after orig_due (Jan 8) = Jan 15
+        assert_eq!(
+            task.get_due(),
+            Some(time_start() + chrono::Duration::weeks(1))
+        );
+    }
+
+    #[tokio::test]
+    async fn test_fixed_plus_advances_from_now() {
+        super::mock_time::set(time_start());
+        let (_, mut task, mut ops, _) = setup_iterative_task("weekly", Some("fixed+")).await;
+        super::mock_time::set(time_twenty_four_days_later());
+        task.set_status(Status::Completed, &mut ops).unwrap();
+        super::mock_time::reset();
+        // FixedPlus: first weekly occurrence strictly after now (Jan 25) = Jan 29
+        assert_eq!(
+            task.get_due(),
+            Some(time_start() + chrono::Duration::weeks(4))
+        );
+    }
+
+    #[tokio::test]
+    async fn test_chained_advances_period_from_now() {
+        super::mock_time::set(time_start());
+        let (_, mut task, mut ops, _) = setup_iterative_task("weekly", None).await;
+        super::mock_time::set(time_twenty_four_days_later());
+        task.set_status(Status::Completed, &mut ops).unwrap();
+        super::mock_time::reset();
+        // Chained: new rrule anchored to now (Jan 25), first occurrence after now = Feb 1
+        assert_eq!(
+            task.get_due(),
+            Some(time_twenty_four_days_later() + chrono::Duration::weeks(1))
+        );
     }
 
     #[tokio::test]

--- a/src/task/task.rs
+++ b/src/task/task.rs
@@ -335,9 +335,9 @@ impl Task {
     /// This also updates the task's "end" property appropriately.
     pub fn set_status(&mut self, status: Status, ops: &mut Operations) -> Result<()> {
         match status {
-            Status::Pending | Status::Recurring
+            Status::Pending | Status::Recurring => {
                 // clear "end" when a task becomes "pending" or "recurring"
-                if self.data.has(Prop::End.as_ref()) => {
+                if self.data.has(Prop::End.as_ref()) {
                     self.set_timestamp(Prop::End.as_ref(), None, ops)?;
                 }
             }

--- a/src/task/task.rs
+++ b/src/task/task.rs
@@ -24,7 +24,7 @@ mod mock_time {
     use chrono::{DateTime, Utc};
     use std::cell::Cell;
     thread_local! {
-        static T: Cell<Option<i64>> = Cell::new(None);
+        static T: Cell<Option<i64>> = const {Cell::new(None)};
     }
     pub(super) fn now() -> DateTime<Utc> {
         T.with(|t| match t.get() {

--- a/src/task/task.rs
+++ b/src/task/task.rs
@@ -1130,6 +1130,59 @@ mod test {
     }
 
     #[tokio::test]
+    async fn test_set_status_iterative_basic() {
+        with_mut_task(
+            |task, ops| {
+                task.data.update("iter", Some("daily".into()), ops);
+                task.set_status(Status::Iterative, ops).unwrap();
+            },
+            |task| {
+                assert_eq!(task.get_status(), Status::Iterative);
+                assert!(task.data.has("rrule"));
+                assert!(task.get_due().is_some());
+                assert_eq!(task.data.get("iter_type"), Some("chained"));
+            },
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_set_status_iterative_preserves_iter_type() {
+        with_mut_task(
+            |task, ops| {
+                task.data.update("iter", Some("weekly".into()), ops);
+                task.data.update("iter_type", Some("fixed".into()), ops);
+                task.set_status(Status::Iterative, ops).unwrap();
+            },
+            |task| {
+                assert_eq!(task.data.get("iter_type"), Some("fixed"));
+            },
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_set_status_iterative_no_iter() {
+        let mut replica = Replica::new(InMemoryStorage::new());
+        let mut ops = Operations::new();
+        let uuid = Uuid::new_v4();
+        let mut task = replica.create_task(uuid, &mut ops).await.unwrap();
+        let result = task.set_status(Status::Iterative, &mut ops);
+        assert!(matches!(result, Err(Error::Usage(_))));
+    }
+
+    #[tokio::test]
+    async fn test_set_status_iterative_invalid_iter() {
+        let mut replica = Replica::new(InMemoryStorage::new());
+        let mut ops = Operations::new();
+        let uuid = Uuid::new_v4();
+        let mut task = replica.create_task(uuid, &mut ops).await.unwrap();
+        task.data.update("iter", Some("3blarg".into()), &mut ops);
+        let result = task.set_status(Status::Iterative, &mut ops);
+        assert!(matches!(result, Err(Error::Usage(_))));
+    }
+
+    #[tokio::test]
     async fn test_set_get_value() {
         let property = "property-name";
         with_mut_task(

--- a/src/task/task.rs
+++ b/src/task/task.rs
@@ -6,6 +6,7 @@ use crate::storage::TaskMap;
 use crate::{Operations, TaskData};
 use chrono::prelude::*;
 use log::trace;
+use rrule::Tz;
 use std::convert::AsRef;
 use std::convert::TryInto;
 use std::str::FromStr;
@@ -317,7 +318,33 @@ impl Task {
                     self.set_timestamp(Prop::End.as_ref(), Some(Utc::now()), ops)?;
                 }
             }
-            _ => {}
+            Status::Iterative => {
+                // Check that there is a an 'iter' value.
+                if let Some(iter) = self.data.get("iter") {
+                    // calculate dates, etc
+                    // For the proof of concept, we'll assume that the rrule dt_start
+                    // time is now. In the future this could be parsed from 'iter'.
+                    let dt_start = chrono::Utc::now().with_timezone(&Tz::Local(chrono::Local));
+                    // Create the rrule. For the proof of concept, we'll assume
+                    // that 'iter' is an rrule. In the future, we'd parse 'iter'
+                    // into one.
+                    let rule: rrule::RRule<rrule::Unvalidated> = iter.parse().map_err(|e| {
+                        Error::Usage(format!("Couldn't parse iter into rrule: {e}"))
+                    })?;
+                    let rule = rule
+                        .validate(dt_start)
+                        .map_err(|e| Error::Usage(format!("Couldn't validate rrule: {e}")))?
+                        .to_string();
+                    // Set the rrule value.
+                    self.set_value("rrule", Some(rule), ops)?;
+                    // Set the next due date.
+                } else {
+                    return Err(Error::Usage(
+                        "Iterative tasks require an 'iter' value.".into(),
+                    ));
+                }
+            }
+            Status::Unknown(_) => {}
         }
         self.set_value(
             Prop::Status.as_ref(),

--- a/src/task/task.rs
+++ b/src/task/task.rs
@@ -3,7 +3,7 @@ use super::{utc_timestamp, Annotation, Status, Tag, Timestamp};
 use crate::depmap::DependencyMap;
 use crate::errors::{Error, Result};
 use crate::storage::TaskMap;
-use crate::task::{iter, IterType};
+use crate::task::{iter, utc_now, IterType};
 use crate::{Operations, TaskData};
 use chrono::prelude::*;
 use log::trace;
@@ -13,34 +13,6 @@ use std::convert::TryInto;
 use std::str::FromStr;
 use std::sync::Arc;
 use uuid::Uuid;
-
-#[cfg(not(test))]
-fn now() -> DateTime<Utc> {
-    Utc::now()
-}
-
-#[cfg(test)]
-mod mock_time {
-    use chrono::{DateTime, Utc};
-    use std::cell::Cell;
-    thread_local! {
-        static T: Cell<Option<i64>> = const {Cell::new(None)};
-    }
-    pub(super) fn now() -> DateTime<Utc> {
-        T.with(|t| match t.get() {
-            Some(secs) => DateTime::from_timestamp(secs, 0).unwrap(),
-            None => Utc::now(),
-        })
-    }
-    pub(super) fn set(t: DateTime<Utc>) {
-        T.with(|c| c.set(Some(t.timestamp())));
-    }
-    pub(super) fn reset() {
-        T.with(|c| c.set(None));
-    }
-}
-#[cfg(test)]
-use mock_time::now;
 
 /// A task, with a high-level interface.
 ///
@@ -354,18 +326,21 @@ impl Task {
                         Some(String::from(Status::Completed.to_taskmap())),
                         ops,
                     )?;
-                    dup.set_timestamp(Prop::End.as_ref(), Some(now()), ops)?;
+                    dup.set_timestamp(Prop::End.as_ref(), Some(utc_now()), ops)?;
                     // Generate new due date.
                     let iter_type = match self.data.get("iter_type") {
-                        Some(t) => IterType::from_str(t).unwrap_or_default(),
+                        Some(t) => IterType::from_str(t).map_err(|e| {
+                            Error::Iterative(format!("Couldn't parse iter type {}", e))
+                        })?,
                         None => IterType::Chained,
                     };
+                    dup.set_value("parent", Some(self.get_uuid().into()), ops)?;
                     let rule_str = self.data.get("rrule").ok_or_else(|| {
                         Error::Iterative("Couldn't get rrule from iter task.".into())
                     })?;
                     let orig_due = self
                         .get_due()
-                        .unwrap_or_else(now)
+                        .unwrap_or_else(utc_now)
                         .with_timezone(&Tz::Local(chrono::Local));
 
                     let due = match iter_type {
@@ -376,7 +351,13 @@ impl Task {
                             })?;
                             // get first date strictly after orig due date
                             let after = orig_due + chrono::Duration::seconds(1);
-                            rrule_set.after(after).all(1).dates[0].to_utc()
+                            rrule_set
+                                .after(after)
+                                .all(1)
+                                .dates
+                                .get(0)
+                                .ok_or_else(|| Error::Iterative("no future occurrence".into()))?
+                                .to_utc()
                         }
                         IterType::FixedPlus => {
                             // create rule set from rule and orig date
@@ -384,13 +365,19 @@ impl Task {
                                 Error::Iterative(format!("Couldn't get rule set from rule: {}", e))
                             })?;
                             // get first date strictly after now
-                            let now = now().with_timezone(&Tz::Local(chrono::Local));
+                            let now = utc_now().with_timezone(&Tz::Local(chrono::Local));
                             let after = now + chrono::Duration::seconds(1);
-                            rrule_set.after(after).all(1).dates[0].to_utc()
+                            rrule_set
+                                .after(after)
+                                .all(1)
+                                .dates
+                                .get(0)
+                                .ok_or_else(|| Error::Iterative("no future occurrence".into()))?
+                                .to_utc()
                         }
                         IterType::Chained => {
                             // get now
-                            let now = now().with_timezone(&Tz::Local(chrono::Local));
+                            let now = utc_now().with_timezone(&Tz::Local(chrono::Local));
                             // rebuild the rule anchored to now using the stored iter string
                             let iter_str = self.data.get("iter").ok_or_else(|| {
                                 Error::Iterative("Couldn't get iter from iter task.".into())
@@ -403,21 +390,24 @@ impl Task {
                             rrule_set
                                 .after(now + chrono::Duration::seconds(1))
                                 .all(1)
-                                .dates[0]
+                                .dates
+                                .get(0)
+                                .ok_or_else(|| Error::Iterative("no future occurrence".into()))?
                                 .to_utc()
                         }
                     };
                     self.set_due(Some(due), ops)?;
+                    return Ok(());
                 }
                 // set "end" when a task is deleted or completed
                 if !self.data.has(Prop::End.as_ref()) {
-                    self.set_timestamp(Prop::End.as_ref(), Some(now()), ops)?;
+                    self.set_timestamp(Prop::End.as_ref(), Some(utc_now()), ops)?;
                 }
             }
             Status::Deleted => {
                 // set "end" when a task is deleted or completed
                 if !self.data.has(Prop::End.as_ref()) {
-                    self.set_timestamp(Prop::End.as_ref(), Some(now()), ops)?;
+                    self.set_timestamp(Prop::End.as_ref(), Some(utc_now()), ops)?;
                 }
             }
             Status::Iterative => {
@@ -425,7 +415,7 @@ impl Task {
                 if let Some(iter) = self.data.get("iter") {
                     // For the proof of concept, we'll assume that the rrule dt_start
                     // time is now. In the future this could be parsed from 'iter', .
-                    let dt_start = now().with_timezone(&Tz::Local(chrono::Local));
+                    let dt_start = utc_now().with_timezone(&Tz::Local(chrono::Local));
                     // Create the rrule.
                     let rule = iter::str2rrule(iter)?;
                     let rule = rule
@@ -439,7 +429,13 @@ impl Task {
                         self.set_value("iter_type", Some(IterType::Chained.to_string()), ops)?;
                     }
                     // Set the next due date.
-                    let due = rrule_set.after(dt_start).all(1).dates[0].to_utc();
+                    let due = rrule_set
+                        .after(dt_start)
+                        .all(1)
+                        .dates
+                        .get(0)
+                        .ok_or_else(|| Error::Iterative("no future occurrence".into()))?
+                        .to_utc();
                     self.set_due(Some(due), ops)?;
                 } else {
                     return Err(Error::Usage(
@@ -714,7 +710,7 @@ impl Task {
 #[allow(deprecated)]
 mod test {
     use super::*;
-    use crate::{storage::inmemory::InMemoryStorage, Replica};
+    use crate::{storage::inmemory::InMemoryStorage, task::time::mock_time, Replica};
     use pretty_assertions::assert_eq;
     use std::collections::HashSet;
 
@@ -1364,11 +1360,11 @@ mod test {
 
     #[tokio::test]
     async fn test_fixed_advances_from_schedule() {
-        super::mock_time::set(time_start());
+        mock_time::set(time_start());
         let (_, mut task, mut ops, _) = setup_iterative_task("weekly", Some("fixed")).await;
-        super::mock_time::set(time_twenty_four_days_later());
+        mock_time::set(time_twenty_four_days_later());
         task.set_status(Status::Completed, &mut ops).unwrap();
-        super::mock_time::reset();
+        mock_time::reset();
         // Fixed: first weekly occurrence strictly after orig_due (Jan 8) = Jan 15
         assert_eq!(
             task.get_due(),
@@ -1378,11 +1374,11 @@ mod test {
 
     #[tokio::test]
     async fn test_fixed_plus_advances_from_now() {
-        super::mock_time::set(time_start());
+        mock_time::set(time_start());
         let (_, mut task, mut ops, _) = setup_iterative_task("weekly", Some("fixed+")).await;
-        super::mock_time::set(time_twenty_four_days_later());
+        mock_time::set(time_twenty_four_days_later());
         task.set_status(Status::Completed, &mut ops).unwrap();
-        super::mock_time::reset();
+        mock_time::reset();
         // FixedPlus: first weekly occurrence strictly after now (Jan 25) = Jan 29
         assert_eq!(
             task.get_due(),
@@ -1392,11 +1388,11 @@ mod test {
 
     #[tokio::test]
     async fn test_chained_advances_period_from_now() {
-        super::mock_time::set(time_start());
+        mock_time::set(time_start());
         let (_, mut task, mut ops, _) = setup_iterative_task("weekly", None).await;
-        super::mock_time::set(time_twenty_four_days_later());
+        mock_time::set(time_twenty_four_days_later());
         task.set_status(Status::Completed, &mut ops).unwrap();
-        super::mock_time::reset();
+        mock_time::reset();
         // Chained: new rrule anchored to now (Jan 25), first occurrence after now = Feb 1
         assert_eq!(
             task.get_due(),

--- a/src/task/task.rs
+++ b/src/task/task.rs
@@ -3,16 +3,20 @@ use super::{utc_timestamp, Annotation, Status, Tag, Timestamp};
 use crate::depmap::DependencyMap;
 use crate::errors::{Error, Result};
 use crate::storage::TaskMap;
-use crate::task::{iter, utc_now, IterType};
+use crate::task::utc_now;
+#[cfg(feature = "iterative-tasks")]
+use crate::task::{iter, local_tz, IterType};
 use crate::{Operations, TaskData};
 use chrono::prelude::*;
 use log::trace;
+#[cfg(feature = "iterative-tasks")]
 use rrule::{RRuleSet, Tz};
 use std::convert::AsRef;
 use std::convert::TryInto;
 use std::str::FromStr;
 use std::sync::Arc;
 use uuid::Uuid;
+
 
 /// A task, with a high-level interface.
 ///
@@ -314,6 +318,7 @@ impl Task {
                 }
             }
             Status::Completed => {
+                #[cfg(feature = "iterative-tasks")]
                 if self.get_status() == Status::Iterative {
                     // Create clone with Completed status.
                     let uuid = Uuid::new_v4();
@@ -341,7 +346,7 @@ impl Task {
                     let orig_due = self
                         .get_due()
                         .unwrap_or_else(utc_now)
-                        .with_timezone(&Tz::Local(chrono::Local));
+                        .with_timezone(&local_tz());
 
                     let due = match iter_type {
                         IterType::Fixed => {
@@ -365,7 +370,7 @@ impl Task {
                                 Error::Iterative(format!("Couldn't get rule set from rule: {}", e))
                             })?;
                             // get first date strictly after now
-                            let now = utc_now().with_timezone(&Tz::Local(chrono::Local));
+                            let now = utc_now().with_timezone(&local_tz());
                             let after = now + chrono::Duration::seconds(1);
                             rrule_set
                                 .after(after)
@@ -377,7 +382,7 @@ impl Task {
                         }
                         IterType::Chained => {
                             // get now
-                            let now = utc_now().with_timezone(&Tz::Local(chrono::Local));
+                            let now = utc_now().with_timezone(&local_tz());
                             // rebuild the rule anchored to now using the stored iter string
                             let iter_str = self.data.get("iter").ok_or_else(|| {
                                 Error::Iterative("Couldn't get iter from iter task.".into())
@@ -411,37 +416,48 @@ impl Task {
                 }
             }
             Status::Iterative => {
-                // Check that there is a an 'iter' value.
-                if let Some(iter) = self.data.get("iter") {
-                    // For the proof of concept, we'll assume that the rrule dt_start
-                    // time is now. In the future this could be parsed from 'iter', .
-                    let dt_start = utc_now().with_timezone(&Tz::Local(chrono::Local));
-                    // Create the rrule.
-                    let rule = iter::str2rrule(iter)?;
-                    let rule = rule
-                        .validate(dt_start)
-                        .map_err(|e| Error::Usage(format!("Couldn't validate rrule: {e}")))?;
-                    let rrule_set = RRuleSet::new(dt_start).rrule(rule);
-                    // Set the rrule value.
-                    self.set_value("rrule", Some(rrule_set.to_string()), ops)?;
-                    // Check that iter_type exists, otherwise assume chained.
-                    if self.data.get("iter_type").is_none() {
-                        self.set_value("iter_type", Some(IterType::Chained.to_string()), ops)?;
+                #[cfg(feature = "iterative-tasks")]
+                {
+                    // Check that there is a an 'iter' value.
+                    if let Some(iter) = self.data.get("iter") {
+                        // For the proof of concept, we'll assume that the rrule dt_start
+                        // time is now. In the future this could be parsed from 'iter', .
+                        let dt_start = utc_now().with_timezone(&local_tz());
+                        // Create the rrule.
+                        let rule = iter::str2rrule(iter)?;
+                        let rule = rule
+                            .validate(dt_start)
+                            .map_err(|e| Error::Usage(format!("Couldn't validate rrule: {e}")))?;
+                        let rrule_set = RRuleSet::new(dt_start).rrule(rule);
+                        // Set the rrule value.
+                        self.set_value("rrule", Some(rrule_set.to_string()), ops)?;
+                        // Check that iter_type exists, otherwise assume chained.
+                        if self.data.get("iter_type").is_none() {
+                            self.set_value(
+                                "iter_type",
+                                Some(IterType::Chained.to_string()),
+                                ops,
+                            )?;
+                        }
+                        // Set the next due date.
+                        let due = rrule_set
+                            .after(dt_start)
+                            .all(1)
+                            .dates
+                            .get(0)
+                            .ok_or_else(|| Error::Iterative("no future occurrence".into()))?
+                            .to_utc();
+                        self.set_due(Some(due), ops)?;
+                    } else {
+                        return Err(Error::Usage(
+                            "Iterative tasks require an 'iter' value.".into(),
+                        ));
                     }
-                    // Set the next due date.
-                    let due = rrule_set
-                        .after(dt_start)
-                        .all(1)
-                        .dates
-                        .get(0)
-                        .ok_or_else(|| Error::Iterative("no future occurrence".into()))?
-                        .to_utc();
-                    self.set_due(Some(due), ops)?;
-                } else {
-                    return Err(Error::Usage(
-                        "Iterative tasks require an 'iter' value.".into(),
-                    ));
                 }
+                #[cfg(not(feature = "iterative-tasks"))]
+                return Err(Error::Usage(
+                    "iterative-tasks feature is not enabled".into(),
+                ));
             }
             Status::Unknown(_) => {}
         }

--- a/src/task/task.rs
+++ b/src/task/task.rs
@@ -3,14 +3,28 @@ use super::{utc_timestamp, Annotation, Status, Tag, Timestamp};
 use crate::depmap::DependencyMap;
 use crate::errors::{Error, Result};
 use crate::storage::TaskMap;
+use crate::task::utc_now;
+#[cfg(feature = "iterative-tasks")]
+use crate::task::{iter, local_tz, IterType};
 use crate::{Operations, TaskData};
 use chrono::prelude::*;
 use log::trace;
+#[cfg(feature = "iterative-tasks")]
+use rrule::{RRule, RRuleSet, Unvalidated};
 use std::convert::AsRef;
 use std::convert::TryInto;
 use std::str::FromStr;
 use std::sync::Arc;
 use uuid::Uuid;
+
+/// Fixed namespace for deriving an iterative task's successor UUID via UUIDv5.
+///
+/// This is derived (per RFC 4122) as
+/// `v5(NAMESPACE_URL, "taskchampion-iterative-task")`.
+/// `Uuid::new_v5` is not `const`, so the precomputed value is inlined here. The
+/// test verifies it still matches.
+#[cfg(feature = "iterative-tasks")]
+const ITERATIVE_NAMESPACE: Uuid = Uuid::from_u128(0x6ab813ab_3ff5_56f4_820e_31ada24844af);
 
 /// A task, with a high-level interface.
 ///
@@ -55,6 +69,7 @@ enum Prop {
     Start,
     Status,
     Priority,
+    Scheduled,
     Wait,
     End,
     Entry,
@@ -131,6 +146,11 @@ impl Task {
         self.get_timestamp(Prop::Wait.as_ref())
     }
 
+    /// Get the scheduled time a task can be started.
+    pub fn get_scheduled(&self) -> Option<Timestamp> {
+        self.get_timestamp(Prop::Scheduled.as_ref())
+    }
+
     /// Determine whether this task is waiting now.
     pub fn is_waiting(&self) -> bool {
         if let Some(ts) = self.get_wait() {
@@ -161,7 +181,9 @@ impl Task {
         match synth {
             SyntheticTag::Waiting => self.is_waiting(),
             SyntheticTag::Active => self.is_active(),
-            SyntheticTag::Pending => self.get_status() == Status::Pending,
+            SyntheticTag::Pending => {
+                matches!(self.get_status(), Status::Pending | Status::Iterative)
+            }
             SyntheticTag::Completed => self.get_status() == Status::Completed,
             SyntheticTag::Deleted => self.get_status() == Status::Deleted,
             SyntheticTag::Blocked => self.is_blocked(),
@@ -305,23 +327,308 @@ impl Task {
     /// This also updates the task's "end" property appropriately.
     pub fn set_status(&mut self, status: Status, ops: &mut Operations) -> Result<()> {
         match status {
-            Status::Pending | Status::Recurring
+            Status::Pending | Status::Recurring => {
                 // clear "end" when a task becomes "pending" or "recurring"
-                if self.data.has(Prop::End.as_ref()) => {
+                if self.data.has(Prop::End.as_ref()) {
                     self.set_timestamp(Prop::End.as_ref(), None, ops)?;
                 }
-            Status::Completed | Status::Deleted
-                // set "end" when a task is deleted or completed
-                if !self.data.has(Prop::End.as_ref()) => {
-                    self.set_timestamp(Prop::End.as_ref(), Some(Utc::now()), ops)?;
+            }
+            Status::Completed => {
+                #[cfg(feature = "iterative-tasks")]
+                if self.get_status() == Status::Iterative {
+                    return self.set_iterative_completed(ops);
                 }
-            _ => {}
+                // set "end" when a task is deleted or completed
+                if !self.data.has(Prop::End.as_ref()) {
+                    self.set_timestamp(Prop::End.as_ref(), Some(utc_now()), ops)?;
+                }
+            }
+            Status::Deleted => {
+                // set "end" when a task is deleted or completed
+                if !self.data.has(Prop::End.as_ref()) {
+                    self.set_timestamp(Prop::End.as_ref(), Some(utc_now()), ops)?;
+                }
+            }
+            Status::Iterative => {
+                #[cfg(feature = "iterative-tasks")]
+                self.set_iterative_status(ops)?;
+                #[cfg(not(feature = "iterative-tasks"))]
+                return Err(Error::Usage(
+                    "iterative-tasks feature is not enabled".into(),
+                ));
+            }
+            Status::Unknown(_) => {}
         }
         self.set_value(
             Prop::Status.as_ref(),
             Some(String::from(status.to_taskmap())),
             ops,
         )
+    }
+
+    #[cfg(feature = "iterative-tasks")]
+    fn set_iterative_status(&mut self, ops: &mut Operations) -> Result<()> {
+        if let Some(iter) = self.data.get("iter") {
+            use crate::task::iter::AnchorKind;
+
+            if iter.trim().is_empty() {
+                return Err(Error::Usage(
+                    "Iterative tasks require a non-empty 'iter' value.".into(),
+                ));
+            }
+            // If one of the possible anchor dates is already set, use it as the
+            // first date and dt_start.
+            // Otherwise dt_start is now, and the first due is the first rrule
+            // occurrence on or after now.
+            let (anchor_date, anchor_kind) = self
+                .get_due()
+                .map(|t| (t, Some(AnchorKind::Due)))
+                .or_else(|| {
+                    self.get_scheduled()
+                        .map(|t| (t, Some(AnchorKind::Scheduled)))
+                })
+                .or_else(|| self.get_wait().map(|t| (t, Some(AnchorKind::Wait))))
+                .unwrap_or_else(|| (utc_timestamp(utc_now().timestamp()), None));
+            let dt_start = anchor_date.with_timezone(&local_tz());
+            let unvalidated = iter::str2rrule(iter)?;
+            // Validate against dt_start to get the first occurrence.
+            let rule = unvalidated
+                .clone()
+                .validate(dt_start)
+                .map_err(|e| Error::Usage(format!("Couldn't validate rrule: {e}")))?;
+            let rrule_set = RRuleSet::new(dt_start).rrule(rule);
+            // Store the rule in unvalidated form, so completeion can re-anchor
+            // it to a new date without inheriting the original anchor's weekday,
+            // and there is no stored DTSTART to go stale.
+            self.set_value("rrule", Some(unvalidated.to_string()), ops)?;
+            // Set the first date. If the caller supplied one it directly,
+            // just use it. Otherwise take the first rrule occurrence on or
+            // after dt_start.
+            match anchor_kind {
+                Some(AnchorKind::Due) => self.set_due(Some(anchor_date), ops)?,
+                Some(AnchorKind::Scheduled) => self.set_scheduled(Some(anchor_date), ops)?,
+                Some(AnchorKind::Wait) => self.set_wait(Some(anchor_date), ops)?,
+                None => {
+                    let due = rrule_set
+                        .all(1)
+                        .dates
+                        .first()
+                        .ok_or_else(|| Error::Iterative("no future occurrence".into()))?
+                        .to_utc();
+                    self.set_due(Some(due), ops)?;
+                }
+            };
+            // Check that iter_type exists, otherwise assume chained.
+            if self.data.get("iter_type").is_none() {
+                self.set_value("iter_type", Some(IterType::Chained.to_string()), ops)?;
+            }
+            // Set the series id (the root task's own UUID) if not already set.
+            if self.data.get("series").is_none() {
+                self.set_value("series", Some(self.get_uuid().into()), ops)?;
+            }
+            // Set the initial series count if not set. 1-based, since it is a count.
+            if self.data.get("iter_count").is_none() {
+                self.set_value("iter_count", Some("1".to_string()), ops)?;
+            }
+            // Stamp `entry` if absent.
+            if self.get_entry().is_none() {
+                self.set_entry(Some(utc_timestamp(utc_now().timestamp())), ops)?;
+            }
+            Ok(())
+        } else {
+            Err(Error::Usage(
+                "Iterative tasks require an 'iter' value.".into(),
+            ))
+        }
+    }
+
+    #[cfg(feature = "iterative-tasks")]
+    fn set_iterative_completed(&mut self, ops: &mut Operations) -> Result<()> {
+        let now = utc_timestamp(utc_now().timestamp());
+
+        // Compute the next occurrence's date from the current schedule before
+        // changing anything.
+        let iter_type = match self.data.get("iter_type") {
+            Some(t) => IterType::from_str(t)
+                .map_err(|e| Error::Iterative(format!("Couldn't parse iter type {}", e)))?,
+            None => IterType::Chained,
+        };
+        let rule_str = self
+            .data
+            .get("rrule")
+            .ok_or_else(|| Error::Iterative("Couldn't get rrule from iter task.".into()))?;
+        // The stored rrule is unvalidated. Parse it once, then re-anchor it to
+        // the appropriate date per iteration type.
+        let unvalidated = RRule::<Unvalidated>::from_str(rule_str)
+            .map_err(|e| Error::Iterative(format!("Couldn't parse stored rrule: {e}")))?;
+        let anchored_set = |anchor: DateTime<rrule::Tz>| -> Result<RRuleSet> {
+            let rule = unvalidated
+                .clone()
+                .validate(anchor)
+                .map_err(|e| Error::Usage(format!("Couldn't validate rrule: {e}")))?;
+            Ok(RRuleSet::new(anchor).rrule(rule))
+        };
+        // Anchor the schedule off the highest-priority present date.
+        let anchor_old = self
+            .get_due()
+            .or_else(|| self.get_scheduled())
+            .or_else(|| self.get_wait())
+            .map(|t| t.with_timezone(&local_tz()));
+        let now_local = utc_now().with_timezone(&local_tz());
+        let next_anchor = match iter_type {
+            IterType::Fixed => {
+                // Fixed anchors off the original date, but if there is no date
+                // fall back to now.
+                let anchor = anchor_old.unwrap_or(now_local);
+                // First occurrence strictly after the anchor date.
+                let after = anchor + chrono::Duration::seconds(1);
+                anchored_set(anchor)?
+                    .after(after)
+                    .all(1)
+                    .dates
+                    .first()
+                    .map(|d| d.to_utc())
+            }
+            IterType::FixedPlus => {
+                let anchor = anchor_old.unwrap_or(now_local);
+                // Anchor strictly after both now and the completed occurrence, so
+                // it skips missed occurrences but still advances when completed early.
+                let after = std::cmp::max(now_local, anchor) + chrono::Duration::seconds(1);
+                anchored_set(anchor)?
+                    .after(after)
+                    .all(1)
+                    .dates
+                    .first()
+                    .map(|d| d.to_utc())
+            }
+            IterType::Chained => {
+                // Chained re-anchors the rule to now, so the next occurrence is
+                // one period from the completion time.
+                anchored_set(now_local)?
+                    .after(now_local + chrono::Duration::seconds(1))
+                    .all(1)
+                    .dates
+                    .first()
+                    .map(|d| d.to_utc())
+            }
+        };
+
+        // Spawn the next instance only if the schedule yields a future occurrence
+        // and the series has not reached its rrule COUNT length.
+        let cap = unvalidated.get_count();
+        let pos = self
+            .data
+            .get("iter_count")
+            .and_then(|s| s.parse::<u32>().ok())
+            .unwrap_or(1);
+        let within_cap = cap.is_none_or(|c| pos.saturating_add(1) <= c);
+        if let Some(next_anchor) = next_anchor.filter(|_| within_cap) {
+            self.spawn_successor(next_anchor, anchor_old, pos, now, ops)?;
+        }
+
+        // Finally, complete the task.
+        self.set_value(
+            Prop::Status.as_ref(),
+            Some(String::from(Status::Completed.to_taskmap())),
+            ops,
+        )?;
+        self.set_timestamp(Prop::End.as_ref(), Some(now), ops)?;
+        self.set_value("iter", None, ops)?;
+        self.set_value("rrule", None, ops)?;
+        self.set_value("iter_type", None, ops)?;
+        Ok(())
+    }
+
+    /// Build the successor for a completed iterative occurrence.
+    ///
+    /// The successor is a copy of `self` under a deterministic UUID, its schedule
+    /// re-anchored to `next_anchor` and its dates advanced by the same wall-clock
+    /// delta. `iter_count` is the completed instance's count, the successor's
+    /// `iter_count` is `iter_count + 1`.
+    #[cfg(feature = "iterative-tasks")]
+    fn spawn_successor(
+        &self,
+        next_anchor: Timestamp,
+        anchor_old: Option<DateTime<rrule::Tz>>,
+        iter_count: u32,
+        now: Timestamp,
+        ops: &mut Operations,
+    ) -> Result<()> {
+        let self_uuid = self.get_uuid();
+        let successor_uuid = Uuid::new_v5(&ITERATIVE_NAMESPACE, self_uuid.as_bytes());
+        let mut successor = Task::new(TaskData::create(successor_uuid, ops), self.depmap.clone());
+
+        // Copy the source properties, except those handled explicitly below.
+        for (prop, value) in self.data.iter() {
+            let set_below = matches!(
+                prop.as_str(),
+                "status"
+                    | "modified"
+                    | "end"
+                    | "start"
+                    | "due"
+                    | "scheduled"
+                    | "wait"
+                    | "entry"
+                    | "prior"
+                    | "iter_count"
+            ) || prop.starts_with("dep_");
+            if !set_below {
+                successor.data.update(prop, Some(value.to_owned()), ops);
+            }
+        }
+
+        successor.set_value(
+            Prop::Status.as_ref(),
+            Some(String::from(Status::Iterative.to_taskmap())),
+            ops,
+        )?;
+
+        successor.set_value(
+            "iter_count",
+            Some(iter_count.saturating_add(1).to_string()),
+            ops,
+        )?;
+
+        // Advance each present date by the same delta as the anchor, with local
+        // DST awareness.
+        if let Some(anchor_old) = anchor_old {
+            let naive_delta =
+                next_anchor.with_timezone(&local_tz()).naive_local() - anchor_old.naive_local();
+            let raw_delta = next_anchor - anchor_old.with_timezone(&Utc);
+            let shift = |date: Timestamp| -> Timestamp {
+                let naive = date.with_timezone(&local_tz()).naive_local() + naive_delta;
+                match local_tz().from_local_datetime(&naive) {
+                    chrono::LocalResult::Single(t) => t.with_timezone(&Utc),
+                    chrono::LocalResult::Ambiguous(earliest, _) => earliest.with_timezone(&Utc),
+                    // Nonexistent local time due to spring-forward, leap seconds etc:
+                    // fall back to raw UTC delta for this date.
+                    chrono::LocalResult::None => date + raw_delta,
+                }
+            };
+            if let Some(due) = self.get_due() {
+                successor.set_due(Some(shift(due)), ops)?;
+            }
+            if let Some(scheduled) = self.get_scheduled() {
+                successor.set_scheduled(Some(shift(scheduled)), ops)?;
+            }
+            if let Some(wait) = self.get_wait() {
+                successor.set_wait(Some(shift(wait)), ops)?;
+            }
+        } else {
+            // No prior date to advance, so set the successor's `due` with the
+            // next occurrence.
+            successor.set_due(Some(next_anchor), ops)?;
+        }
+
+        successor.set_entry(Some(now), ops)?;
+        successor.set_value("prior", Some(self_uuid.into()), ops)?;
+        // If this task had no series id treat it as the series root.
+        // Shouldn't happen, but prevents possible cross-version corruption.
+        if successor.data.get("series").is_none() {
+            successor.set_value("series", Some(self_uuid.into()), ops)?;
+        }
+        Ok(())
     }
 
     pub fn set_description(&mut self, description: String, ops: &mut Operations) -> Result<()> {
@@ -334,6 +641,14 @@ impl Task {
 
     pub fn set_entry(&mut self, entry: Option<Timestamp>, ops: &mut Operations) -> Result<()> {
         self.set_timestamp(Prop::Entry.as_ref(), entry, ops)
+    }
+
+    pub fn set_scheduled(
+        &mut self,
+        scheduled: Option<Timestamp>,
+        ops: &mut Operations,
+    ) -> Result<()> {
+        self.set_timestamp(Prop::Scheduled.as_ref(), scheduled, ops)
     }
 
     pub fn set_wait(&mut self, wait: Option<Timestamp>, ops: &mut Operations) -> Result<()> {
@@ -359,7 +674,7 @@ impl Task {
 
         // update the modified timestamp unless we are setting it explicitly
         if &property != "modified" && !self.updated_modified {
-            let now = format!("{}", Utc::now().timestamp());
+            let now = format!("{}", utc_now().timestamp());
             trace!("task {}: set property modified={:?}", self.get_uuid(), now);
             self.data.update(Prop::Modified.as_ref(), Some(now), ops);
             self.updated_modified = true;
@@ -575,6 +890,17 @@ impl Task {
             || key.starts_with("tag_")
             || key.starts_with("annotation_")
             || key.starts_with("dep_")
+            || Task::is_iterative_key(key)
+    }
+
+    /// Keys the iterative-tasks system uses.
+    #[cfg(feature = "iterative-tasks")]
+    fn is_iterative_key(key: &str) -> bool {
+        matches!(key, "rrule" | "series" | "prior" | "iter_count")
+    }
+    #[cfg(not(feature = "iterative-tasks"))]
+    fn is_iterative_key(_key: &str) -> bool {
+        false
     }
 }
 
@@ -582,7 +908,9 @@ impl Task {
 #[allow(deprecated)]
 mod test {
     use super::*;
-    use crate::{storage::inmemory::InMemoryStorage, Replica};
+    #[cfg(feature = "iterative-tasks")]
+    use crate::task::time::mock_tz;
+    use crate::{storage::inmemory::InMemoryStorage, task::time::mock_time, Replica};
     use pretty_assertions::assert_eq;
     use std::collections::HashSet;
 
@@ -1087,6 +1415,908 @@ mod test {
         .await;
     }
 
+    #[cfg(feature = "iterative-tasks")]
+    #[tokio::test]
+    async fn test_set_status_iterative_basic() {
+        with_mut_task(
+            |task, ops| {
+                task.data.update("iter", Some("daily".into()), ops);
+                task.set_status(Status::Iterative, ops).unwrap();
+            },
+            |task| {
+                assert_eq!(task.get_status(), Status::Iterative);
+                assert!(task.data.has("rrule"));
+                assert!(task.get_due().is_some());
+                assert_eq!(task.data.get("iter_type"), Some("chained"));
+            },
+        )
+        .await;
+    }
+
+    #[cfg(feature = "iterative-tasks")]
+    #[tokio::test]
+    async fn test_set_status_iterative_preserves_iter_type() {
+        with_mut_task(
+            |task, ops| {
+                task.data.update("iter", Some("weekly".into()), ops);
+                task.data.update("iter_type", Some("fixed".into()), ops);
+                task.set_status(Status::Iterative, ops).unwrap();
+            },
+            |task| {
+                assert_eq!(task.data.get("iter_type"), Some("fixed"));
+            },
+        )
+        .await;
+    }
+
+    #[cfg(feature = "iterative-tasks")]
+    #[tokio::test]
+    async fn test_set_status_iterative_uses_due_when_set() {
+        // When `due` is set before transitioning to Iterative, it is preserved
+        // as the first due. The rrule itself is stored unbaked (anchor-independent):
+        // the anchor lives in `due`, not in the stored rrule.
+        let preset_due = Utc.with_ymd_and_hms(2026, 1, 10, 12, 0, 0).unwrap();
+        let mut replica = Replica::new(InMemoryStorage::new());
+        let mut ops = Operations::new();
+        let uuid = Uuid::new_v4();
+        let mut task = replica.create_task(uuid, &mut ops).await.unwrap();
+        task.set_due(Some(preset_due), &mut ops).unwrap();
+        task.data.update("iter", Some("weekly".into()), &mut ops);
+        task.set_status(Status::Iterative, &mut ops).unwrap();
+        assert_eq!(task.get_due(), Some(preset_due));
+        let rrule = task.data.get("rrule").expect("rrule should be set");
+        // No DTSTART/anchor date baked in, and no weekday baked from the anchor.
+        assert_eq!(
+            rrule, "FREQ=WEEKLY",
+            "rrule should be stored unbaked, got: {rrule}"
+        );
+    }
+
+    #[cfg(feature = "iterative-tasks")]
+    #[tokio::test]
+    async fn test_set_status_iterative_no_due_inclusive_today() {
+        // weekdays anchored to a weekday should yield that weekday itself as
+        // the first occurrence
+        // 2026-01-07 is a Wednesday.
+        // Pin scheduling to UTC so the anchor's weekday does not depend on the
+        // host's system timezone (C1-004).
+        mock_tz::set(rrule::Tz::UTC);
+        let wednesday = Utc.with_ymd_and_hms(2026, 1, 7, 9, 0, 0).unwrap();
+        mock_time::set(wednesday);
+        let (_, task, _, _) = setup_iterative_task("weekdays", None).await;
+        mock_time::reset();
+        mock_tz::reset();
+        let due = task.get_due().expect("due should be set");
+        // First valid occurrence on or after Wednesday is Wednesday itself.
+        assert_eq!(
+            due.date_naive(),
+            wednesday.date_naive(),
+            "first due should be the same Wednesday, got {due}"
+        );
+    }
+
+    #[cfg(feature = "iterative-tasks")]
+    #[tokio::test]
+    async fn test_set_status_iterative_no_due_skips_to_next_match() {
+        // weekdays anchored to a Saturday should skip to Monday.
+        // 2026-01-03 is a Saturday. 2026-01-05 is the following Monday.
+        // Pin scheduling to UTC so the anchor's weekday does not depend on the
+        // host's system timezone (C1-004).
+        mock_tz::set(rrule::Tz::UTC);
+        let saturday = Utc.with_ymd_and_hms(2026, 1, 3, 9, 0, 0).unwrap();
+        let expected_monday = Utc
+            .with_ymd_and_hms(2026, 1, 5, 0, 0, 0)
+            .unwrap()
+            .date_naive();
+        mock_time::set(saturday);
+        let (_, task, _, _) = setup_iterative_task("weekdays", None).await;
+        mock_time::reset();
+        mock_tz::reset();
+        let due = task.get_due().expect("due should be set");
+        assert_eq!(
+            due.date_naive(),
+            expected_monday,
+            "first due should be the following Monday, got {due}"
+        );
+    }
+
+    #[cfg(feature = "iterative-tasks")]
+    #[tokio::test]
+    async fn test_set_status_iterative_no_iter() {
+        let mut replica = Replica::new(InMemoryStorage::new());
+        let mut ops = Operations::new();
+        let uuid = Uuid::new_v4();
+        let mut task = replica.create_task(uuid, &mut ops).await.unwrap();
+        let result = task.set_status(Status::Iterative, &mut ops);
+        assert!(matches!(result, Err(Error::Usage(_))));
+    }
+
+    #[cfg(feature = "iterative-tasks")]
+    #[tokio::test]
+    async fn test_set_status_iterative_invalid_iter() {
+        let mut replica = Replica::new(InMemoryStorage::new());
+        let mut ops = Operations::new();
+        let uuid = Uuid::new_v4();
+        let mut task = replica.create_task(uuid, &mut ops).await.unwrap();
+        task.data.update("iter", Some("3blarg".into()), &mut ops);
+        let result = task.set_status(Status::Iterative, &mut ops);
+        assert!(matches!(result, Err(Error::Usage(_))));
+    }
+
+    #[cfg(feature = "iterative-tasks")]
+    async fn setup_iterative_task(
+        iter: &str,
+        iter_type: Option<&str>,
+    ) -> (Replica<InMemoryStorage>, Task, Operations, Uuid) {
+        let mut replica = Replica::new(InMemoryStorage::new());
+        let mut ops = Operations::new();
+        let uuid = Uuid::new_v4();
+        let mut task = replica.create_task(uuid, &mut ops).await.unwrap();
+        task.data.update("iter", Some(iter.into()), &mut ops);
+        if let Some(t) = iter_type {
+            task.data.update("iter_type", Some(t.into()), &mut ops);
+        }
+        task.set_status(Status::Iterative, &mut ops).unwrap();
+        (replica, task, ops, uuid)
+    }
+
+    /// UUID of the successor a task spawns when it is completed.
+    #[cfg(feature = "iterative-tasks")]
+    fn successor_of(uuid: Uuid) -> Uuid {
+        Uuid::new_v5(&ITERATIVE_NAMESPACE, uuid.as_bytes())
+    }
+
+    #[cfg(feature = "iterative-tasks")]
+    #[test]
+    fn iterative_namespace_is_derived() {
+        // The inlined constant must match its documented RFC 4122 derivation.
+        assert_eq!(
+            ITERATIVE_NAMESPACE,
+            Uuid::new_v5(&Uuid::NAMESPACE_URL, b"taskchampion-iterative-task")
+        );
+    }
+
+    #[cfg(feature = "iterative-tasks")]
+    #[tokio::test]
+    async fn test_complete_iterative_fixed_no_date_seeds_due() {
+        // A Fixed task with no anchor date anchors to now and seeds the
+        // successor's `due` with the next occurrence, so the series becomes a
+        // normal dated one rather than an endless chain of dateless successors.
+        mock_tz::set(rrule::Tz::UTC);
+        mock_time::set(time_start());
+        let (mut replica, mut task, mut ops, uuid) =
+            setup_iterative_task("daily", Some("fixed")).await;
+        mock_time::set(time_start());
+        task.set_due(None, &mut ops).unwrap();
+        task.set_status(Status::Completed, &mut ops).unwrap();
+        replica.commit_operations(ops).await.unwrap();
+        mock_time::reset();
+        mock_tz::reset();
+
+        let all = replica.all_tasks().await.unwrap();
+        let succ = all
+            .get(&successor_of(uuid))
+            .expect("successor should exist");
+        assert_eq!(succ.get_status(), Status::Iterative);
+        // The next daily occurrence strictly after now is seeded onto `due`.
+        assert_eq!(
+            succ.get_due(),
+            Some(time_start() + chrono::Duration::days(1))
+        );
+        // Only `due` is seeded; scheduled and wait stay unset.
+        assert_eq!(succ.get_scheduled(), None);
+        assert_eq!(succ.get_wait(), None);
+    }
+
+    #[cfg(feature = "iterative-tasks")]
+    #[tokio::test]
+    async fn test_complete_iterative_status_is_completed() {
+        // Completing an iterative task makes the handle itself Completed (it is now
+        // the log); the live instance is the separate successor.
+        let (_, mut task, mut ops, _) = setup_iterative_task("daily", None).await;
+        task.set_status(Status::Completed, &mut ops).unwrap();
+        assert_eq!(task.get_status(), Status::Completed);
+    }
+
+    #[cfg(feature = "iterative-tasks")]
+    #[tokio::test]
+    async fn test_complete_iterative_spawns_successor() {
+        mock_time::set(time_start());
+        let (mut replica, mut task, mut ops, uuid) = setup_iterative_task("daily", None).await;
+        task.set_status(Status::Completed, &mut ops).unwrap();
+        replica.commit_operations(ops).await.unwrap();
+        mock_time::reset();
+
+        let all = replica.all_tasks().await.unwrap();
+        assert_eq!(
+            all.len(),
+            2,
+            "should have the completed log + its successor"
+        );
+
+        // `self` is now the completed log: status Completed, end set, no schedule.
+        let log = all.get(&uuid).unwrap();
+        assert_eq!(log.get_status(), Status::Completed);
+        assert!(log.data.has("end"));
+        assert_eq!(log.get_value("iter"), None);
+        assert_eq!(log.get_value("rrule"), None);
+        assert_eq!(log.get_value("iter_type"), None);
+
+        // The successor is the new live instance: schedule copied, prior points
+        // back to the log, entry is now, status Iterative.
+        let succ = all
+            .get(&successor_of(uuid))
+            .expect("successor should exist");
+        assert_eq!(succ.get_status(), Status::Iterative);
+        assert!(succ.get_value("iter").is_some());
+        assert!(succ.get_value("rrule").is_some());
+        assert!(succ.get_value("iter_type").is_some());
+        assert_eq!(
+            succ.get_value("prior")
+                .and_then(|p| Uuid::parse_str(p).ok()),
+            Some(uuid)
+        );
+        assert_eq!(
+            succ.get_value("entry"),
+            Some(time_start().timestamp().to_string().as_str())
+        );
+
+        // The series id is the root task's own uuid, on both the log and successor.
+        assert_eq!(
+            log.get_value("series")
+                .and_then(|s| Uuid::parse_str(s).ok()),
+            Some(uuid)
+        );
+        assert_eq!(
+            succ.get_value("series")
+                .and_then(|s| Uuid::parse_str(s).ok()),
+            Some(uuid)
+        );
+    }
+
+    #[cfg(feature = "iterative-tasks")]
+    #[tokio::test]
+    async fn test_complete_iterative_unblocks_dependents() {
+        // An iterative task with a dependent on it.
+        let (mut replica, _, ops, iter_uuid) = setup_iterative_task("daily", None).await;
+        replica.commit_operations(ops).await.unwrap();
+
+        let mut ops = Operations::new();
+        let dep_uuid = Uuid::new_v4();
+        let mut dep_task = replica.create_task(dep_uuid, &mut ops).await.unwrap();
+        dep_task.set_status(Status::Pending, &mut ops).unwrap();
+        dep_task.add_dependency(iter_uuid, &mut ops).unwrap();
+        replica.commit_operations(ops).await.unwrap();
+
+        // Complete the iterative task.
+        let mut ops = Operations::new();
+        let mut iter_task = replica.get_task(iter_uuid).await.unwrap().unwrap();
+        iter_task.set_status(Status::Completed, &mut ops).unwrap();
+        replica.commit_operations(ops).await.unwrap();
+
+        // No dependency rewriting happened: the dependent still points at the same
+        // uuid, which is now Completed, so it is unblocked.
+        let dep_task = replica.get_task(dep_uuid).await.unwrap().unwrap();
+        let deps: Vec<Uuid> = dep_task.get_dependencies().collect();
+        assert_eq!(deps, vec![iter_uuid], "dependent edge is unchanged");
+        assert!(
+            !deps.contains(&successor_of(iter_uuid)),
+            "dependent is not rerouted to the successor"
+        );
+        let completed = replica.get_task(iter_uuid).await.unwrap().unwrap();
+        assert_eq!(completed.get_status(), Status::Completed);
+    }
+
+    #[cfg(feature = "iterative-tasks")]
+    #[tokio::test]
+    async fn test_undo_iterative_completion_leaves_dependent_untouched() {
+        // Completing an iterative task never mutates a dependent, so undoing the
+        // completion restores prior state exactly (the dependent's modified and dep
+        // edge are preserved).
+        let (mut replica, _, ops, iter_uuid) = setup_iterative_task("daily", None).await;
+        replica.commit_operations(ops).await.unwrap();
+
+        let mut ops = Operations::new();
+        let dep_uuid = Uuid::new_v4();
+        let mut dep_task = replica.create_task(dep_uuid, &mut ops).await.unwrap();
+        dep_task.set_status(Status::Pending, &mut ops).unwrap();
+        dep_task.add_dependency(iter_uuid, &mut ops).unwrap();
+        replica.commit_operations(ops).await.unwrap();
+
+        let before = replica.get_task(dep_uuid).await.unwrap().unwrap();
+        let modified_before = before.get_value("modified").map(str::to_owned);
+        let deps_before: Vec<Uuid> = before.get_dependencies().collect();
+
+        // Complete behind an undo point, then undo.
+        let mut ops = Operations::new();
+        ops.push(crate::Operation::UndoPoint);
+        let mut iter_task = replica.get_task(iter_uuid).await.unwrap().unwrap();
+        iter_task.set_status(Status::Completed, &mut ops).unwrap();
+        replica.commit_operations(ops).await.unwrap();
+
+        let undo_ops = replica.get_undo_operations().await.unwrap();
+        assert!(replica.commit_reversed_operations(undo_ops).await.unwrap());
+
+        let after = replica.get_task(dep_uuid).await.unwrap().unwrap();
+        assert_eq!(
+            after.get_value("modified").map(str::to_owned),
+            modified_before,
+            "dependent's modified should be preserved"
+        );
+        assert_eq!(
+            after.get_dependencies().collect::<Vec<_>>(),
+            deps_before,
+            "dependent's dependency edge should be preserved"
+        );
+    }
+
+    #[cfg(feature = "iterative-tasks")]
+    #[tokio::test]
+    async fn test_complete_iterative_no_rrule_error() {
+        let mut replica = Replica::new(InMemoryStorage::new());
+        let mut ops = Operations::new();
+        let uuid = Uuid::new_v4();
+        let mut task = replica.create_task(uuid, &mut ops).await.unwrap();
+        // Manually set status=iterative without going through set_status(Iterative),
+        // so no "rrule" property is stored.
+        task.data
+            .update("status", Some("iterative".into()), &mut ops);
+        let result = task.set_status(Status::Completed, &mut ops);
+        assert!(matches!(result, Err(Error::Iterative(_))));
+    }
+
+    // time_start = 2026-01-01 00:00:00 UTC.  Weekly occurrences: Jan 8, Jan 15, Jan 22, Jan 29 …
+    // time_twenty_four_days_later = 2026-01-25 00:00:00 UTC (task is ~2.5 weeks overdue when completed).
+    #[cfg(feature = "iterative-tasks")]
+    fn time_start() -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap()
+    }
+    #[cfg(feature = "iterative-tasks")]
+    fn time_twenty_four_days_later() -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 1, 25, 0, 0, 0).unwrap()
+    }
+
+    #[cfg(feature = "iterative-tasks")]
+    #[tokio::test]
+    async fn test_fixed_advances_from_schedule() {
+        mock_time::set(time_start());
+        let (mut replica, mut task, mut ops, uuid) =
+            setup_iterative_task("weekly", Some("fixed")).await;
+        mock_time::set(time_twenty_four_days_later());
+        task.set_status(Status::Completed, &mut ops).unwrap();
+        replica.commit_operations(ops).await.unwrap();
+        mock_time::reset();
+        // Fixed: orig_due is Jan 1; first weekly occurrence strictly after Jan 1 = Jan 8.
+        let succ = replica.get_task(successor_of(uuid)).await.unwrap().unwrap();
+        assert_eq!(
+            succ.get_due(),
+            Some(time_start() + chrono::Duration::weeks(1))
+        );
+    }
+
+    #[cfg(feature = "iterative-tasks")]
+    #[tokio::test]
+    async fn test_fixed_plus_advances_from_now() {
+        mock_time::set(time_start());
+        let (mut replica, mut task, mut ops, uuid) =
+            setup_iterative_task("weekly", Some("fixed+")).await;
+        mock_time::set(time_twenty_four_days_later());
+        task.set_status(Status::Completed, &mut ops).unwrap();
+        replica.commit_operations(ops).await.unwrap();
+        mock_time::reset();
+        // FixedPlus: first weekly occurrence strictly after now (Jan 25) = Jan 29
+        let succ = replica.get_task(successor_of(uuid)).await.unwrap().unwrap();
+        assert_eq!(
+            succ.get_due(),
+            Some(time_start() + chrono::Duration::weeks(4))
+        );
+    }
+
+    #[cfg(feature = "iterative-tasks")]
+    #[tokio::test]
+    async fn test_fixed_plus_advances_when_completed_early() {
+        // The first due date is at Jan 1. Complete it early. FixedPlus must still
+        // advance past the occurrence just completed rather than returning it
+        // again.
+        mock_time::set(time_start());
+        let (mut replica, mut task, mut ops, uuid) =
+            setup_iterative_task("weekly", Some("fixed+")).await;
+        mock_time::set(time_start() - chrono::Duration::days(1));
+        task.set_status(Status::Completed, &mut ops).unwrap();
+        replica.commit_operations(ops).await.unwrap();
+        mock_time::reset();
+        // Next weekly occurrence strictly after the completed one (Jan 1) = Jan 8.
+        let succ = replica.get_task(successor_of(uuid)).await.unwrap().unwrap();
+        assert_eq!(
+            succ.get_due(),
+            Some(time_start() + chrono::Duration::weeks(1))
+        );
+    }
+
+    #[cfg(feature = "iterative-tasks")]
+    #[tokio::test]
+    async fn test_chained_advances_period_from_now() {
+        mock_time::set(time_start());
+        let (mut replica, mut task, mut ops, uuid) = setup_iterative_task("weekly", None).await;
+        mock_time::set(time_twenty_four_days_later());
+        task.set_status(Status::Completed, &mut ops).unwrap();
+        replica.commit_operations(ops).await.unwrap();
+        mock_time::reset();
+        // Chained: rule anchored to now (Jan 25), first occurrence after now = Feb 1
+        let succ = replica.get_task(successor_of(uuid)).await.unwrap().unwrap();
+        assert_eq!(
+            succ.get_due(),
+            Some(time_twenty_four_days_later() + chrono::Duration::weeks(1))
+        );
+    }
+
+    #[cfg(feature = "iterative-tasks")]
+    #[tokio::test]
+    async fn test_chained_successor_rrule_unbaked() {
+        // The successor carries the rule, still anchor-independent: no DTSTART to
+        // go stale (B1-005) and the free-text iter is not re-parsed (D2-008).
+        mock_time::set(time_start());
+        let (mut replica, mut task, mut ops, uuid) = setup_iterative_task("weekly", None).await;
+        mock_time::set(time_twenty_four_days_later());
+        task.set_status(Status::Completed, &mut ops).unwrap();
+        replica.commit_operations(ops).await.unwrap();
+        mock_time::reset();
+        let succ = replica.get_task(successor_of(uuid)).await.unwrap().unwrap();
+        let rrule = succ.get_value("rrule").expect("successor has rrule");
+        assert_eq!(rrule, "FREQ=WEEKLY");
+        assert!(!rrule.contains("DTSTART"));
+    }
+
+    #[cfg(feature = "iterative-tasks")]
+    #[tokio::test]
+    async fn test_chained_then_fixed_anchors_to_current_due() {
+        // A task completed as Chained advances its successor's due to a new
+        // weekday. Switching that successor to Fixed must then anchor off its
+        // current due, not a stale original anchor.
+        mock_time::set(time_start());
+        let (mut replica, mut task, mut ops, uuid) = setup_iterative_task("weekly", None).await;
+        // Complete once as Chained: successor due = Jan 25 + 1 week = Feb 1.
+        mock_time::set(time_twenty_four_days_later());
+        task.set_status(Status::Completed, &mut ops).unwrap();
+        replica.commit_operations(ops).await.unwrap();
+        let succ_uuid = successor_of(uuid);
+        let chained_due = replica
+            .get_task(succ_uuid)
+            .await
+            .unwrap()
+            .unwrap()
+            .get_due()
+            .unwrap();
+        assert_eq!(
+            chained_due,
+            time_twenty_four_days_later() + chrono::Duration::weeks(1)
+        );
+        // Switch the successor to Fixed and complete it. Fixed anchors off its
+        // current due (Feb 1), so its successor's due is one week on (Feb 8).
+        let mut ops = Operations::new();
+        let mut succ = replica.get_task(succ_uuid).await.unwrap().unwrap();
+        succ.set_value("iter_type", Some("fixed".into()), &mut ops)
+            .unwrap();
+        succ.set_status(Status::Completed, &mut ops).unwrap();
+        replica.commit_operations(ops).await.unwrap();
+        mock_time::reset();
+        let succ2 = replica
+            .get_task(successor_of(succ_uuid))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            succ2.get_due(),
+            Some(chained_due + chrono::Duration::weeks(1))
+        );
+    }
+
+    #[cfg(feature = "iterative-tasks")]
+    #[tokio::test]
+    async fn test_iterative_is_pending_synthetic_tag() {
+        let (_replica, task, _ops, _uuid) = setup_iterative_task("weekly", None).await;
+        assert_eq!(task.get_status(), Status::Iterative);
+        assert!(task.has_tag(&stag(SyntheticTag::Pending)));
+        assert!(!task.has_tag(&stag(SyntheticTag::Completed)));
+    }
+
+    #[cfg(feature = "iterative-tasks")]
+    #[tokio::test]
+    async fn test_exhausted_rrule_completes_without_successor() {
+        // A finite RRULE (COUNT/UNTIL) must complete the task as its final
+        // occurrence.
+        mock_time::set(time_start());
+        let (mut replica, mut task, mut ops, uuid) =
+            setup_iterative_task("FREQ=DAILY;COUNT=1", None).await;
+        // Re-assert the mocked time after the setup await (the thread-local may
+        // not survive it), so completion anchors at the mocked time.
+        mock_time::set(time_start());
+        // Previously this returned Err and left the task stuck as Iterative.
+        task.set_status(Status::Completed, &mut ops).unwrap();
+        replica.commit_operations(ops).await.unwrap();
+        mock_time::reset();
+        // The original task is Completed, not stuck as Iterative.
+        let done = replica.get_task(uuid).await.unwrap().unwrap();
+        assert_eq!(done.get_status(), Status::Completed);
+        // No successor was spawned for the exhausted schedule.
+        assert!(replica
+            .get_task(successor_of(uuid))
+            .await
+            .unwrap()
+            .is_none());
+    }
+
+    #[cfg(feature = "iterative-tasks")]
+    #[tokio::test]
+    async fn test_corrupt_rrule_errors_on_completion() {
+        // A stored rrule that cannot be parsed must surface an error on
+        // completion.
+        mock_time::set(time_start());
+        let (_replica, mut task, mut ops, _uuid) = setup_iterative_task("weekly", None).await;
+        // Corrupt the stored rrule directly, then attempt completion.
+        task.set_value("rrule", Some("NOT-A-RULE".into()), &mut ops)
+            .unwrap();
+        let err = task.set_status(Status::Completed, &mut ops);
+        mock_time::reset();
+        assert!(err.is_err(), "corrupt rrule should error on completion");
+    }
+
+    #[cfg(feature = "iterative-tasks")]
+    #[tokio::test]
+    async fn test_chained_daily_keeps_local_wall_clock_across_dst() {
+        use chrono::Timelike;
+        // 2026-03-07 13:00 UTC = 08:00 EST, the day before US spring-forward
+        let completed_at = Utc.with_ymd_and_hms(2026, 3, 7, 13, 0, 0).unwrap();
+        mock_tz::set(rrule::Tz::America__New_York);
+        mock_time::set(completed_at);
+        let (mut replica, mut task, mut ops, uuid) = setup_iterative_task("daily", None).await;
+        // Re-assert the mocked zone and time after the setup.
+        mock_tz::set(rrule::Tz::America__New_York);
+        mock_time::set(completed_at);
+        task.set_status(Status::Completed, &mut ops).unwrap();
+        replica.commit_operations(ops).await.unwrap();
+        mock_time::reset();
+        let succ = replica.get_task(successor_of(uuid)).await.unwrap().unwrap();
+        let due = succ.get_due().unwrap();
+        mock_tz::reset();
+        // Next daily occurrence is 08:00 local the following day, after
+        // after spring-forward.
+        let due_local = due.with_timezone(&rrule::Tz::America__New_York);
+        assert_eq!(
+            due_local.hour(),
+            8,
+            "daily task keeps 08:00 local, got {due_local}"
+        );
+        assert_eq!(
+            due_local.date_naive(),
+            chrono::NaiveDate::from_ymd_opt(2026, 3, 8).unwrap()
+        );
+        assert_eq!(due, Utc.with_ymd_and_hms(2026, 3, 8, 12, 0, 0).unwrap());
+    }
+
+    #[cfg(feature = "iterative-tasks")]
+    #[tokio::test]
+    async fn test_scheduled_wait_keep_wall_clock_across_dst() {
+        use chrono::Timelike;
+        let ny = rrule::Tz::America__New_York;
+        // Anchor `due` = Fri 2026-03-06 12:00 EST, the week before US spring-forward.
+        let due = Utc.with_ymd_and_hms(2026, 3, 6, 17, 0, 0).unwrap();
+        mock_tz::set(ny);
+        mock_time::set(due);
+        let (mut replica, mut task, mut ops, uuid) =
+            setup_iterative_task("weekly", Some("fixed")).await;
+        mock_tz::set(ny);
+        mock_time::set(due);
+        // `scheduled` 3 days before due: its span (03-03 -> 03-10) crosses the
+        // 03-08 boundary. `wait` 10 days before due: its span (02-24 -> 03-03)
+        // does NOT cross it, which is where a raw UTC delta drifts the wall clock.
+        task.set_due(Some(due), &mut ops).unwrap();
+        task.set_scheduled(Some(due - chrono::Duration::days(3)), &mut ops)
+            .unwrap();
+        task.set_wait(Some(due - chrono::Duration::days(10)), &mut ops)
+            .unwrap();
+        task.set_status(Status::Completed, &mut ops).unwrap();
+        replica.commit_operations(ops).await.unwrap();
+        mock_time::reset();
+
+        let succ = replica.get_task(successor_of(uuid)).await.unwrap().unwrap();
+        let new_due = succ.get_due().unwrap().with_timezone(&ny);
+        let new_scheduled = succ.get_scheduled().unwrap().with_timezone(&ny);
+        let new_wait = succ.get_wait().unwrap().with_timezone(&ny);
+        mock_tz::reset();
+
+        // Fixed weekly: next due is 2026-03-13 12:00 EDT. Every date keeps its
+        // 12:00 local time, including `wait` whose span does not cross the DST
+        // boundary the anchor crosses.
+        assert_eq!(new_due.hour(), 12, "due keeps 12:00 local, got {new_due}");
+        assert_eq!(
+            new_scheduled.hour(),
+            12,
+            "scheduled keeps 12:00 local, got {new_scheduled}"
+        );
+        assert_eq!(
+            new_wait.hour(),
+            12,
+            "wait keeps 12:00 local, got {new_wait}"
+        );
+        // Calendar-day spacing is preserved (due-3d, due-10d).
+        assert_eq!(
+            new_due.date_naive(),
+            chrono::NaiveDate::from_ymd_opt(2026, 3, 13).unwrap()
+        );
+        assert_eq!(
+            new_scheduled.date_naive(),
+            chrono::NaiveDate::from_ymd_opt(2026, 3, 10).unwrap()
+        );
+        assert_eq!(
+            new_wait.date_naive(),
+            chrono::NaiveDate::from_ymd_opt(2026, 3, 3).unwrap()
+        );
+    }
+
+    #[cfg(feature = "iterative-tasks")]
+    #[tokio::test]
+    async fn test_scheduled_and_wait_advance_fixed() {
+        // `scheduled` and `wait` advance by the same delta as the anchoring
+        // `due`, so their spacing relative to `due` is preserved.
+        mock_time::set(time_start());
+        let (mut replica, mut task, mut ops, uuid) =
+            setup_iterative_task("weekly", Some("fixed")).await;
+        mock_time::set(time_start());
+        task.set_scheduled(Some(time_start() - chrono::Duration::days(2)), &mut ops)
+            .unwrap();
+        task.set_wait(Some(time_start() - chrono::Duration::days(5)), &mut ops)
+            .unwrap();
+        mock_time::set(time_twenty_four_days_later());
+        task.set_status(Status::Completed, &mut ops).unwrap();
+        replica.commit_operations(ops).await.unwrap();
+        mock_time::reset();
+
+        let succ = replica.get_task(successor_of(uuid)).await.unwrap().unwrap();
+        let due = succ.get_due().unwrap();
+        // Fixed anchors off the original due (Jan 1); next weekly is Jan 8.
+        assert_eq!(due, time_start() + chrono::Duration::weeks(1));
+        assert_eq!(
+            succ.get_scheduled(),
+            Some(due - chrono::Duration::days(2)),
+            "scheduled keeps its 2-day lead on due"
+        );
+        assert_eq!(
+            succ.get_wait(),
+            Some(due - chrono::Duration::days(5)),
+            "wait keeps its 5-day lead on due"
+        );
+    }
+
+    #[cfg(feature = "iterative-tasks")]
+    #[tokio::test]
+    async fn test_scheduled_and_wait_advance_fixed_plus() {
+        mock_time::set(time_start());
+        let (mut replica, mut task, mut ops, uuid) =
+            setup_iterative_task("weekly", Some("fixed+")).await;
+        mock_time::set(time_start());
+        task.set_scheduled(Some(time_start() - chrono::Duration::days(2)), &mut ops)
+            .unwrap();
+        task.set_wait(Some(time_start() - chrono::Duration::days(5)), &mut ops)
+            .unwrap();
+        mock_time::set(time_twenty_four_days_later());
+        task.set_status(Status::Completed, &mut ops).unwrap();
+        replica.commit_operations(ops).await.unwrap();
+        mock_time::reset();
+
+        let succ = replica.get_task(successor_of(uuid)).await.unwrap().unwrap();
+        let due = succ.get_due().unwrap();
+        // FixedPlus skips missed occurrences: first weekly after now (Jan 25) is Jan 29.
+        assert_eq!(due, time_start() + chrono::Duration::weeks(4));
+        assert_eq!(succ.get_scheduled(), Some(due - chrono::Duration::days(2)));
+        assert_eq!(succ.get_wait(), Some(due - chrono::Duration::days(5)));
+    }
+
+    #[cfg(feature = "iterative-tasks")]
+    #[tokio::test]
+    async fn test_scheduled_and_wait_advance_chained() {
+        mock_time::set(time_start());
+        let (mut replica, mut task, mut ops, uuid) = setup_iterative_task("weekly", None).await;
+        mock_time::set(time_start());
+        task.set_scheduled(Some(time_start() - chrono::Duration::days(2)), &mut ops)
+            .unwrap();
+        task.set_wait(Some(time_start() - chrono::Duration::days(5)), &mut ops)
+            .unwrap();
+        mock_time::set(time_twenty_four_days_later());
+        task.set_status(Status::Completed, &mut ops).unwrap();
+        replica.commit_operations(ops).await.unwrap();
+        mock_time::reset();
+
+        let succ = replica.get_task(successor_of(uuid)).await.unwrap().unwrap();
+        let due = succ.get_due().unwrap();
+        // Chained anchors to now (Jan 25); next weekly is Feb 1.
+        assert_eq!(
+            due,
+            time_twenty_four_days_later() + chrono::Duration::weeks(1)
+        );
+        assert_eq!(succ.get_scheduled(), Some(due - chrono::Duration::days(2)));
+        assert_eq!(succ.get_wait(), Some(due - chrono::Duration::days(5)));
+    }
+
+    #[cfg(feature = "iterative-tasks")]
+    #[tokio::test]
+    async fn test_count_limits_series_length() {
+        // A COUNT=2 series yields exactly two instances. The rule is not mutated:
+        // the successor carries the same `rrule` and its `iter_count` advances to
+        // 2, so termination is by position rather than by decrementing COUNT.
+        mock_time::set(time_start());
+        let (mut replica, mut task, mut ops, uuid) =
+            setup_iterative_task("FREQ=DAILY;COUNT=2", None).await;
+        mock_time::set(time_start());
+        task.set_status(Status::Completed, &mut ops).unwrap();
+        replica.commit_operations(ops).await.unwrap();
+
+        let succ_uuid = successor_of(uuid);
+        let succ = replica.get_task(succ_uuid).await.unwrap().unwrap();
+        assert_eq!(
+            succ.get_value("rrule"),
+            Some("FREQ=DAILY;COUNT=2"),
+            "successor carries the schedule unchanged"
+        );
+        assert_eq!(
+            succ.get_value("iter_count"),
+            Some("2"),
+            "successor is the second instance in the series"
+        );
+
+        // Complete the second (final) instance; the count is now exhausted.
+        mock_time::set(time_start());
+        let mut ops = Operations::new();
+        let mut succ = replica.get_task(succ_uuid).await.unwrap().unwrap();
+        succ.set_status(Status::Completed, &mut ops).unwrap();
+        replica.commit_operations(ops).await.unwrap();
+        mock_time::reset();
+
+        assert_eq!(
+            replica
+                .get_task(succ_uuid)
+                .await
+                .unwrap()
+                .unwrap()
+                .get_status(),
+            Status::Completed
+        );
+        assert!(
+            replica
+                .get_task(successor_of(succ_uuid))
+                .await
+                .unwrap()
+                .is_none(),
+            "no third instance is spawned once COUNT is exhausted"
+        );
+    }
+
+    #[cfg(feature = "iterative-tasks")]
+    #[tokio::test]
+    async fn test_blank_iter_rejected() {
+        // A blank `iter` has no schedule, so setting Iterative status is an error.
+        let mut replica = Replica::new(InMemoryStorage::new());
+        let mut ops = Operations::new();
+        let uuid = Uuid::new_v4();
+        let mut task = replica.create_task(uuid, &mut ops).await.unwrap();
+        task.data.update("iter", Some("".into()), &mut ops);
+        let result = task.set_status(Status::Iterative, &mut ops);
+        assert!(matches!(result, Err(Error::Usage(_))));
+    }
+
+    #[cfg(feature = "iterative-tasks")]
+    #[tokio::test]
+    async fn test_set_status_iterative_rebakes_edited_iter() {
+        // Editing `iter` and re-asserting Iterative status re-bakes the rule from
+        // `iter`, so `iter` stays the source of truth for the schedule.
+        let (_replica, mut task, mut ops, _uuid) = setup_iterative_task("daily", None).await;
+        assert_eq!(task.get_value("rrule"), Some("FREQ=DAILY"));
+        // Change the schedule via `iter` and re-assert the status.
+        task.data.update("iter", Some("weekly".into()), &mut ops);
+        task.set_status(Status::Iterative, &mut ops).unwrap();
+        assert_eq!(
+            task.get_value("rrule"),
+            Some("FREQ=WEEKLY"),
+            "re-baking picks up the edited iter"
+        );
+    }
+
+    #[cfg(feature = "iterative-tasks")]
+    #[tokio::test]
+    async fn test_status_roundtrip_preserves_series_position() {
+        // A live successor's series position is stored in `iter_count`. Toggling
+        // its status Iterative -> Pending -> Iterative re-bakes the rule from
+        // `iter` but leaves `iter_count` untouched, so the series stays capped.
+        mock_time::set(time_start());
+        let (mut replica, mut task, mut ops, uuid) =
+            setup_iterative_task("FREQ=DAILY;COUNT=2", None).await;
+        mock_time::set(time_start());
+        task.set_status(Status::Completed, &mut ops).unwrap();
+        replica.commit_operations(ops).await.unwrap();
+        mock_time::reset();
+
+        let succ_uuid = successor_of(uuid);
+        let mut succ = replica.get_task(succ_uuid).await.unwrap().unwrap();
+        assert_eq!(succ.get_value("iter_count"), Some("2"));
+
+        // Round-trip the successor's status through Pending and back.
+        let mut ops = Operations::new();
+        succ.set_status(Status::Pending, &mut ops).unwrap();
+        succ.set_status(Status::Iterative, &mut ops).unwrap();
+        replica.commit_operations(ops).await.unwrap();
+
+        let succ = replica.get_task(succ_uuid).await.unwrap().unwrap();
+        assert_eq!(
+            succ.get_value("iter_count"),
+            Some("2"),
+            "status round-trip must not change the series position"
+        );
+    }
+
+    #[cfg(feature = "iterative-tasks")]
+    #[tokio::test]
+    async fn test_iter_count_increments_across_the_series() {
+        // Each instance records its 1-based position in `iter_count`, the
+        // completed record keeps its own position, and successors keep counting up.
+        mock_time::set(time_start());
+        let (mut replica, mut task, mut ops, uuid) = setup_iterative_task("daily", None).await;
+        mock_time::set(time_start());
+        task.set_status(Status::Completed, &mut ops).unwrap();
+        replica.commit_operations(ops).await.unwrap();
+
+        // The completed root keeps its own position (1).
+        let root = replica.get_task(uuid).await.unwrap().unwrap();
+        assert_eq!(
+            root.get_value("iter_count"),
+            Some("1"),
+            "the completed record keeps its position"
+        );
+
+        // The second instance is position 2.
+        let succ2_uuid = successor_of(uuid);
+        let mut succ2 = replica.get_task(succ2_uuid).await.unwrap().unwrap();
+        assert_eq!(succ2.get_value("iter_count"), Some("2"));
+
+        // Completing it spawns a third instance at position 3.
+        mock_time::set(time_start());
+        let mut ops = Operations::new();
+        succ2.set_status(Status::Completed, &mut ops).unwrap();
+        replica.commit_operations(ops).await.unwrap();
+        mock_time::reset();
+
+        let succ3 = replica
+            .get_task(successor_of(succ2_uuid))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(succ3.get_value("iter_count"), Some("3"));
+    }
+
+    #[cfg(feature = "iterative-tasks")]
+    #[tokio::test]
+    async fn test_anchors_off_scheduled_when_no_due() {
+        // With no `due`, the highest-priority present date (`scheduled`) anchors
+        // the schedule and advances; the successor still has no `due`.
+        mock_time::set(time_start());
+        let (mut replica, mut task, mut ops, uuid) =
+            setup_iterative_task("weekly", Some("fixed")).await;
+        mock_time::set(time_start());
+        task.set_due(None, &mut ops).unwrap();
+        task.set_scheduled(Some(time_start()), &mut ops).unwrap();
+        mock_time::set(time_twenty_four_days_later());
+        task.set_status(Status::Completed, &mut ops).unwrap();
+        replica.commit_operations(ops).await.unwrap();
+        mock_time::reset();
+
+        let succ = replica.get_task(successor_of(uuid)).await.unwrap().unwrap();
+        assert_eq!(succ.get_due(), None);
+        assert_eq!(
+            succ.get_scheduled(),
+            Some(time_start() + chrono::Duration::weeks(1)),
+            "scheduled anchors the schedule and advances one week"
+        );
+    }
+
     #[tokio::test]
     async fn test_set_get_value() {
         let property = "property-name";
@@ -1379,6 +2609,34 @@ mod test {
                     .is_err());
             },
             |_task| {},
+        )
+        .await
+    }
+
+    #[cfg(feature = "iterative-tasks")]
+    #[tokio::test]
+    async fn test_iterative_keys_not_udas() {
+        with_mut_task(
+            |task, ops| {
+                assert!(task
+                    .set_user_defined_attribute("rrule", "FREQ=DAILY", ops)
+                    .is_err());
+                assert!(task.set_user_defined_attribute("series", "x", ops).is_err());
+                assert!(task.set_user_defined_attribute("prior", "x", ops).is_err());
+                task.set_user_defined_attribute("iter", "weekly", ops)
+                    .unwrap();
+                task.set_user_defined_attribute("iter_type", "fixed", ops)
+                    .unwrap();
+                task.set_value("series", Some("s".into()), ops).unwrap();
+            },
+            |task| {
+                let keys: Vec<&str> = task.get_user_defined_attributes().map(|(k, _)| k).collect();
+                assert!(keys.contains(&"iter"));
+                assert!(keys.contains(&"iter_type"));
+                assert!(!keys.contains(&"series"));
+                assert!(!keys.contains(&"rrule"));
+                assert!(!keys.contains(&"prior"));
+            },
         )
         .await
     }

--- a/src/task/task.rs
+++ b/src/task/task.rs
@@ -502,13 +502,31 @@ impl Task {
                     .map(|d| d.to_utc())
             }
             IterType::Chained => {
-                // Chained re-anchors the rule to now, so the next occurrence is
-                // one period from the completion time.
-                anchored_set(now_local)?
-                    .after(now_local + chrono::Duration::seconds(1))
-                    .all(1)
-                    .dates
-                    .first()
+                // Chained schedules the next occurrence one whole period after
+                // the completion time. If the rrule has a weekday or other
+                // specific date, make sure to advance by at least one perioid
+                // so that the task doesn't span one wit hthe same date.
+                let freq = unvalidated.get_freq();
+                let period = |dt: &DateTime<rrule::Tz>| -> Option<(i32, u32)> {
+                    match freq {
+                        rrule::Frequency::Daily => Some((dt.year(), dt.ordinal())),
+                        rrule::Frequency::Weekly => {
+                            let w = dt.iso_week();
+                            Some((w.year(), w.week()))
+                        }
+                        rrule::Frequency::Monthly => Some((dt.year(), dt.month())),
+                        rrule::Frequency::Yearly => Some((dt.year(), 0)),
+                        _ => None,
+                    }
+                };
+                let now_period = period(&now_local);
+                let set = anchored_set(now_local)?;
+                (&set)
+                    .into_iter()
+                    .find(|d| match now_period {
+                        Some(np) => period(d) != Some(np),
+                        None => *d > now_local,
+                    })
                     .map(|d| d.to_utc())
             }
         };

--- a/src/task/task.rs
+++ b/src/task/task.rs
@@ -588,7 +588,7 @@ impl Task {
                     | "scheduled"
                     | "wait"
                     | "entry"
-                    | "prior"
+                    | "iter_prior"
                     | "iter_count"
             ) || prop.starts_with("dep_");
             if !set_below {
@@ -640,7 +640,7 @@ impl Task {
         }
 
         successor.set_entry(Some(now), ops)?;
-        successor.set_value("prior", Some(self_uuid.into()), ops)?;
+        successor.set_value("iter_prior", Some(self_uuid.into()), ops)?;
         // If this task had no series id treat it as the series root.
         // Shouldn't happen, but prevents possible cross-version corruption.
         if successor.data.get("series").is_none() {
@@ -914,7 +914,7 @@ impl Task {
     /// Keys the iterative-tasks system uses.
     #[cfg(feature = "iterative-tasks")]
     fn is_iterative_key(key: &str) -> bool {
-        matches!(key, "rrule" | "series" | "prior" | "iter_count")
+        matches!(key, "rrule" | "series" | "iter_prior" | "iter_count")
     }
     #[cfg(not(feature = "iterative-tasks"))]
     fn is_iterative_key(_key: &str) -> bool {
@@ -1670,7 +1670,7 @@ mod test {
         assert!(succ.get_value("rrule").is_some());
         assert!(succ.get_value("iter_type").is_some());
         assert_eq!(
-            succ.get_value("prior")
+            succ.get_value("iter_prior")
                 .and_then(|p| Uuid::parse_str(p).ok()),
             Some(uuid)
         );
@@ -2640,7 +2640,7 @@ mod test {
                     .set_user_defined_attribute("rrule", "FREQ=DAILY", ops)
                     .is_err());
                 assert!(task.set_user_defined_attribute("series", "x", ops).is_err());
-                assert!(task.set_user_defined_attribute("prior", "x", ops).is_err());
+                assert!(task.set_user_defined_attribute("iter_prior", "x", ops).is_err());
                 task.set_user_defined_attribute("iter", "weekly", ops)
                     .unwrap();
                 task.set_user_defined_attribute("iter_type", "fixed", ops)
@@ -2653,7 +2653,7 @@ mod test {
                 assert!(keys.contains(&"iter_type"));
                 assert!(!keys.contains(&"series"));
                 assert!(!keys.contains(&"rrule"));
-                assert!(!keys.contains(&"prior"));
+                assert!(!keys.contains(&"iter_prior"));
             },
         )
         .await

--- a/src/task/task.rs
+++ b/src/task/task.rs
@@ -401,7 +401,7 @@ impl Task {
             // it to a new date without inheriting the original anchor's weekday,
             // and there is no stored DTSTART to go stale.
             self.set_value("rrule", Some(unvalidated.to_string()), ops)?;
-            // Set the first date. If the caller supplied one it directly,
+            // Set the first date. If the caller supplied one directly,
             // just use it. Otherwise take the first rrule occurrence on or
             // after dt_start.
             match anchor_kind {
@@ -503,9 +503,9 @@ impl Task {
             }
             IterType::Chained => {
                 // Chained schedules the next occurrence one whole period after
-                // the completion time. If the rrule has a weekday or other
-                // specific date, make sure to advance by at least one perioid
-                // so that the task doesn't span one wit hthe same date.
+                // the completion time. If the rrule is a non-specific period,
+                // make sure to advance by at least one period
+                // so that the task doesn't land on the same date.
                 let freq = unvalidated.get_freq();
                 let period = |dt: &DateTime<rrule::Tz>| -> Option<(i32, u32)> {
                     match freq {
@@ -540,7 +540,7 @@ impl Task {
             .and_then(|s| s.parse::<u32>().ok())
             .unwrap_or(1);
         let within_cap = cap.is_none_or(|c| pos.saturating_add(1) <= c);
-        if let Some(next_anchor) = next_anchor.filter(|_| within_cap) {
+        if within_cap && let Some(next_anchor) = next_anchor {
             self.spawn_successor(next_anchor, anchor_old, pos, now, ops)?;
         }
 

--- a/src/task/task.rs
+++ b/src/task/task.rs
@@ -333,17 +333,11 @@ impl Task {
                     self.set_timestamp(Prop::End.as_ref(), None, ops)?;
                 }
             }
-            Status::Completed => {
-                #[cfg(feature = "iterative-tasks")]
-                if self.get_status() == Status::Iterative {
-                    return self.set_iterative_completed(ops);
-                }
-                // set "end" when a task is deleted or completed
-                if !self.data.has(Prop::End.as_ref()) {
-                    self.set_timestamp(Prop::End.as_ref(), Some(utc_now()), ops)?;
-                }
+            #[cfg(feature = "iterative-tasks")]
+            Status::Completed if self.get_status() == Status::Iterative => {
+                return self.set_iterative_completed(ops);
             }
-            Status::Deleted => {
+            Status::Completed | Status::Deleted => {
                 // set "end" when a task is deleted or completed
                 if !self.data.has(Prop::End.as_ref()) {
                     self.set_timestamp(Prop::End.as_ref(), Some(utc_now()), ops)?;
@@ -539,11 +533,11 @@ impl Task {
             .get("iter_count")
             .and_then(|s| s.parse::<u32>().ok())
             .unwrap_or(1);
-        let within_cap = cap.is_none_or(|c| pos.saturating_add(1) <= c);
-        if within_cap && let Some(next_anchor) = next_anchor {
-            self.spawn_successor(next_anchor, anchor_old, pos, now, ops)?;
+        if cap.is_none_or(|c| pos.saturating_add(1) <= c) {
+            if let Some(next_anchor) = next_anchor {
+                self.spawn_successor(next_anchor, anchor_old, pos, now, ops)?;
+            }
         }
-
         // Finally, complete the task.
         self.set_value(
             Prop::Status.as_ref(),
@@ -2640,7 +2634,9 @@ mod test {
                     .set_user_defined_attribute("rrule", "FREQ=DAILY", ops)
                     .is_err());
                 assert!(task.set_user_defined_attribute("series", "x", ops).is_err());
-                assert!(task.set_user_defined_attribute("iter_prior", "x", ops).is_err());
+                assert!(task
+                    .set_user_defined_attribute("iter_prior", "x", ops)
+                    .is_err());
                 task.set_user_defined_attribute("iter", "weekly", ops)
                     .unwrap();
                 task.set_user_defined_attribute("iter_type", "fixed", ops)

--- a/src/task/time.rs
+++ b/src/task/time.rs
@@ -1,4 +1,6 @@
 use chrono::{offset::LocalResult, DateTime, TimeZone, Utc};
+#[cfg(feature = "iterative-tasks")]
+use rrule::Tz;
 
 pub(crate) type Timestamp = DateTime<Utc>;
 
@@ -9,3 +11,63 @@ pub fn utc_timestamp(secs: i64) -> Timestamp {
         _ => unreachable!("We're requesting UTC so daylight saving time isn't a factor."),
     }
 }
+/// Returns the local timezone for rrule scheduling.
+/// On WASM, `chrono::Local` is unavailable, so UTC is used as a fallback.
+#[cfg(feature = "iterative-tasks")]
+pub(crate) fn local_tz() -> Tz {
+    #[cfg(test)]
+    if let Some(tz) = mock_tz::get() {
+        return tz;
+    }
+    #[cfg(not(target_arch = "wasm32"))]
+    return Tz::Local(chrono::Local);
+    #[cfg(target_arch = "wasm32")]
+    return Tz::UTC;
+}
+
+/// Test-only override of the timezone used by `local_tz`.
+#[cfg(all(feature = "iterative-tasks", test))]
+pub(crate) mod mock_tz {
+    use rrule::Tz;
+    use std::cell::Cell;
+    thread_local! {
+        static TZ: Cell<Option<Tz>> = const { Cell::new(None) };
+    }
+    pub(crate) fn get() -> Option<Tz> {
+        TZ.with(|t| t.get())
+    }
+    pub(crate) fn set(tz: Tz) {
+        TZ.with(|c| c.set(Some(tz)));
+    }
+    pub(crate) fn reset() {
+        TZ.with(|c| c.set(None));
+    }
+}
+
+#[cfg(not(test))]
+pub(crate) fn utc_now() -> DateTime<Utc> {
+    Utc::now()
+}
+
+#[cfg(test)]
+pub(crate) mod mock_time {
+    use chrono::{DateTime, Utc};
+    use std::cell::Cell;
+    thread_local! {
+        static T: Cell<Option<i64>> = const {Cell::new(None)};
+    }
+    pub(crate) fn utc_now() -> DateTime<Utc> {
+        T.with(|t| match t.get() {
+            Some(secs) => DateTime::from_timestamp(secs, 0).unwrap(),
+            None => Utc::now(),
+        })
+    }
+    pub(crate) fn set(t: DateTime<Utc>) {
+        T.with(|c| c.set(Some(t.timestamp())));
+    }
+    pub(crate) fn reset() {
+        T.with(|c| c.set(None));
+    }
+}
+#[cfg(test)]
+pub(crate) use mock_time::utc_now;

--- a/src/task/time.rs
+++ b/src/task/time.rs
@@ -9,3 +9,30 @@ pub fn utc_timestamp(secs: i64) -> Timestamp {
         _ => unreachable!("We're requesting UTC so daylight saving time isn't a factor."),
     }
 }
+#[cfg(not(test))]
+pub(crate) fn utc_now() -> DateTime<Utc> {
+    Utc::now()
+}
+
+#[cfg(test)]
+pub(crate) mod mock_time {
+    use chrono::{DateTime, Utc};
+    use std::cell::Cell;
+    thread_local! {
+        static T: Cell<Option<i64>> = const {Cell::new(None)};
+    }
+    pub(crate) fn utc_now() -> DateTime<Utc> {
+        T.with(|t| match t.get() {
+            Some(secs) => DateTime::from_timestamp(secs, 0).unwrap(),
+            None => Utc::now(),
+        })
+    }
+    pub(crate) fn set(t: DateTime<Utc>) {
+        T.with(|c| c.set(Some(t.timestamp())));
+    }
+    pub(crate) fn reset() {
+        T.with(|c| c.set(None));
+    }
+}
+#[cfg(test)]
+pub(crate) use mock_time::utc_now;

--- a/src/task/time.rs
+++ b/src/task/time.rs
@@ -1,4 +1,6 @@
 use chrono::{offset::LocalResult, DateTime, TimeZone, Utc};
+#[cfg(feature = "iterative-tasks")]
+use rrule::Tz;
 
 pub(crate) type Timestamp = DateTime<Utc>;
 
@@ -9,6 +11,16 @@ pub fn utc_timestamp(secs: i64) -> Timestamp {
         _ => unreachable!("We're requesting UTC so daylight saving time isn't a factor."),
     }
 }
+/// Returns the local timezone for rrule scheduling.
+/// On WASM, `chrono::Local` is unavailable, so UTC is used as a fallback.
+#[cfg(feature = "iterative-tasks")]
+pub(crate) fn local_tz() -> Tz {
+    #[cfg(not(target_arch = "wasm32"))]
+    return Tz::Local(chrono::Local);
+    #[cfg(target_arch = "wasm32")]
+    return Tz::UTC;
+}
+
 #[cfg(not(test))]
 pub(crate) fn utc_now() -> DateTime<Utc> {
     Utc::now()

--- a/tests/iterative-sync.rs
+++ b/tests/iterative-sync.rs
@@ -1,0 +1,80 @@
+#![cfg(all(feature = "server-local", feature = "iterative-tasks"))]
+
+//! Two replicas completing the same iterative task before syncing must produce
+//! the same successor task UUIDv5.
+
+use pretty_assertions::assert_eq;
+use std::collections::BTreeSet;
+use taskchampion::storage::inmemory::InMemoryStorage;
+use taskchampion::{Operations, Replica, ServerConfig, Status, Uuid};
+use tempfile::TempDir;
+
+#[tokio::test]
+async fn concurrent_iterative_completion_converges() -> anyhow::Result<()> {
+    let mut rep1 = Replica::new(InMemoryStorage::new());
+    let mut rep2 = Replica::new(InMemoryStorage::new());
+
+    let tmp_dir = TempDir::new().expect("TempDir failed");
+    let server_config = ServerConfig::Local {
+        server_dir: tmp_dir.path().to_path_buf(),
+    };
+    let mut server = server_config.into_server().await?;
+
+    // Create an iterative task on rep1 and replicate it to rep2.
+    let uuid = Uuid::new_v4();
+    let mut ops = Operations::new();
+    let mut t = rep1.create_task(uuid, &mut ops).await?;
+    t.set_value("iter", Some("daily".into()), &mut ops)?;
+    t.set_status(Status::Iterative, &mut ops)?;
+    rep1.commit_operations(ops).await?;
+    rep1.sync(&mut server, false).await?;
+    rep2.sync(&mut server, false).await?;
+
+    // Both replicas complete the same task before syncing again.
+    let mut ops = Operations::new();
+    let mut t1 = rep1.get_task(uuid).await?.expect("task on rep1");
+    t1.set_status(Status::Completed, &mut ops)?;
+    rep1.commit_operations(ops).await?;
+
+    let mut ops = Operations::new();
+    let mut t2 = rep2.get_task(uuid).await?.expect("task on rep2");
+    t2.set_status(Status::Completed, &mut ops)?;
+    rep2.commit_operations(ops).await?;
+
+    // Sync back and forth until both have seen each other's changes.
+    rep1.sync(&mut server, false).await?;
+    rep2.sync(&mut server, false).await?;
+    rep1.sync(&mut server, false).await?;
+
+    let all1 = rep1.all_tasks().await?;
+    let all2 = rep2.all_tasks().await?;
+
+    // Convergence: identical task sets, exactly the completed log + one successor.
+    let keys1: BTreeSet<Uuid> = all1.keys().copied().collect();
+    let keys2: BTreeSet<Uuid> = all2.keys().copied().collect();
+    assert_eq!(keys1, keys2, "replicas should converge to the same tasks");
+    assert_eq!(
+        all1.len(),
+        2,
+        "one completed + one successor, not a duplicate successor"
+    );
+
+    // The original is completed.
+    assert_eq!(all1[&uuid].get_status(), Status::Completed);
+
+    // The other task is the successor, and points back.
+    let successor = all1
+        .values()
+        .find(|t| t.get_uuid() != uuid)
+        .expect("successor should exist");
+    assert_eq!(successor.get_status(), Status::Iterative);
+    assert_eq!(
+        successor
+            .get_value("prior")
+            .and_then(|p| Uuid::parse_str(p).ok()),
+        Some(uuid),
+        "successor's prior is the completed task"
+    );
+
+    Ok(())
+}

--- a/tests/iterative-sync.rs
+++ b/tests/iterative-sync.rs
@@ -70,7 +70,7 @@ async fn concurrent_iterative_completion_converges() -> anyhow::Result<()> {
     assert_eq!(successor.get_status(), Status::Iterative);
     assert_eq!(
         successor
-            .get_value("prior")
+            .get_value("iter_prior")
             .and_then(|p| Uuid::parse_str(p).ok()),
         Some(uuid),
         "successor's prior is the completed task"


### PR DESCRIPTION
This is a proof of concept of iterative tasks, or recurrence v2. In the pr is a document describing the general approach and design. 

Going this route would allow  TaskWarrior a way to address many of the reported issues with recurring tasks, either in the PR or in future work. 

It definitely has not been sufficiently tested in the real world yet and there are some missing features, but I wanted to start a conversation before moving forward any more on this. 

The basics of creating and iterating iterative tasks is in this PR.  I have tested TaskWarrior integration with my task lists quite a bit at this point.