### PR TITLE
Properly account for "holes" in the working set

### DIFF
--- a/src/taskdb/working_set.rs
+++ b/src/taskdb/working_set.rs
@@ -21,26 +21,21 @@ where
     // The goal here is for existing working-set items to be "compressed' down to index 1, so
     // we begin by scanning the current working set and inserting any tasks that should still
     // be in the set into new_ws, implicitly dropping any tasks that are no longer in the
-    // working set.
-    for elt in &old_ws[1..] {
-        if let Some(uuid) = elt {
-            if let Some(task) = txn.get_task(*uuid).await? {
-                if in_working_set(&task) {
-                    // The existing working-set item is still in the working set -- no change.
-                    new_ws.push(Some(*uuid));
-                    seen.insert(*uuid);
-                } else {
-                    // The item should not be present. If we are not renumbering, then insert a
-                    // blank working-set item here
-                    if !renumber {
-                        new_ws.push(None);
-                    }
+    // working set or are already set to None (the latter is achieved with flatten).
+    for uuid in old_ws[1..].iter().flatten() {
+        if let Some(task) = txn.get_task(*uuid).await? {
+            if in_working_set(&task) {
+                // The existing working-set item is still in the working set -- no change.
+                new_ws.push(Some(*uuid));
+                seen.insert(*uuid);
+            } else {
+                // The item should not be present. If we are not renumbering, then insert a
+                // blank working-set item here
+                if !renumber {
+                    new_ws.push(None);
                 }
-                continue;
             }
-        } else {
-            // This item was already None.
-            new_ws.push(None);
+            continue;
         }
     }
 
@@ -287,6 +282,71 @@ mod test {
         .await?;
 
         assert_eq!(db.working_set().await?, vec![None, Some(uuids[0])]);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn rebuild_working_set_middle_removed() -> Result<()> {
+        let mut db = TaskDb::new(InMemoryStorage::new());
+
+        let mut uuids = vec![];
+        uuids.push(Uuid::new_v4());
+        println!("uuids[0]: {:?} - pending, in working set", uuids[0]);
+        uuids.push(Uuid::new_v4());
+        println!("uuids[1]: {:?} - not pending, in working set", uuids[1]);
+        uuids.push(Uuid::new_v4());
+        println!("uuids[2]: {:?} - pending, in working set", uuids[2]);
+
+        // add everything to the TaskDb
+        let mut ops = Operations::new();
+        for uuid in &uuids {
+            ops.push(Operation::Create { uuid: *uuid });
+        }
+        ops.push(Operation::Update {
+            uuid: uuids[0],
+            property: String::from("status"),
+            value: Some("pending".into()),
+            old_value: None,
+            timestamp: Utc::now(),
+        });
+        ops.push(Operation::Update {
+            uuid: uuids[2],
+            property: String::from("status"),
+            value: Some("pending".into()),
+            old_value: None,
+            timestamp: Utc::now(),
+        });
+        db.commit_operations(ops, |_| false).await?;
+
+        // set the existing working_set as we want it, containing all three UUIDs.
+        {
+            let mut txn = db.storage.txn().await?;
+            txn.clear_working_set().await?;
+
+            for uuid in &uuids {
+                txn.add_to_working_set(*uuid).await?;
+            }
+            txn.set_working_set_item(2, None).await?;
+
+            txn.commit().await?;
+        }
+        rebuild(
+            db.storage.txn().await?.as_mut(),
+            |t| {
+                if let Some(status) = t.get("status") {
+                    status == "pending"
+                } else {
+                    false
+                }
+            },
+            true,
+        )
+        .await?;
+
+        assert_eq!(
+            db.working_set().await?,
+            vec![None, Some(uuids[0]), Some(uuids[2])]
+        );
         Ok(())
     }
 }


### PR DESCRIPTION
If an index in the working set is already None, that should be collapsed out of the new numbering.