### PR TITLE
Don't build a dep map (twice!) when creating a new task.

### DIFF
--- a/src/replica.rs
+++ b/src/replica.rs
@@ -308,11 +308,17 @@ impl<S: Storage> Replica<S> {
     /// Use [Uuid::new_v4] to invent a new task ID, if necessary. If the task already
     /// exists, it is returned.
     pub async fn create_task(&mut self, uuid: Uuid, ops: &mut Operations) -> Result<Task> {
-        if let Some(task) = self.get_task(uuid).await? {
-            return Ok(task);
+        // Check for task existence without building the depmap if it doen't exist.
+        if let Some(taskdata) = self.get_task_data(uuid).await? {
+            let depmap = self.dependency_map(false).await?;
+            return Ok(Task::new(taskdata, depmap));
         }
-        let depmap = self.dependency_map(false).await?;
-        Ok(Task::new(TaskData::create(uuid, ops), depmap))
+        // A brand new task doesn't have dependencies or dependants, so creating an empty
+        // map is fine and much faster.
+        Ok(Task::new(
+            TaskData::create(uuid, ops),
+            Arc::new(DependencyMap::new()),
+        ))
     }
 
     /// Create a new, empty task with the given UUID.  This is useful for importing tasks, but

--- a/src/replica.rs
+++ b/src/replica.rs
@@ -308,13 +308,14 @@ impl<S: Storage> Replica<S> {
     /// Use [Uuid::new_v4] to invent a new task ID, if necessary. If the task already
     /// exists, it is returned.
     pub async fn create_task(&mut self, uuid: Uuid, ops: &mut Operations) -> Result<Task> {
-        // Check for task existence without building the depmap if it doen't exist.
+        // Check for task existence without building the depmap if it doesn't exist.
         if let Some(taskdata) = self.get_task_data(uuid).await? {
             let depmap = self.dependency_map(false).await?;
             return Ok(Task::new(taskdata, depmap));
         }
-        // A brand new task doesn't have dependencies or dependants, so creating an empty
-        // map is fine and much faster.
+        // The returned Task only ever queries the depmap for its own UUID, and a
+        // brand-new task has no dependencies or dependents, so an empty map yields the
+        // same result as a full scan here, without the cost of a full scan..
         Ok(Task::new(
             TaskData::create(uuid, ops),
             Arc::new(DependencyMap::new()),


### PR DESCRIPTION
Bulk creating tasks is O(n^2) because of a redundant depmap scan.  

`Replica::create_task` builds the full depmap for a brand new task, but that map is only ever queried for the tasks own UUID and a brand new task has no dependencies or dependents. 

The map is invalidated on every `commit_operations`, so bulk creating tasks one at a time (like `TDB2::add` does) does a full scan on every task. This is the cause of the test timeout on https://github.com/GothenburgBitFactory/taskwarrior/pull/4157

This changes the new task creation to skip the scan and use an empty depmap, which will have the same results for a new task without the scan. Existing tasks still get the real depmap.